### PR TITLE
Add local variable API to driver interface: def_local_var and put_varl;

### DIFF
--- a/src/drivers/e3sm_io_driver.hpp
+++ b/src/drivers/e3sm_io_driver.hpp
@@ -25,6 +25,8 @@ class e3sm_io_driver {
     virtual int inq_rec_size (int fid, MPI_Offset *size)                          = 0;
     virtual int def_var (
         int fid, std::string name, MPI_Datatype type, int ndim, int *dimids, int *did) = 0;
+    virtual int def_local_var (
+        int fid, std::string name, MPI_Datatype type, int ndim, MPI_Offset *dsize, int *did) = 0;
     virtual int inq_var (int fid, std::string name, int *did)                          = 0;
     virtual int inq_var_off (int fid, int vid, MPI_Offset *off)                        = 0;
     virtual int def_dim (int fid, std::string name, MPI_Offset size, int *dimid)       = 0;
@@ -36,6 +38,11 @@ class e3sm_io_driver {
     virtual int put_att (
         int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf) = 0;
     virtual int get_att (int fid, int vid, std::string name, void *buf)                    = 0;
+    virtual int put_varl (int fid,
+                          int vid,
+                          MPI_Datatype type,
+                          void *buf,
+                          e3sm_io_op_mode mode)                                            = 0;
     virtual int put_vara (int fid,
                           int vid,
                           MPI_Datatype type,

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -19,6 +19,26 @@
 
 #include <e3sm_io_driver.hpp>
 
+inline adios2_type mpi_type_to_adios2_type (MPI_Datatype mpitype) {
+    switch (mpitype) {
+        case MPI_INT:
+            return adios2_type_int32_t;
+        case MPI_FLOAT:
+            return adios2_type_float;
+        case MPI_DOUBLE:
+            return adios2_type_double;
+        case MPI_LONG_LONG:
+            return adios2_type_int64_t;
+        case MPI_CHAR:
+            return adios2_type_uint8_t;
+        default:
+            printf ("Error at line %d in %s: Unknown type %d\n", __LINE__, __FILE__, mpitype);
+            DEBUG_ABORT
+    }
+
+    return adios2_type_unknown;
+}
+
 class e3sm_io_driver_adios2 : public e3sm_io_driver {
     typedef struct adios2_file {
         std::string path;
@@ -29,6 +49,7 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
         std::vector<adios2_variable *> dids;
         std::vector<int> ndims;
         std::vector<size_t> dsizes;
+        std::vector<adios2_variable*> ddids;
         MPI_Offset recsize = 0;
         adios2_operator *op;
     } adios2_file;
@@ -48,6 +69,8 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
     int inq_malloc_max_size (MPI_Offset *size);
     int inq_rec_size (int fid, MPI_Offset *size);
     int def_var (int fid, std::string name, MPI_Datatype type, int ndim, int *dimids, int *did);
+    int def_local_var (
+        int fid, std::string name, MPI_Datatype type, int ndim, MPI_Offset *dsize, int *did);
     int inq_var (int fid, std::string name, int *did);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);
@@ -58,6 +81,7 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
     int wait (int fid);
     int put_att (int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf);
     int get_att (int fid, int vid, std::string name, void *buf);
+    int put_varl (int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode);
     int put_vara (int fid,
                   int vid,
                   MPI_Datatype type,

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -358,6 +358,15 @@ err_out:;
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5)
     return nerrs;
 }
+int e3sm_io_driver_hdf5::def_local_var (
+    int fid, std::string name, MPI_Datatype type, int ndim, MPI_Offset *dsize, int *did) {
+    int nerrs = 0;
+
+    RET_ERR ("HDF5 does not support local variables")
+
+err_out:;
+    return nerrs;
+}
 
 int e3sm_io_driver_hdf5::inq_var (int fid, std::string name, int *did) {
     int nerrs = 0;
@@ -540,6 +549,15 @@ err_out:;
     if (aid >= 0) H5Aclose (aid);
     if (tid >= 0) H5Tclose (tid);
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5)
+    return nerrs;
+}
+
+int e3sm_io_driver_hdf5::put_varl (int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode){
+    int nerrs=0;
+
+    RET_ERR("HDF5 does not support local variables")
+    
+    err_out:;
     return nerrs;
 }
 

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -90,6 +90,8 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
     int inq_malloc_max_size (MPI_Offset *size);
     int inq_rec_size (int fid, MPI_Offset *size);
     int def_var (int fid, std::string name, MPI_Datatype type, int ndim, int *dimids, int *did);
+    int def_local_var (
+        int fid, std::string name, MPI_Datatype type, int ndim, MPI_Offset *dsize, int *did);
     int inq_var (int fid, std::string name, int *did);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);
