### PR TITLE
Support variable chunking and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ sharing Decomposition 4, 2 sharing Decomposition 5, and 4 sharing Decomposition
        [-o output_dir] Output directory name (default ./)
        [-i target_dir] Path to directory containing the input files
        [-a api] Underlying API to test (pnc (default), hdf5, adios2)
+       [-c chunk_size] Use chunked storage layout with chunk_size (0 (no chunking) (default))
+       [-z filter] Apply the filter if supported by the underlying API (none (default), deflate)
        FILE: Name of input netCDF file describing data decompositions
   ```
 * An example batch script file for running a job on Cori @NERSC with 8 KNL
@@ -251,6 +253,18 @@ sharing Decomposition 4, 2 sharing Decomposition 5, and 4 sharing Decomposition
   `g_case_11135652x80_9600p.nc.gz` (126 MB) from high-resolution simulations of
   F and G cases running on 21632 and 9600 MPI processes respectively are
   available upon request.
+
+### Environment variables
+* E3SM_IO_HDF5_ENABLE_LOGVOL 
+  + 1: Use Log I/O VOL if available
+  + 0: Use the native VOL (default)
+* E3SM_IO_HDF5_USE_LOGVOL_WRITEN
+  + 1: Use the H5Dwrite_N API in Log I/O VOL
+  + 0: Use the HDF5 driver varn implementation (default)
+  + Only effective when E3SM_IO_HDF5_ENABLE_LOGVOL is 1
+* E3SM_IO_HDF5_MERGE_VARN
+  + 1: Merge varn hyper-slabs into one dataspace selection
+  + 0: Call H5Dwrite per hyper-slab (default)
 
 ### example outputs shown on screen
 ```

--- a/src/drivers/e3sm_io_driver.hpp
+++ b/src/drivers/e3sm_io_driver.hpp
@@ -9,7 +9,11 @@
 typedef enum e3sm_io_op_mode { coll, indep, nb, nbe } e3sm_io_op_mode;
 
 class e3sm_io_driver {
+   protected:
+    e3sm_io_config *cfg;
+
    public:
+    e3sm_io_driver (e3sm_io_config *cfg) : cfg (cfg) {};
     virtual int create (std::string path, MPI_Comm comm, MPI_Info info, int *fid) = 0;
     virtual int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid)   = 0;
     virtual int close (int fid)                                                   = 0;

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -16,6 +16,7 @@
 #include <mpi.h>
 //
 #include <e3sm_io.h>
+
 #include <e3sm_io_driver.hpp>
 
 class e3sm_io_driver_adios2 : public e3sm_io_driver {
@@ -29,13 +30,13 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
         std::vector<int> ndims;
         std::vector<size_t> dsizes;
         MPI_Offset recsize = 0;
+        adios2_operator *op;
     } adios2_file;
     std::vector<adios2_file *> files;
-
     double tsel, twrite, tread, text;
 
    public:
-    e3sm_io_driver_adios2 ();
+    e3sm_io_driver_adios2 (e3sm_io_config *cfg);
     ~e3sm_io_driver_adios2 ();
     int create (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
     int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid);

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -72,9 +72,10 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
     hsize_t one[H5S_MAX_RANK];
 
     // Config
-    bool use_logvol      = false;
-    bool use_logvol_varn = false;
-    bool merge_varn      = false;
+    bool use_logvol       = false;
+    bool use_logvol_varn  = false;
+    bool use_dwrite_multi = false;
+    bool merge_varn       = false;
 
     // Profiling
     double tsel, twrite, tread, text, tsort, tcpy;
@@ -83,7 +84,7 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
     hsize_t total_data_size = 0;
 
    public:
-    e3sm_io_driver_hdf5 ();
+    e3sm_io_driver_hdf5 (e3sm_io_config *cfg);
     ~e3sm_io_driver_hdf5 ();
     int create (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
     int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid);

