### PR TITLE
Add IO communicator support

### DIFF
--- a/e3sm_io.h
+++ b/e3sm_io.h
@@ -60,7 +60,7 @@ typedef float itype;   /* internal data type of buffer in memory */
 #endif
 
 extern int
-read_decomp(const char *infname, int *num_decomp, MPI_Offset dims[][2],
+read_decomp(MPI_Comm io_comm, const char *infname, int *num_decomp, MPI_Offset dims[][2],
             int contig_nreqs[3], int *disps[3], int *blocklens[3]);
 
 extern void
@@ -73,7 +73,8 @@ extern int
 def_F_case_h1(int ncid, const MPI_Offset dims[2], int nvars, int *varids);
 
 extern int
-run_vard_F_case(const char *out_dir,      /* output folder name */
+run_vard_F_case(MPI_Comm io_comm,         /* MPI communicator that includes all the tasks involved in IO */
+                const char *out_dir,      /* output folder name */
                 const char *outfile,      /* output file name */
                 int         nvars,        /* number of variables 408 or 51 */
                 int         num_recs,     /* number of records */
@@ -85,7 +86,8 @@ run_vard_F_case(const char *out_dir,      /* output folder name */
                 int* const  blocklens[3]);/* request's block lengths */
 
 extern int
-run_varn_F_case(const char *out_dir,      /* output folder name */
+run_varn_F_case(MPI_Comm io_comm,         /* MPI communicator that includes all the tasks involved in IO */
+                const char *out_dir,      /* output folder name */
                 const char *outfile,      /* output file name */
                 int         nvars,        /* number of variables 408 or 51 */
                 int         num_recs,     /* number of records */
@@ -108,7 +110,8 @@ def_G_case_h0(int               ncid,       /* file ID */
               int              *varids);    /* variable IDs */
 
 extern int
-run_varn_G_case(const char *out_dir,      /* output folder name */
+run_varn_G_case(MPI_Comm io_comm,         /* MPI communicator that includes all the tasks involved in IO */
+                const char *out_dir,      /* output folder name */
                 const char *outfile,      /* output file name */
                 int         nvars,        /* number of variables 51 */
                 int         num_recs,     /* number of records */

--- a/read_decomp.c
+++ b/read_decomp.c
@@ -100,7 +100,8 @@ static int compare(const void *p1, const void *p2)
  *                         and to be freed by the caller.
  */
 int
-read_decomp(const char *infname,        /* IN */
+read_decomp(MPI_Comm io_comm,           /* MPI communicator that includes all the tasks involved in IO */
+            const char *infname,        /* IN */
             int        *num_decomp,     /* OUT */
             MPI_Offset  dims[][2],      /* OUT */
             int         contig_nreqs[], /* OUT */
@@ -113,11 +114,11 @@ read_decomp(const char *infname,        /* IN */
     MPI_Offset num, decomp_nprocs, total_nreqs, start, count;
     struct off_len *myreqs;
 
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+    MPI_Comm_rank(io_comm, &rank);
+    MPI_Comm_size(io_comm, &nprocs);
 
     /* open input file that contains I/O decomposition information */
-    err = ncmpi_open(MPI_COMM_WORLD, infname, NC_NOWRITE, MPI_INFO_NULL,
+    err = ncmpi_open(io_comm, infname, NC_NOWRITE, MPI_INFO_NULL,
                      &ncid); ERR
 
     /* number of decompositions stored in file */


### PR DESCRIPTION
An IO communicator is created based on stride (default  stride is 1).
Only IO tasks will call PnetCDF APIs.

A new command-line option is used to set the IO stride:
[-s num] Stride between IO tasks (default 1)

This change can better simulate E3SM productions runs with a PIO
stride larger than 1.

For example, to simulate E3SM G case run on Cori with 9600 MPI tasks
and PIO stride 64 (150 IO tasks), existing E3SM-IO program might be run
with 150 MPI tasks (3 KNL nodes). The issue is that the PE layout will be
quite different from the production run, and each MPI task (also an IO task)
has less memory to use.

With IO stride set to 64, E3SM-IO program can be run with 9600 MPI tasks
(150 KNL nodes), assigning an IO communicator of 150 IO tasks (one IO
task per KNL node) to PnetCDF. In this case, the PE layout will be similar
to the production run.

Note:
It seems that this PR has conflicts with pending PR (read functionality).
For example, [-s] option has a different usage:
[-s] Write 2D variables followed by 3D variables

One possible solution is to merge this PR first (which has less code
changes), then rebase PR on read functionality (which has more
code changes) before merging.