@@ -100,6 +102,7 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
     int wait (int fid);
     int put_att (int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf);
     int get_att (int fid, int vid, std::string name, void *buf);
+    int put_varl (int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode);
     int put_vara (int fid,
                   int vid,
                   MPI_Datatype type,

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -28,23 +28,6 @@
         }                                                                       \
     }
 
-static inline nc_type mpitype2nctype (MPI_Datatype type) {
-    switch (type) {
-        case MPI_INT:
-            return NC_INT;
-        case MPI_LONG_LONG:
-            return NC_INT64;
-        case MPI_FLOAT:
-            return NC_FLOAT;
-        case MPI_DOUBLE:
-            return NC_DOUBLE;
-        case MPI_CHAR:
-            return NC_CHAR;
-        default:
-            throw "Unsupported datatype";
-    }
-}
-
 e3sm_io_driver_pnc::e3sm_io_driver_pnc (e3sm_io_config *cfg) : e3sm_io_driver (cfg) {
     if ((cfg->chunksize != 0) && (cfg->filter != none)) {
         throw "Fitler requries chunking in PnetCDF";
@@ -216,6 +199,16 @@ int e3sm_io_driver_pnc::def_var (
 err_out:;
     return nerrs;
 }
+int e3sm_io_driver_pnc::def_local_var (
+    int fid, std::string name, MPI_Datatype type, int ndim, MPI_Offset *dsize, int *did) {
+    int nerrs = 0;
+
+    RET_ERR ("PNC does not support local variables")
+
+err_out:;
+    return nerrs;
+}
+
 int e3sm_io_driver_pnc::inq_var (int fid, std::string name, int *did) {
     int err, nerrs = 0;
 
@@ -315,6 +308,16 @@ int e3sm_io_driver_pnc::get_att (int fid, int vid, std::string name, void *buf) 
 
     err = ncmpi_get_att (fid, vid, name.c_str (), buf);
     CHECK_NCERR
+
+err_out:;
+    return nerrs;
+}
+
+int e3sm_io_driver_pnc::put_varl (
+    int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode) {
+    int nerrs = 0;
+
+    RET_ERR ("PNC does not support local variables")
 
 err_out:;
     return nerrs;

--- a/src/drivers/e3sm_io_driver_pnc.hpp
+++ b/src/drivers/e3sm_io_driver_pnc.hpp
@@ -18,6 +18,21 @@
 
 #include <e3sm_io_driver.hpp>
 
+inline nc_type mpitype2nctype (MPI_Datatype type) {
+    switch (type) {
+        case MPI_INT:
+            return NC_INT;
+        case MPI_FLOAT:
+            return NC_FLOAT;
+        case MPI_DOUBLE:
+            return NC_DOUBLE;
+        case MPI_CHAR:
+            return NC_CHAR;
+        default:
+            throw "Unsupported datatype";
+    }
+}
+
 class e3sm_io_driver_pnc : public e3sm_io_driver {
     MPI_Comm comm;
     MPI_Info info;
@@ -38,6 +53,8 @@ class e3sm_io_driver_pnc : public e3sm_io_driver {
     int inq_malloc_max_size (MPI_Offset *size);
     int inq_rec_size (int fid, MPI_Offset *size);
     int def_var (int fid, std::string name, MPI_Datatype type, int ndim, int *dimids, int *did);
+    int def_local_var (
+        int fid, std::string name, MPI_Datatype type, int ndim, MPI_Offset *dsize, int *did);
     int inq_var (int fid, std::string name, int *did);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);
@@ -48,6 +65,7 @@ class e3sm_io_driver_pnc : public e3sm_io_driver {
     int wait (int fid);
     int put_att (int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf);
     int get_att (int fid, int vid, std::string name, void *buf);
+    int put_varl (int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode);
     int put_vara (int fid,
                   int vid,
                   MPI_Datatype type,


### PR DESCRIPTION
Some underlying I/O API support local variables in which the variable is formed as a collection of data blocks without any information regarding its global view.
ADIOS's local variable API reference:
https://adios2.readthedocs.io/en/latest/components/components.html#shapes