--- a/src/drivers/e3sm_io_driver_pnc.hpp
+++ b/src/drivers/e3sm_io_driver_pnc.hpp
@@ -27,6 +27,7 @@ class e3sm_io_driver_pnc : public e3sm_io_driver {
     std::map<int, MPI_Info> file_infos;
 
    public:
+    e3sm_io_driver_pnc (e3sm_io_config *cfg);
     int create (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
     int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
     int close (int fid);

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -89,7 +89,10 @@ static void usage (char *argv0) {
         "       [-o output_dir] Output directory name (default ./)\n"
         "       [-i target_dir] Path to directory containing the input files\n"
         "       [-a api] Underlying API to test (pnc (default), hdf5, adios2)\n"
-        //"       [-l layout] Storage layout of the variables (contig (default), chunk)\n"
+        "       [-c chunk_size] Use chunked storage layout with chunk_size (0 (no chunking) "
+        "(default))\n"
+        "       [-z filter] Apply the filter if supported by the underlying API (none (default), "
+        "deflate) \n"
         "       FILE: Name of input netCDF file describing data decompositions\n";
     "\n";
     fprintf (stderr, help, argv0);
@@ -120,8 +123,8 @@ int main (int argc, char **argv) {
     cfg.rd             = 0;
     cfg.nvars          = 0;
     cfg.api            = pnc;
-    cfg.layout         = contig;
-    cfg.vard        = 0;
+    cfg.filter         = none;
+    cfg.vard           = 0;
     cfg.verbose        = 0;
     cfg.keep_outfile   = 0;
     cfg.two_buf        = 0;
@@ -190,6 +193,18 @@ int main (int argc, char **argv) {
                 break;
             case 'f':
                 cfg.hx = atoi (optarg);
+                break;
+            case 'c':
+                cfg.chunksize = atoll (optarg);
+                break;
+            case 'z':
+                if (strcmp (optarg, "deflate") == 0) {
+                    cfg.filter = deflate;
+                } else if (strcmp (optarg, "zlib") == 0) {
+                    cfg.filter = deflate;
+                } else {
+                    RET_ERR ("Unknown filter")
+                }
                 break;
             case 'h':
             default:

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -14,8 +14,8 @@
 #include <pnetcdf.h>
 #include <stdio.h>
 
-#define E3SM_IO_MAX_PATH 1024
-#define MAX_NUM_DECOMP 6
+#define E3SM_IO_MAX_PATH    1024
+#define MAX_NUM_DECOMP      6
 #define E3SM_IO_GLOBAL_ATTR -1
 
 #define PRINT_MSG(V, ...)                                                    \
@@ -48,7 +48,7 @@ typedef float itype; /* internal data type of buffer in memory */
 
 typedef enum e3sm_io_api { pnc, hdf5, adios2 } e3sm_io_api;
 
-typedef enum e3sm_io_layout { contig, chunk } e3sm_io_layout;
+typedef enum e3sm_io_filter { none, deflate, bzip2 } e3sm_io_filter;
 
 typedef struct e3sm_io_config {
     int rank;
@@ -60,22 +60,23 @@ typedef struct e3sm_io_config {
     char *targetdir;
     char *datadir;
     char *cfgpath;
-    int hx                           ;
-    int nrec                         ;
-    int wr                           ;
-    int rd                           ;
-    int nvars                        ;
+    int hx;
+    int nrec;
+    int wr;
+    int rd;
+    int nvars;
 
     e3sm_io_api api;
-    e3sm_io_layout layout;
-    int vard ;
+    e3sm_io_filter filter;
+    size_t chunksize;
+    int vard;
 
-    int verbose      ; /* verbose mode to print additional messages on screen */
-    int keep_outfile ; /* whether to keep the output files when exits */
+    int verbose;      /* verbose mode to print additional messages on screen */
+    int keep_outfile; /* whether to keep the output files when exits */
 
-    int two_buf        ;
-    int non_contig_buf ;
-    int io_stride      ;
+    int two_buf;
+    int non_contig_buf;
+    int io_stride;
 } e3sm_io_config;
 
 typedef struct e3sm_io_decom {

--- a/src/e3sm_io_core.cpp
+++ b/src/e3sm_io_core.cpp
@@ -12,6 +12,7 @@
 //
 #include <e3sm_io.h>
 #include <e3sm_io_err.h>
+
 #include <e3sm_io_case.hpp>
 #include <e3sm_io_driver.hpp>
 #include <e3sm_io_driver_pnc.hpp>
@@ -29,18 +30,18 @@ extern "C" int e3sm_io_core (e3sm_io_config *cfg, e3sm_io_decom *decom) {
 
     switch (cfg->api) {
         case pnc:
-            driver = new e3sm_io_driver_pnc ();
+            driver = new e3sm_io_driver_pnc (cfg);
             break;
         case hdf5:
 #ifdef ENABLE_HDF5
-            driver = new e3sm_io_driver_hdf5 ();
+            driver = new e3sm_io_driver_hdf5 (cfg);
 #else
             RET_ERR ("HDF5 support was not enabled in this build")
 #endif
             break;
         case adios2:
 #ifdef ENABLE_ADIOS2
-            driver = new e3sm_io_driver_adios2 ();
+            driver = new e3sm_io_driver_adios2 (cfg);
 #else
             RET_ERR ("ADIOS2 support was not enabled in this build")
 #endif


### PR DESCRIPTION
Add command line option to set variable chunking and filters. Apply the setting if support by the underlying I/O method.