### PR TITLE
Add new case that mimic the I/O strategy of the scorpio module in E3SM F case

### DIFF
--- a/src/cases/Makefile.am
+++ b/src/cases/Makefile.am
@@ -12,14 +12,19 @@ AM_CPPFLAGS += -I${top_srcdir}/src/cases
 noinst_LIBRARIES = libe3sm_io_cases.a
 
 CXX_SRCS =  var_io_F_case.cpp \
+            var_io_F_case_pio.cpp \
             var_io_G_case.cpp \
             e3sm_io_case_F.cpp \
+            e3sm_io_case_F_pio.cpp \
             e3sm_io_case_G.cpp \
             header_io_F_case.cpp \
+            header_io_F_case_pio.cpp \
             header_io_G_case.cpp 
 
 H_SRCS =    e3sm_io_case.hpp \
+            e3sm_io_case_pio.hpp \
             e3sm_io_F_case.hpp \
+            e3sm_io_F_case_pio.hpp \
             e3sm_io_G_case.hpp 
 
 libe3sm_io_cases_a_SOURCES = $(CXX_SRCS) $(H_SRCS)

--- a/src/cases/e3sm_io_case.hpp
+++ b/src/cases/e3sm_io_case.hpp
@@ -7,7 +7,10 @@
  *
  *********************************************************************/
 //
+#pragma once
+//
 #include <e3sm_io.h>
+
 #include <e3sm_io_driver.hpp>
 class e3sm_io_case {
    public:
@@ -18,6 +21,7 @@ class e3sm_io_case {
 };
 
 class e3sm_io_case_F : public e3sm_io_case {
+   protected:
     double *dbl_buf_h0 = NULL, *dbl_buf_h1 = NULL;
     itype *rec_buf_h0 = NULL, *rec_buf_h1 = NULL;
     char txt_buf[2][16];
@@ -32,6 +36,7 @@ class e3sm_io_case_F : public e3sm_io_case {
 };
 
 class e3sm_io_case_G : public e3sm_io_case {
+   protected:
     double *D1_rec_dbl_buf = NULL, *D3_rec_dbl_buf = NULL, *D4_rec_dbl_buf = NULL,
            *D5_rec_dbl_buf = NULL, *D6_rec_dbl_buf = NULL, *D1_fix_dbl_buf = NULL;
     int *D1_fix_int_buf = NULL, *D2_fix_int_buf = NULL, *D3_fix_int_buf = NULL,
@@ -40,6 +45,15 @@ class e3sm_io_case_G : public e3sm_io_case {
    public:
     e3sm_io_case_G ();
     ~e3sm_io_case_G ();
+    int load_data (e3sm_io_config &cfg, e3sm_io_decom &decom, e3sm_io_driver &driver);
+    int wr_test (e3sm_io_config &cfg, e3sm_io_decom &decom, e3sm_io_driver &driver);
+    int rd_test (e3sm_io_config &cfg, e3sm_io_decom &decom, e3sm_io_driver &driver);
+};
+
+class e3sm_io_case_F_pio : public e3sm_io_case_F {
+   public:
+    e3sm_io_case_F_pio ();
+    ~e3sm_io_case_F_pio ();
     int load_data (e3sm_io_config &cfg, e3sm_io_decom &decom, e3sm_io_driver &driver);
     int wr_test (e3sm_io_config &cfg, e3sm_io_decom &decom, e3sm_io_driver &driver);
     int rd_test (e3sm_io_config &cfg, e3sm_io_decom &decom, e3sm_io_driver &driver);

--- a/src/cases/e3sm_io_case_F_pio.cpp
+++ b/src/cases/e3sm_io_case_F_pio.cpp
@@ -1,0 +1,93 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+//
+#include <e3sm_io.h>
+#include <e3sm_io_err.h>
+
+#include <e3sm_io_case.hpp>
+#include <e3sm_io_case_F_pio.hpp>
+
+e3sm_io_case_F_pio::e3sm_io_case_F_pio () {}
+e3sm_io_case_F_pio::~e3sm_io_case_F_pio () {}
+int e3sm_io_case_F_pio::load_data (e3sm_io_config &cfg,
+                                   e3sm_io_decom &decom,
+                                   e3sm_io_driver &driver) {
+    int err, nerrs = 0;
+    RET_ERR ("PIO case does not support reading")
+err_out:;
+    return nerrs;
+}
+int e3sm_io_case_F_pio::wr_test (e3sm_io_config &cfg,
+                                 e3sm_io_decom &decom,
+                                 e3sm_io_driver &driver) {
+    int err, nerrs = 0;
+    int nvar;
+
+    PRINT_MSG (0, "number of requests for D1=%d D2=%d D3=%d\n", decom.contig_nreqs[0],
+               decom.contig_nreqs[1], decom.contig_nreqs[2]);
+
+    if ((cfg.verbose >= 0) && (cfg.rank == 0)) {
+        printf ("Total number of MPI processes      = %d\n", cfg.np);
+        printf ("Number of IO processes             = %d\n", cfg.num_iotasks);
+        printf ("Input decomposition file           = %s\n", cfg.cfgpath);
+        printf ("Number of decompositions           = %d\n", decom.num_decomp);
+        printf ("Output file directory              = %s\n", cfg.targetdir);
+        printf ("Variable dimensions (C order)      = %lld x %lld\n", decom.dims[2][0],
+                decom.dims[2][1]);
+        printf ("Write number of records (time dim) = %d\n", cfg.nrec);
+        printf ("Using noncontiguous write buffer   = %s\n", cfg.non_contig_buf ? "yes" : "no");
+    }
+
+    nvar = cfg.nvars;
+
+    /* vard APIs require internal data type matches external one */
+    if (cfg.vard) {
+        RET_ERR ("PIO case does not support vard API")
+    } else {
+        PRINT_MSG (0,
+                   "\n==== benchmarking PIO F case writing using varn API ========================\n");
+
+        if (cfg.two_buf) {
+            PRINT_MSG (0, "Variable written order: 2D variables then 3D variables\n\n");
+        } else {
+            PRINT_MSG (0, "Variable written order: same as variables are defined\n\n");
+        }
+
+        fflush (stdout);
+
+        if (cfg.hx == 0 || cfg.hx == -1) {
+            MPI_Barrier (cfg.io_comm);
+            cfg.nvars = 414;
+            nerrs += run_varn_F_case_pio (cfg, decom, driver, "f_case_h0_varn.nc", this->dbl_buf_h0,
+                                          this->rec_buf_h0, this->txt_buf[0], this->int_buf[0]);
+        }
+
+        if (cfg.hx == 0 || cfg.hx == -1) {
+            MPI_Barrier (cfg.io_comm);
+            cfg.nvars = 51;
+            nerrs += run_varn_F_case_pio (cfg, decom, driver, "f_case_h1_varn.nc", this->dbl_buf_h0,
+                                          this->rec_buf_h0, this->txt_buf[0], this->int_buf[0]);
+        }
+    }
+
+    cfg.nvars = nvar;
+err_out:;
+    return nerrs;
+}
+int e3sm_io_case_F_pio::rd_test (e3sm_io_config &cfg,
+                                 e3sm_io_decom &decom,
+                                 e3sm_io_driver &driver) {
+    int err, nerrs = 0;
+    RET_ERR ("PIO case does not support reading")
+err_out:;
+    return nerrs;
+}

--- a/src/cases/e3sm_io_case_F_pio.hpp
+++ b/src/cases/e3sm_io_case_F_pio.hpp
@@ -1,0 +1,47 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+//
+#pragma once
+//
+#include <string>
+#include <vector>
+//
+#include <mpi.h>
+//
+#include <e3sm_io.h>
+
+#include <e3sm_io_case_pio.hpp>
+#include <e3sm_io_driver.hpp>
+
+int def_F_case_h0_pio (e3sm_io_driver &driver,
+                       e3sm_io_decom &decom,
+                       int ncid,                 /* file ID */
+                       const MPI_Offset dims[2], /* dimension sizes */
+                       int nvars,                /* number of variables */
+                       std::vector<int> &decomids,
+                       e3sm_io_pio_var *varids,
+                       int *piovars);
+
+int def_F_case_h1_pio (e3sm_io_driver &driver,
+                       e3sm_io_decom &decom,
+                       int ncid,                 /* file ID */
+                       const MPI_Offset dims[2], /* dimension sizes */
+                       int nvars,                /* number of variables */
+                       std::vector<int> &decomids,
+                       e3sm_io_pio_var *varids,
+                       int *piovars);
+
+int run_varn_F_case_pio (e3sm_io_config &cfg,
+                         e3sm_io_decom &decom,
+                         e3sm_io_driver &driver,
+                         std::string outfile, /* output file name */
+                         double *dbl_bufp,    /* buffer for fixed size double var */
+                         itype *rec_bufp,     /* buffer for rec floating point var */
+                         char *txt_buf,       /* buffer for char var */
+                         int *int_buf);       /* buffer for int var */

--- a/src/cases/e3sm_io_case_pio.hpp
+++ b/src/cases/e3sm_io_case_pio.hpp
@@ -1,0 +1,230 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+//
+#pragma once
+//
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+//
+#include <cstring>
+#include <map>
+//
+#include <e3sm_io.h>
+#include <e3sm_io_err.h>
+
+#include <e3sm_io_case.hpp>
+#include <e3sm_io_case_F.hpp>
+#include <e3sm_io_driver.hpp>
+#include <e3sm_io_driver_adios2.hpp>
+#include <e3sm_io_driver_pnc.hpp>
+
+typedef struct e3sm_io_pio_var {
+    int data;
+    int frame_id;
+    int decomp_id;
+    int fillval_id;
+    MPI_Datatype type;
+    int decomid;
+} e3sm_io_pio_var;
+
+inline int e3sm_io_pio_define_dim (e3sm_io_driver &driver,
+                                   int fid,
+                                   std::string name,
+                                   MPI_Offset size,
+                                   std::map<int, std::string> &dnames,
+                                   int *did) {
+    int err, nerrs = 0;
+
+    err = driver.def_dim (fid, name, size, did);
+    CHECK_ERR
+
+    dnames[*did] = name;
+
+err_out:;
+    return nerrs;
+}
+
+inline int e3sm_io_pio_define_var (e3sm_io_driver &driver,
+                                   std::map<int, std::string> &dnames,
+                                   e3sm_io_decom &decom,
+                                   int decomid,
+                                   int fid,
+                                   std::string name,
+                                   MPI_Datatype type,
+                                   int ndim,
+                                   int *dimids,
+                                   e3sm_io_pio_var *var) {
+    int err, nerrs = 0;
+    int i, j;
+    char cbuf[64], *cbufp;
+    int ibuf;
+    int ret;
+
+    var->type    = type;
+    var->decomid = decomid;
+
+    if (decomid >= 0) {
+        MPI_Offset one = 1;
+
+        err = driver.def_local_var (fid, name, type, 1, &(decom.raw_nreqs[decomid]), &(var->data));
+        CHECK_ERR
+
+        if (ndim > 0) {
+            err =
+                driver.def_local_var (fid, "frame_id/" + name, MPI_INT, 1, &one, &(var->frame_id));
+            CHECK_ERR
+
+            err = driver.def_local_var (fid, "decomp_id/" + name, MPI_INT, 1, &one,
+                                        &(var->decomp_id));
+            CHECK_ERR
+
+            // Only double vars have fillval_id
+            if (type == MPI_DOUBLE) {
+                err = driver.def_local_var (fid, "fillval_id/" + name, type, 1, &one,
+                                            &(var->fillval_id));
+                CHECK_ERR
+            } else {
+                var->fillval_id = -1;
+            }
+
+            // Attributes
+            // err = driver.put_att (fid, var->data, "_FillValue", var->type, 1, cbuf);
+            // CHECK_ERR
+
+            ibuf = var->decomp_id + 512;
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/decomp", MPI_INT, 1, &ibuf);
+            CHECK_ERR
+
+            cbufp = cbuf;
+            ret   = sprintf (cbufp, "{%s", dnames[dimids[0]].c_str ());
+            cbufp += ret;
+            for (i = 1; i < ndim; i++) {
+                ret = sprintf (cbufp, ", %s", dnames[dimids[i]].c_str ());
+                cbufp += ret;
+            }
+            err =
+                driver.put_att (fid, var->data, "__e3sm_io__/dims", MPI_CHAR, strlen (cbuf), cbuf);
+            CHECK_ERR
+
+            err =
+                driver.put_att (fid, var->data, "__e3sm_io__/ncop", MPI_CHAR, 7, (void *)"darray");
+            CHECK_ERR
+
+            ibuf = 5;
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/nctype", MPI_INT, 1, &ibuf);
+            CHECK_ERR
+
+            err = driver.put_att (fid, var->data, "__e3sm_io__/ndims", MPI_INT, 1, &ndim);
+            CHECK_ERR
+        }
+    } else {
+        std::vector<MPI_Offset> dsize (ndim);
+        MPI_Offset vsize = 1;
+
+        for (i = j = 0; i < ndim; i++) {
+            err = driver.inq_dimlen (fid, dimids[i], &(dsize[j]));
+            CHECK_ERR
+
+            // Skip time dim
+            if (dsize[j] > 0) { j++; }
+        }
+
+        // flatten into 1 dim
+        for (i = 0; i < j; i++) { vsize *= dsize[i]; }
+        err = driver.def_local_var (fid, name, type, 1, &vsize, &(var->data));
+        CHECK_ERR
+
+        // Attributes for non-constant small vars
+        if (ndim > 0) {
+            ibuf = (int)mpi_type_to_adios2_type (type);
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/adiostype", MPI_INT, 1, &ibuf);
+            CHECK_ERR
+
+            cbufp = cbuf;
+            ret   = sprintf (cbufp, "{%s", dnames[dimids[0]].c_str ());
+            cbufp += ret;
+            for (i = 1; i < ndim; i++) {
+                ret = sprintf (cbufp, ", %s", dnames[dimids[i]].c_str ());
+                cbufp += ret;
+            }
+            err =
+                driver.put_att (fid, var->data, "__e3sm_io__/dims", MPI_CHAR, strlen (cbuf), cbuf);
+            CHECK_ERR
+
+            err =
+                driver.put_att (fid, var->data, "__e3sm_io__/ncop", MPI_CHAR, 7, (void *)"put_var");
+            CHECK_ERR
+
+            ibuf = (int)mpitype2nctype (type);
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/nctype", MPI_INT, 1, &ibuf);
+            CHECK_ERR
+
+            err = driver.put_att (fid, var->data, "__e3sm_io__/ndims", MPI_INT, 1, &ndim);
+            CHECK_ERR
+        }
+
+        var->decomp_id  = -1;
+        var->frame_id   = -1;
+        var->fillval_id = -1;
+    }
+err_out:;
+    return nerrs;
+}
+
+inline int e3sm_io_pio_write_var (e3sm_io_driver &driver,
+                                  int frameid,
+                                  int fid,
+                                  e3sm_io_pio_var &var,
+                                  MPI_Datatype type,
+                                  void *buf,
+                                  e3sm_io_op_mode mode) {
+    int err, nerrs = 0;
+
+    err = driver.put_varl (fid, var.data, type, buf, mode);
+    CHECK_ERR
+
+    if (var.frame_id >= 0) {
+        err = driver.put_varl (fid, var.frame_id, MPI_INT, &frameid, mode);
+        CHECK_ERR
+
+        err = driver.put_varl (fid, var.decomp_id, MPI_INT, &(var.decomid), mode);
+        CHECK_ERR
+
+        if (var.fillval_id >= 0) {
+            double fbuf = 1e+20;
+
+            err = driver.put_varl (fid, var.fillval_id, var.type, &fbuf, mode);
+            CHECK_ERR
+        }
+    }
+
+err_out:;
+    return nerrs;
+}
+
+inline int e3sm_io_pio_put_att (e3sm_io_driver &driver,
+                                int fid,
+                                int vid,
+                                std::string name,
+                                MPI_Datatype type,
+                                MPI_Offset size,
+                                void *buf) {
+    return driver.put_att (fid, vid, name, type, size, buf);
+}
+
+inline int e3sm_io_pio_put_att (e3sm_io_driver &driver,
+                                int fid,
+                                e3sm_io_pio_var &var,
+                                std::string name,
+                                MPI_Datatype type,
+                                MPI_Offset size,
+                                void *buf) {
+    return driver.put_att (fid, var.data, name, type, size, buf);
+}

--- a/src/cases/header_io_F_case_pio.cpp
+++ b/src/cases/header_io_F_case_pio.cpp
@@ -1,0 +1,6554 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+//
+#include <assert.h>
+
+#include <map>
+#include <vector>
+//
+#include <mpi.h>
+//
+#include <e3sm_io.h>
+#include <e3sm_io_err.h>
+
+#include <e3sm_io_case_F_pio.hpp>
+#include <e3sm_io_case_pio.hpp>
+#include <e3sm_io_driver.hpp>
+
+#define PUT_ATT_TEXT(F, D, N, S, B) e3sm_io_pio_put_att (driver, F, D, N, MPI_CHAR, S, (void *)B);
+#define PUT_ATT_FLOAT(F, D, N, T, S, B) \
+    e3sm_io_pio_put_att (driver, F, D, N, MPI_FLOAT, S, (float *)B);
+#define PUT_ATT_INT(F, D, N, T, S, B) e3sm_io_pio_put_att (driver, F, D, N, MPI_FLOAT, S, (int *)B);
+
+#define GET_ATT_TEXT(F, D, N, S, B)     driver.get_att (F, D, N, (void *)attbuf);
+#define GET_ATT_FLOAT(F, D, N, T, S, B) driver.get_att (F, D, N, (float *)attbuf);
+#define GET_ATT_INT(F, D, N, T, S, B)   driver.get_att (F, D, N, (int *)attbuf);
+#define GET_ATT(F, D, N, T, S, B)       driver.get_att (F, D, N, (void *)attbuf);
+
+#define INQ_VID(F, N, T, S, B, V) driver.inq_var (F, N, V);
+
+static char attbuf[4096];
+
+/*----< def_F_case_h0_pio() >----------------------------------------------------*/
+int def_F_case_h0_pio (e3sm_io_driver &driver,
+                       e3sm_io_decom &decom,
+                       int ncid,                 /* file ID */
+                       const MPI_Offset dims[2], /* dimension sizes */
+                       int nvars,                /* number of variables */
+                       std::vector<int> &decomids,
+                       e3sm_io_pio_var *varids, /* variable IDs */
+                       int *piovars) {
+    int err, nerrs = 0;
+    /* Total 414 variables */
+    e3sm_io_pio_var lat, lon, area, lev, hyam, hybm, P0, ilev, hyai, hybi, time, date, datesec,
+        time_bnds, date_written, time_written, ndbase, nsbase, nbdate, nbsec, mdt, ndcur, nscur,
+        co2vmr, ch4vmr, n2ovmr, f11vmr, f12vmr, sol_tsi, nsteph, AEROD_v, ANRAIN, ANSNOW, AODABS,
+        AODABSBC, AODALL, AODBC, AODDUST, AODDUST1, AODDUST3, AODDUST4, AODMODE1, AODMODE2,
+        AODMODE3, AODMODE4, AODNIR, AODPOM, AODSO4, AODSOA, AODSS, AODUV, AODVIS, AQRAIN, AQSNOW,
+        AQ_DMS, AQ_H2O2, AQ_H2SO4, AQ_O3, AQ_SO2, AQ_SOAG, AREI, AREL, AWNC, AWNI, BURDEN1, BURDEN2,
+        BURDEN3, BURDEN4, CCN3, CDNUMC, CLDHGH, CLDICE, CLDLIQ, CLDLOW, CLDMED, CLDTOT, CLOUD,
+        CLOUDFRAC_CLUBB, CONCLD, DCQ, DF_DMS, DF_H2O2, DF_H2SO4, DF_O3, DF_SO2, DF_SOAG, DMS_SRF,
+        DP_KCLDBASE, DP_MFUP_MAX, DP_WCLDBASE, DSTSFMBL, DTCOND, DTENDTH, DTENDTQ, EXTINCT, FICE,
+        FLDS, FLNS, FLNSC, FLNT, FLNTC, FLUT, FLUTC, FREQI, FREQL, FREQR, FREQS, FSDS, FSDSC, FSNS,
+        FSNSC, FSNT, FSNTC, FSNTOA, FSNTOAC, FSUTOA, FSUTOAC, F_eff, H2O2_SRF, H2SO4_SRF,
+        H2SO4_sfgaex1, ICEFRAC, ICIMR, ICWMR, IWC, LANDFRAC, LHFLX, LINOZ_DO3, LINOZ_DO3_PSC,
+        LINOZ_O3CLIM, LINOZ_O3COL, LINOZ_SFCSINK, LINOZ_SSO3, LINOZ_SZA, LND_MBL, LWCF, Mass_bc,
+        Mass_dst, Mass_mom, Mass_ncl, Mass_pom, Mass_so4, Mass_soa, NUMICE, NUMLIQ, NUMRAI, NUMSNO,
+        O3, O3_SRF, OCNFRAC, OMEGA, OMEGA500, OMEGAT, PBLH, PHIS, PRECC, PRECL, PRECSC, PRECSL, PS,
+        PSL, Q, QFLX, QREFHT, QRL, QRS, RAINQM, RAM1, RELHUM, SCO, SFDMS, SFH2O2, SFH2SO4, SFO3,
+        SFSO2, SFSOAG, SFbc_a1, SFbc_a3, SFbc_a4, SFdst_a1, SFdst_a3, SFmom_a1, SFmom_a2, SFmom_a3,
+        SFmom_a4, SFncl_a1, SFncl_a2, SFncl_a3, SFnum_a1, SFnum_a2, SFnum_a3, SFnum_a4, SFpom_a1,
+        SFpom_a3, SFpom_a4, SFso4_a1, SFso4_a2, SFso4_a3, SFsoa_a1, SFsoa_a2, SFsoa_a3, SHFLX,
+        SH_KCLDBASE, SH_MFUP_MAX, SH_WCLDBASE, SNOWHICE, SNOWHLND, SNOWQM, SO2, SO2_CLXF, SO2_SRF,
+        SOAG_CLXF, SOAG_SRF, SOAG_sfgaex1, SOLIN, SSAVIS, SSTSFMBL, SSTSFMBL_OM, SWCF, T, TAUGWX,
+        TAUGWY, TAUX, TAUY, TCO, TGCLDCWP, TGCLDIWP, TGCLDLWP, TH7001000, TMQ, TREFHT, TROP_P,
+        TROP_T, TS, TSMN, TSMX, TUH, TUQ, TVH, TVQ, U, U10, UU, V, VQ, VT, VU, VV, WD_H2O2,
+        WD_H2SO4, WD_SO2, WSUB, Z3, aero_water, airFV, bc_a1DDF, bc_a1SFWET, bc_a1_SRF,
+        bc_a1_sfgaex1, bc_a3DDF, bc_a3SFWET, bc_a3_SRF, bc_a4DDF, bc_a4SFWET, bc_a4_CLXF, bc_a4_SRF,
+        bc_a4_sfgaex1, bc_c1DDF, bc_c1SFWET, bc_c3DDF, bc_c3SFWET, bc_c4DDF, bc_c4SFWET, chla,
+        dst_a1DDF, dst_a1SF, dst_a1SFWET, dst_a1_SRF, dst_a3DDF, dst_a3SF, dst_a3SFWET, dst_a3_SRF,
+        dst_c1DDF, dst_c1SFWET, dst_c3DDF, dst_c3SFWET, hstobie_linoz, mlip, mom_a1DDF, mom_a1SF,
+        mom_a1SFWET, mom_a1_SRF, mom_a1_sfgaex1, mom_a2DDF, mom_a2SF, mom_a2SFWET, mom_a2_SRF,
+        mom_a3DDF, mom_a3SFWET, mom_a3_SRF, mom_a4DDF, mom_a4SF, mom_a4SFWET, mom_a4_SRF,
+        mom_a4_sfgaex1, mom_c1DDF, mom_c1SFWET, mom_c2DDF, mom_c2SFWET, mom_c3DDF, mom_c3SFWET,
+        mom_c4DDF, mom_c4SFWET, mpoly, mprot, ncl_a1DDF, ncl_a1SF, ncl_a1SFWET, ncl_a1_SRF,
+        ncl_a2DDF, ncl_a2SF, ncl_a2SFWET, ncl_a2_SRF, ncl_a3DDF, ncl_a3SF, ncl_a3SFWET, ncl_a3_SRF,
+        ncl_c1DDF, ncl_c1SFWET, ncl_c2DDF, ncl_c2SFWET, ncl_c3DDF, ncl_c3SFWET, num_a1DDF, num_a1SF,
+        num_a1SFWET, num_a1_CLXF, num_a1_SRF, num_a1_sfgaex1, num_a2DDF, num_a2SFWET, num_a2_CLXF,
+        num_a2_SRF, num_a3DDF, num_a3SF, num_a3SFWET, num_a3_SRF, num_a4DDF, num_a4SFWET,
+        num_a4_CLXF, num_a4_SRF, num_a4_sfgaex1, num_c1DDF, num_c1SFWET, num_c2DDF, num_c2SFWET,
+        num_c3DDF, num_c3SFWET, num_c4DDF, num_c4SFWET, pom_a1DDF, pom_a1SFWET, pom_a1_SRF,
+        pom_a1_sfgaex1, pom_a3DDF, pom_a3SFWET, pom_a3_SRF, pom_a4DDF, pom_a4SFWET, pom_a4_CLXF,
+        pom_a4_SRF, pom_a4_sfgaex1, pom_c1DDF, pom_c1SFWET, pom_c3DDF, pom_c3SFWET, pom_c4DDF,
+        pom_c4SFWET, so4_a1DDF, so4_a1SFWET, so4_a1_CLXF, so4_a1_SRF, so4_a1_sfgaex1, so4_a2DDF,
+        so4_a2SFWET, so4_a2_CLXF, so4_a2_SRF, so4_a2_sfgaex1, so4_a3DDF, so4_a3SFWET, so4_a3_SRF,
+        so4_a3_sfgaex1, so4_c1DDF, so4_c1SFWET, so4_c2DDF, so4_c2SFWET, so4_c3DDF, so4_c3SFWET,
+        soa_a1DDF, soa_a1SFWET, soa_a1_SRF, soa_a1_sfgaex1, soa_a2DDF, soa_a2SFWET, soa_a2_SRF,
+        soa_a2_sfgaex1, soa_a3DDF, soa_a3SFWET, soa_a3_SRF, soa_a3_sfgaex1, soa_c1DDF, soa_c1SFWET,
+        soa_c2DDF, soa_c2SFWET, soa_c3DDF, soa_c3SFWET;
+
+    int i, j, k, dimids[3], iattr, mdims = 1;
+    int dim_ncol, dim_time, dim_nbnd, dim_chars, dim_lev, dim_ilev;
+    float fillv = 1.e+36f, missv = 1.e+36f;
+    std::map<int, std::string> dnames;
+    char name[128];
+
+    /* global attributes: */
+    iattr = 4;
+    err   = e3sm_io_pio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR, "ne", MPI_INT, 1, &iattr);
+    CHECK_ERR
+    err = e3sm_io_pio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR, "np", MPI_INT, 1, &iattr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "Conventions", 6, "CF-1.0");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "source", 3, "CAM");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "case", 20, "FC5AV1C-H01B_ne4_ne4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "title", 5, "UNSET");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "logname", 6, "wkliao");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "host", 10, "compute001");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "Version", 6, "$Name$");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "revision_Id", 4, "$Id$");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (
+        ncid, E3SM_IO_GLOBAL_ATTR, "initial_file", 86,
+        "/home/climate1/acme/inputdata/atm/cam/inic/homme/cami_mam3_Linoz_ne4np4_L72_c160909.nc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (
+        ncid, E3SM_IO_GLOBAL_ATTR, "topography_file", 79,
+        "/home/climate1/acme/inputdata/atm/cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "time_period_freq", 5, "day_5");
+    CHECK_ERR
+
+    // PIO attributes
+    k   = 256;
+    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "/__e3sm_io__/fillmode", MPI_INT, 1, &k);
+    CHECK_ERR
+
+    /* define dimensions */
+    err = e3sm_io_pio_define_dim (driver, ncid, "ncol", dims[1], dnames, &dim_ncol);
+    CHECK_ERR
+    err = e3sm_io_pio_define_dim (driver, ncid, "time", NC_UNLIMITED, dnames, &dim_time);
+    CHECK_ERR
+    err = e3sm_io_pio_define_dim (driver, ncid, "nbnd", 2, dnames, &dim_nbnd);
+    CHECK_ERR
+    err = e3sm_io_pio_define_dim (driver, ncid, "chars", 8, dnames, &dim_chars);
+    CHECK_ERR
+    err = e3sm_io_pio_define_dim (driver, ncid, "lev", dims[0], dnames, &dim_lev);
+    CHECK_ERR
+    err = e3sm_io_pio_define_dim (driver, ncid, "ilev", dims[0] + 1, dnames, &dim_ilev);
+    CHECK_ERR
+
+    /* define pio decom map variables */
+    for (j = 0; j < 5; j++) {
+        int piodecomid[] = {0, 1, 1, 1, 2};
+
+        sprintf (name, "/__e3sm_io__/decomp/%d", (j + 512));
+        err = driver.def_local_var (ncid, name, MPI_LONG_LONG, 1, decom.raw_nreqs + piodecomid[j],
+                                    piovars + j);
+        CHECK_ERR
+        err = driver.put_att (ncid, piovars[j], "dimlen", MPI_INT, decom.ndims[piodecomid[j]],
+                              decom.dims + piodecomid[j]);
+        CHECK_ERR
+        err = driver.put_att (ncid, piovars[j], "ndims", MPI_INT, 1, decom.ndims + piodecomid[j]);
+        CHECK_ERR
+
+        k   = 6;
+        err = driver.put_att (ncid, piovars[j], "piotype", MPI_INT, 1, &k);
+        CHECK_ERR
+    }
+
+    // TODO: only the first subfile contain nproc
+    err = driver.def_local_var (ncid, "/__e3sm_io__/info/nproc", MPI_INT, 0, NULL, piovars + (j++));
+    CHECK_ERR
+
+    /* define variables */
+    i = 0;
+
+    dimids[0] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lat", MPI_DOUBLE, 1,
+                                  dimids, &lat);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lat, "long_name", 8, "latitude");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lat, "units", 13, "degrees_north");
+    CHECK_ERR
+    varids[i++] = lat;
+
+    dimids[0] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lon", MPI_DOUBLE, 1,
+                                  dimids, &lon);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lon, "long_name", 9, "longitude");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lon, "units", 12, "degrees_east");
+    CHECK_ERR
+    varids[i++] = lon;
+
+    dimids[0] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "area", MPI_DOUBLE, 1,
+                                  dimids, &area);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, area, "long_name", 14, "gll grid areas");
+    CHECK_ERR
+    varids[i++] = area;
+
+    dimids[0] = dim_lev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lev", MPI_DOUBLE, 1,
+                                  dimids, &lev);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lev, "long_name", 38, "hybrid level at midpoints (1000*(A+B))");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lev, "units", 3, "hPa");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lev, "positive", 4, "down");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lev, "standard_name", 43,
+                        "atmosphere_hybrid_sigma_pressure_coordinate");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lev, "formula_terms", 29, "a: hyam b: hybm p0: P0 ps: PS");
+    CHECK_ERR
+    varids[i++] = lev;
+
+    dimids[0] = dim_lev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hyam", MPI_DOUBLE, 1,
+                                  dimids, &hyam);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, hyam, "long_name", 39, "hybrid A coefficient at layer midpoints");
+    CHECK_ERR
+    varids[i++] = hyam;
+
+    dimids[0] = dim_lev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hybm", MPI_DOUBLE, 1,
+                                  dimids, &hybm);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, hybm, "long_name", 39, "hybrid B coefficient at layer midpoints");
+    CHECK_ERR
+    varids[i++] = hybm;
+
+    dimids[0] = dim_lev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "P0", MPI_DOUBLE, 0,
+                                  NULL, &P0);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, P0, "long_name", 18, "reference pressure");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, P0, "units", 2, "Pa");
+    CHECK_ERR
+    varids[i++] = P0;
+
+    dimids[0] = dim_ilev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ilev", MPI_DOUBLE, 1,
+                                  dimids, &ilev);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ilev, "long_name", 39, "hybrid level at interfaces (1000*(A+B))");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ilev, "units", 3, "hPa");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ilev, "positive", 4, "down");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ilev, "standard_name", 43,
+                        "atmosphere_hybrid_sigma_pressure_coordinate");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ilev, "formula_terms", 29, "a: hyai b: hybi p0: P0 ps: PS");
+    CHECK_ERR
+    varids[i++] = ilev;
+
+    dimids[0] = dim_ilev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hyai", MPI_DOUBLE, 1,
+                                  dimids, &hyai);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, hyai, "long_name", 40, "hybrid A coefficient at layer interfaces");
+    CHECK_ERR
+    varids[i++] = hyai;
+
+    dimids[0] = dim_ilev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hybi", MPI_DOUBLE, 1,
+                                  dimids, &hybi);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, hybi, "long_name", 40, "hybrid B coefficient at layer interfaces");
+    CHECK_ERR
+    varids[i++] = hybi;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time", MPI_DOUBLE, 1,
+                                  dimids, &time);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, time, "long_name", 4, "time");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, time, "units", 30, "days since 0001-01-01 00:00:00");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, time, "calendar", 6, "noleap");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, time, "bounds", 9, "time_bnds");
+    CHECK_ERR
+    varids[i++] = time;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "date", MPI_INT, 1,
+                                  dimids, &date);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, date, "long_name", 23, "current date (YYYYMMDD)");
+    CHECK_ERR
+    varids[i++] = date;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "datesec", MPI_INT, 1,
+                                  dimids, &datesec);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, datesec, "long_name", 31, "current seconds of current date");
+    CHECK_ERR
+    varids[i++] = datesec;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_nbnd;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time_bnds", MPI_DOUBLE,
+                                  2, dimids, &time_bnds);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, time_bnds, "long_name", 23, "time interval endpoints");
+    CHECK_ERR
+    varids[i++] = time_bnds;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_chars;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "date_written",
+                                  MPI_CHAR, 2, dimids, &date_written);
+    CHECK_ERR
+    varids[i++] = date_written;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_chars;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time_written",
+                                  MPI_CHAR, 2, dimids, &time_written);
+    CHECK_ERR
+    varids[i++] = time_written;
+
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ndbase", MPI_INT, 0,
+                                  NULL, &ndbase);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ndbase, "long_name", 8, "base day");
+    CHECK_ERR
+    varids[i++] = ndbase;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nsbase", MPI_INT, 0,
+                                  NULL, &nsbase);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, nsbase, "long_name", 19, "seconds of base day");
+    CHECK_ERR
+    varids[i++] = nsbase;
+
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nbdate", MPI_INT, 0,
+                                  NULL, &nbdate);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, nbdate, "long_name", 20, "base date (YYYYMMDD)");
+    CHECK_ERR
+    varids[i++] = nbdate;
+
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nbsec", MPI_INT, 0,
+                                  NULL, &nbsec);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, nbsec, "long_name", 20, "seconds of base date");
+    CHECK_ERR
+    varids[i++] = nbsec;
+
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mdt", MPI_INT, 0, NULL,
+                                  &mdt);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mdt, "long_name", 8, "timestep");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mdt, "units", 1, "s");
+    CHECK_ERR
+    varids[i++] = mdt;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ndcur", MPI_INT, 1,
+                                  dimids, &ndcur);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ndcur, "long_name", 27, "current day (from base day)");
+    CHECK_ERR
+    varids[i++] = ndcur;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nscur", MPI_INT, 1,
+                                  dimids, &nscur);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, nscur, "long_name", 30, "current seconds of current day");
+    CHECK_ERR
+    varids[i++] = nscur;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "co2vmr", MPI_DOUBLE, 1,
+                                  dimids, &co2vmr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, co2vmr, "long_name", 23, "co2 volume mixing ratio");
+    CHECK_ERR
+    varids[i++] = co2vmr;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ch4vmr", MPI_DOUBLE, 1,
+                                  dimids, &ch4vmr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ch4vmr, "long_name", 23, "ch4 volume mixing ratio");
+    CHECK_ERR
+    varids[i++] = ch4vmr;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "n2ovmr", MPI_DOUBLE, 1,
+                                  dimids, &n2ovmr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, n2ovmr, "long_name", 23, "n2o volume mixing ratio");
+    CHECK_ERR
+    varids[i++] = n2ovmr;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "f11vmr", MPI_DOUBLE, 1,
+                                  dimids, &f11vmr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, f11vmr, "long_name", 23, "f11 volume mixing ratio");
+    CHECK_ERR
+    varids[i++] = f11vmr;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "f12vmr", MPI_DOUBLE, 1,
+                                  dimids, &f12vmr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, f12vmr, "long_name", 23, "f12 volume mixing ratio");
+    CHECK_ERR
+    varids[i++] = f12vmr;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "sol_tsi", MPI_DOUBLE,
+                                  1, dimids, &sol_tsi);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, sol_tsi, "long_name", 22, "total solar irradiance");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, sol_tsi, "units", 4, "W/m2");
+    CHECK_ERR
+    varids[i++] = sol_tsi;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nsteph", MPI_INT, 1,
+                                  dimids, &nsteph);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, nsteph, "long_name", 16, "current timestep");
+    CHECK_ERR
+    varids[i++] = nsteph;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AEROD_v", MPI_FLOAT, 2,
+                                  dimids, &AEROD_v);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AEROD_v, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AEROD_v, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AEROD_v, "units", 1, "1");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AEROD_v, "long_name", 43,
+                        "Total Aerosol Optical Depth in visible band");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AEROD_v, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AEROD_v;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ANRAIN", MPI_FLOAT, 3,
+                                  dimids, &ANRAIN);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, ANRAIN, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ANRAIN, "units", 3, "m-3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ANRAIN, "long_name", 24, "Average rain number conc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ANRAIN, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ANRAIN;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ANSNOW", MPI_FLOAT, 3,
+                                  dimids, &ANSNOW);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, ANSNOW, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ANSNOW, "units", 3, "m-3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ANSNOW, "long_name", 24, "Average snow number conc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ANSNOW, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ANSNOW;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODABS", MPI_FLOAT, 2,
+                                  dimids, &AODABS);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODABS, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODABS, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODABS, "long_name", 39, "Aerosol absorption optical depth 550 nm");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODABS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODABS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODABSBC", MPI_FLOAT,
+                                  2, dimids, &AODABSBC);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODABSBC, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODABSBC, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODABSBC, "long_name", 47,
+                        "Aerosol absorption optical depth 550 nm from BC");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODABSBC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODABSBC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODALL", MPI_FLOAT, 2,
+                                  dimids, &AODALL);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODALL, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODALL, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODALL, "long_name", 35, "AOD 550 nm for all time and species");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODALL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODALL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODBC", MPI_FLOAT, 2,
+                                  dimids, &AODBC);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODBC, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODBC, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODBC, "long_name", 36, "Aerosol optical depth 550 nm from BC");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODBC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODBC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODDUST", MPI_FLOAT, 2,
+                                  dimids, &AODDUST);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODDUST, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODDUST, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODDUST, "long_name", 38, "Aerosol optical depth 550 nm from dust");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODDUST, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODDUST;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODDUST1", MPI_FLOAT,
+                                  2, dimids, &AODDUST1);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODDUST1, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODDUST1, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODDUST1, "long_name", 46,
+                        "Aerosol optical depth 550 nm model 1 from dust");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODDUST1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODDUST1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODDUST3", MPI_FLOAT,
+                                  2, dimids, &AODDUST3);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODDUST3, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODDUST3, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODDUST3, "long_name", 46,
+                        "Aerosol optical depth 550 nm model 3 from dust");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODDUST3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODDUST3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODDUST4", MPI_FLOAT,
+                                  2, dimids, &AODDUST4);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODDUST4, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODDUST4, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODDUST4, "long_name", 46,
+                        "Aerosol optical depth 550 nm model 4 from dust");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODDUST4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODDUST4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODMODE1", MPI_FLOAT,
+                                  2, dimids, &AODMODE1);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODMODE1, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODMODE1, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODMODE1, "long_name", 35, "Aerosol optical depth 550 nm mode 1");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODMODE1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODMODE1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODMODE2", MPI_FLOAT,
+                                  2, dimids, &AODMODE2);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODMODE2, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODMODE2, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODMODE2, "long_name", 35, "Aerosol optical depth 550 nm mode 2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODMODE2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODMODE2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODMODE3", MPI_FLOAT,
+                                  2, dimids, &AODMODE3);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODMODE3, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODMODE3, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODMODE3, "long_name", 35, "Aerosol optical depth 550 nm mode 3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODMODE3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODMODE3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODMODE4", MPI_FLOAT,
+                                  2, dimids, &AODMODE4);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODMODE4, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODMODE4, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODMODE4, "long_name", 35, "Aerosol optical depth 550 nm mode 4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODMODE4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODMODE4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODNIR", MPI_FLOAT, 2,
+                                  dimids, &AODNIR);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODNIR, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODNIR, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODNIR, "long_name", 28, "Aerosol optical depth 850 nm");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODNIR, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODNIR;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODPOM", MPI_FLOAT, 2,
+                                  dimids, &AODPOM);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODPOM, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODPOM, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODPOM, "long_name", 37, "Aerosol optical depth 550 nm from POM");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODPOM, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODPOM;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODSO4", MPI_FLOAT, 2,
+                                  dimids, &AODSO4);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODSO4, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODSO4, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODSO4, "long_name", 37, "Aerosol optical depth 550 nm from SO4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODSO4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODSO4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODSOA", MPI_FLOAT, 2,
+                                  dimids, &AODSOA);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODSOA, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODSOA, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODSOA, "long_name", 37, "Aerosol optical depth 550 nm from SOA");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODSOA, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODSOA;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODSS", MPI_FLOAT, 2,
+                                  dimids, &AODSS);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODSS, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODSS, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODSS, "long_name", 41, "Aerosol optical depth 550 nm from seasalt");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODSS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODSS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODUV", MPI_FLOAT, 2,
+                                  dimids, &AODUV);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODUV, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODUV, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODUV, "long_name", 28, "Aerosol optical depth 350 nm");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODUV, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODUV;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODVIS", MPI_FLOAT, 2,
+                                  dimids, &AODVIS);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODVIS, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, AODVIS, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODVIS, "long_name", 28, "Aerosol optical depth 550 nm");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AODVIS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AODVIS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQRAIN", MPI_FLOAT, 3,
+                                  dimids, &AQRAIN);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, AQRAIN, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQRAIN, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQRAIN, "long_name", 25, "Average rain mixing ratio");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQRAIN, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AQRAIN;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQSNOW", MPI_FLOAT, 3,
+                                  dimids, &AQSNOW);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, AQSNOW, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQSNOW, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQSNOW, "long_name", 25, "Average snow mixing ratio");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQSNOW, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AQSNOW;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_DMS", MPI_FLOAT, 2,
+                                  dimids, &AQ_DMS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_DMS, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_DMS, "long_name", 39, "DMS aqueous chemistry (for gas species)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_DMS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AQ_DMS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_H2O2", MPI_FLOAT, 2,
+                                  dimids, &AQ_H2O2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_H2O2, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_H2O2, "long_name", 40, "H2O2 aqueous chemistry (for gas species)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_H2O2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AQ_H2O2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_H2SO4", MPI_FLOAT,
+                                  2, dimids, &AQ_H2SO4);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_H2SO4, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, AQ_H2SO4, "long_name", 41, "H2SO4 aqueous chemistry (for gas species)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_H2SO4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AQ_H2SO4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_O3", MPI_FLOAT, 2,
+                                  dimids, &AQ_O3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_O3, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_O3, "long_name", 38, "O3 aqueous chemistry (for gas species)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_O3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AQ_O3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_SO2", MPI_FLOAT, 2,
+                                  dimids, &AQ_SO2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_SO2, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_SO2, "long_name", 39, "SO2 aqueous chemistry (for gas species)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_SO2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AQ_SO2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_SOAG", MPI_FLOAT, 2,
+                                  dimids, &AQ_SOAG);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_SOAG, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_SOAG, "long_name", 40, "SOAG aqueous chemistry (for gas species)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AQ_SOAG, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AQ_SOAG;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AREI", MPI_FLOAT, 3,
+                                  dimids, &AREI);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, AREI, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AREI, "units", 6, "Micron");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AREI, "long_name", 28, "Average ice effective radius");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AREI, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AREI;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AREL", MPI_FLOAT, 3,
+                                  dimids, &AREL);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, AREL, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AREL, "units", 6, "Micron");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AREL, "long_name", 32, "Average droplet effective radius");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AREL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AREL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AWNC", MPI_FLOAT, 3,
+                                  dimids, &AWNC);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, AWNC, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AWNC, "units", 3, "m-3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AWNC, "long_name", 31, "Average cloud water number conc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AWNC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AWNC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AWNI", MPI_FLOAT, 3,
+                                  dimids, &AWNI);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, AWNI, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AWNI, "units", 3, "m-3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AWNI, "long_name", 29, "Average cloud ice number conc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, AWNI, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = AWNI;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "BURDEN1", MPI_FLOAT, 2,
+                                  dimids, &BURDEN1);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, BURDEN1, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, BURDEN1, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN1, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN1, "long_name", 21, "Aerosol burden mode 1");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = BURDEN1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "BURDEN2", MPI_FLOAT, 2,
+                                  dimids, &BURDEN2);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, BURDEN2, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, BURDEN2, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN2, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN2, "long_name", 21, "Aerosol burden mode 2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = BURDEN2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "BURDEN3", MPI_FLOAT, 2,
+                                  dimids, &BURDEN3);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, BURDEN3, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, BURDEN3, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN3, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN3, "long_name", 21, "Aerosol burden mode 3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = BURDEN3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "BURDEN4", MPI_FLOAT, 2,
+                                  dimids, &BURDEN4);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, BURDEN4, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, BURDEN4, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN4, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN4, "long_name", 21, "Aerosol burden mode 4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, BURDEN4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = BURDEN4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CCN3", MPI_FLOAT, 3,
+                                  dimids, &CCN3);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, CCN3, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CCN3, "units", 5, "#/cm3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CCN3, "long_name", 27, "CCN concentration at S=0.1%");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CCN3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CCN3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CDNUMC", MPI_FLOAT, 2,
+                                  dimids, &CDNUMC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CDNUMC, "units", 4, "1/m2");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, CDNUMC, "long_name", 43, "Vertically-integrated droplet concentration");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CDNUMC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CDNUMC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDHGH", MPI_FLOAT, 2,
+                                  dimids, &CLDHGH);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDHGH, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDHGH, "long_name", 32, "Vertically-integrated high cloud");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDHGH, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CLDHGH;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDICE", MPI_FLOAT, 3,
+                                  dimids, &CLDICE);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, CLDICE, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDICE, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDICE, "mixing_ratio", 3, "wet");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDICE, "long_name", 34, "Grid box averaged cloud ice amount");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDICE, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CLDICE;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDLIQ", MPI_FLOAT, 3,
+                                  dimids, &CLDLIQ);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, CLDLIQ, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDLIQ, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDLIQ, "mixing_ratio", 3, "wet");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDLIQ, "long_name", 37, "Grid box averaged cloud liquid amount");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDLIQ, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CLDLIQ;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDLOW", MPI_FLOAT, 2,
+                                  dimids, &CLDLOW);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDLOW, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDLOW, "long_name", 31, "Vertically-integrated low cloud");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDLOW, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CLDLOW;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDMED", MPI_FLOAT, 2,
+                                  dimids, &CLDMED);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDMED, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDMED, "long_name", 37, "Vertically-integrated mid-level cloud");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDMED, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CLDMED;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDTOT", MPI_FLOAT, 2,
+                                  dimids, &CLDTOT);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDTOT, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDTOT, "long_name", 33, "Vertically-integrated total cloud");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDTOT, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CLDTOT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLOUD", MPI_FLOAT, 3,
+                                  dimids, &CLOUD);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, CLOUD, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLOUD, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLOUD, "long_name", 14, "Cloud fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLOUD, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CLOUD;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLOUDFRAC_CLUBB",
+                                  MPI_FLOAT, 3, dimids, &CLOUDFRAC_CLUBB);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, CLOUDFRAC_CLUBB, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLOUDFRAC_CLUBB, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLOUDFRAC_CLUBB, "long_name", 14, "Cloud Fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLOUDFRAC_CLUBB, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CLOUDFRAC_CLUBB;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CONCLD", MPI_FLOAT, 3,
+                                  dimids, &CONCLD);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, CONCLD, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CONCLD, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CONCLD, "long_name", 22, "Convective cloud cover");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CONCLD, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = CONCLD;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DCQ", MPI_FLOAT, 3,
+                                  dimids, &DCQ);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, DCQ, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DCQ, "units", 7, "kg/kg/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DCQ, "long_name", 33, "Q tendency due to moist processes");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DCQ, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DCQ;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_DMS", MPI_FLOAT, 2,
+                                  dimids, &DF_DMS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_DMS, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_DMS, "long_name", 19, "dry deposition flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_DMS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DF_DMS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_H2O2", MPI_FLOAT, 2,
+                                  dimids, &DF_H2O2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_H2O2, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_H2O2, "long_name", 19, "dry deposition flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_H2O2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DF_H2O2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_H2SO4", MPI_FLOAT,
+                                  2, dimids, &DF_H2SO4);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_H2SO4, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_H2SO4, "long_name", 19, "dry deposition flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_H2SO4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DF_H2SO4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_O3", MPI_FLOAT, 2,
+                                  dimids, &DF_O3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_O3, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_O3, "long_name", 19, "dry deposition flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_O3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DF_O3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_SO2", MPI_FLOAT, 2,
+                                  dimids, &DF_SO2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_SO2, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_SO2, "long_name", 19, "dry deposition flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_SO2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DF_SO2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_SOAG", MPI_FLOAT, 2,
+                                  dimids, &DF_SOAG);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_SOAG, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_SOAG, "long_name", 19, "dry deposition flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DF_SOAG, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DF_SOAG;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DMS_SRF", MPI_FLOAT, 2,
+                                  dimids, &DMS_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DMS_SRF, "units", 7, "mol/mol");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DMS_SRF, "long_name", 19, "DMS in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DMS_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DMS_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DP_KCLDBASE",
+                                  MPI_FLOAT, 2, dimids, &DP_KCLDBASE);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DP_KCLDBASE, "units", 1, "1");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DP_KCLDBASE, "long_name", 32, "Deep conv. cloudbase level index");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DP_KCLDBASE, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DP_KCLDBASE;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DP_MFUP_MAX",
+                                  MPI_FLOAT, 2, dimids, &DP_MFUP_MAX);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DP_MFUP_MAX, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DP_MFUP_MAX, "long_name", 39,
+                        "Deep conv. column-max updraft mass flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DP_MFUP_MAX, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DP_MFUP_MAX;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DP_WCLDBASE",
+                                  MPI_FLOAT, 2, dimids, &DP_WCLDBASE);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DP_WCLDBASE, "units", 3, "m/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, DP_WCLDBASE, "long_name", 38, "Deep conv. cloudbase vertical velocity");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DP_WCLDBASE, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DP_WCLDBASE;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DSTSFMBL", MPI_FLOAT,
+                                  2, dimids, &DSTSFMBL);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DSTSFMBL, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DSTSFMBL, "long_name", 28, "Mobilization flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DSTSFMBL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DSTSFMBL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DTCOND", MPI_FLOAT, 3,
+                                  dimids, &DTCOND);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, DTCOND, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DTCOND, "units", 3, "K/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DTCOND, "long_name", 28, "T tendency - moist processes");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DTCOND, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DTCOND;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DTENDTH", MPI_FLOAT, 2,
+                                  dimids, &DTENDTH);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DTENDTH, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DTENDTH, "long_name", 69,
+                        "Dynamic Tendency of Total (vertically integrated) moist static energy");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DTENDTH, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DTENDTH;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DTENDTQ", MPI_FLOAT, 2,
+                                  dimids, &DTENDTQ);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DTENDTQ, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DTENDTQ, "long_name", 67,
+                        "Dynamic Tendency of Total (vertically integrated) specific humidity");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, DTENDTQ, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = DTENDTQ;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "EXTINCT", MPI_FLOAT, 3,
+                                  dimids, &EXTINCT);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, EXTINCT, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, EXTINCT, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, EXTINCT, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, EXTINCT, "units", 2, "/m");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, EXTINCT, "long_name", 18, "Aerosol extinction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, EXTINCT, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = EXTINCT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FICE", MPI_FLOAT, 3,
+                                  dimids, &FICE);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, FICE, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FICE, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FICE, "long_name", 35, "Fractional ice content within cloud");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FICE, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FICE;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLDS", MPI_FLOAT, 2,
+                                  dimids, &FLDS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLDS, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLDS, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLDS, "long_name", 36, "Downwelling longwave flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLDS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FLDS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLNS", MPI_FLOAT, 2,
+                                  dimids, &FLNS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNS, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNS, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNS, "long_name", 28, "Net longwave flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FLNS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLNSC", MPI_FLOAT, 2,
+                                  dimids, &FLNSC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNSC, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNSC, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNSC, "long_name", 37, "Clearsky net longwave flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNSC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FLNSC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLNT", MPI_FLOAT, 2,
+                                  dimids, &FLNT);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNT, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNT, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNT, "long_name", 33, "Net longwave flux at top of model");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNT, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FLNT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLNTC", MPI_FLOAT, 2,
+                                  dimids, &FLNTC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNTC, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNTC, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNTC, "long_name", 42, "Clearsky net longwave flux at top of model");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNTC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FLNTC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLUT", MPI_FLOAT, 2,
+                                  dimids, &FLUT);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLUT, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLUT, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLUT, "long_name", 39, "Upwelling longwave flux at top of model");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLUT, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FLUT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLUTC", MPI_FLOAT, 2,
+                                  dimids, &FLUTC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLUTC, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLUTC, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLUTC, "long_name", 48,
+                        "Clearsky upwelling longwave flux at top of model");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLUTC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FLUTC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FREQI", MPI_FLOAT, 3,
+                                  dimids, &FREQI);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, FREQI, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQI, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQI, "long_name", 28, "Fractional occurrence of ice");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQI, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FREQI;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FREQL", MPI_FLOAT, 3,
+                                  dimids, &FREQL);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, FREQL, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQL, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQL, "long_name", 31, "Fractional occurrence of liquid");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FREQL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FREQR", MPI_FLOAT, 3,
+                                  dimids, &FREQR);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, FREQR, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQR, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQR, "long_name", 29, "Fractional occurrence of rain");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQR, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FREQR;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FREQS", MPI_FLOAT, 3,
+                                  dimids, &FREQS);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, FREQS, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQS, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQS, "long_name", 29, "Fractional occurrence of snow");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FREQS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FREQS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSDS", MPI_FLOAT, 2,
+                                  dimids, &FSDS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSDS, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSDS, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSDS, "long_name", 33, "Downwelling solar flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSDS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FSDS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSDSC", MPI_FLOAT, 2,
+                                  dimids, &FSDSC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSDSC, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSDSC, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSDSC, "long_name", 42, "Clearsky downwelling solar flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSDSC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FSDSC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNS", MPI_FLOAT, 2,
+                                  dimids, &FSNS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNS, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNS, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNS, "long_name", 25, "Net solar flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FSNS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNSC", MPI_FLOAT, 2,
+                                  dimids, &FSNSC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNSC, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNSC, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNSC, "long_name", 34, "Clearsky net solar flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNSC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FSNSC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNT", MPI_FLOAT, 2,
+                                  dimids, &FSNT);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNT, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNT, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNT, "long_name", 30, "Net solar flux at top of model");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNT, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FSNT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNTC", MPI_FLOAT, 2,
+                                  dimids, &FSNTC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTC, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTC, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTC, "long_name", 39, "Clearsky net solar flux at top of model");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FSNTC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNTOA", MPI_FLOAT, 2,
+                                  dimids, &FSNTOA);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTOA, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTOA, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTOA, "long_name", 35, "Net solar flux at top of atmosphere");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTOA, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FSNTOA;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNTOAC", MPI_FLOAT, 2,
+                                  dimids, &FSNTOAC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTOAC, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTOAC, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTOAC, "long_name", 44,
+                        "Clearsky net solar flux at top of atmosphere");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSNTOAC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FSNTOAC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSUTOA", MPI_FLOAT, 2,
+                                  dimids, &FSUTOA);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSUTOA, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSUTOA, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSUTOA, "long_name", 41, "Upwelling solar flux at top of atmosphere");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSUTOA, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FSUTOA;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSUTOAC", MPI_FLOAT, 2,
+                                  dimids, &FSUTOAC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSUTOAC, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSUTOAC, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSUTOAC, "long_name", 50,
+                        "Clearsky upwelling solar flux at top of atmosphere");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FSUTOAC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = FSUTOAC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "F_eff", MPI_FLOAT, 2,
+                                  dimids, &F_eff);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, F_eff, "units", 1, "1");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, F_eff, "long_name", 52,
+                        "Effective enrichment factor of marine organic matter");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, F_eff, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = F_eff;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "H2O2_SRF", MPI_FLOAT,
+                                  2, dimids, &H2O2_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, H2O2_SRF, "units", 7, "mol/mol");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, H2O2_SRF, "long_name", 20, "H2O2 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, H2O2_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = H2O2_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "H2SO4_SRF", MPI_FLOAT,
+                                  2, dimids, &H2SO4_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, H2SO4_SRF, "units", 7, "mol/mol");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, H2SO4_SRF, "long_name", 21, "H2SO4 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, H2SO4_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = H2SO4_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "H2SO4_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &H2SO4_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, H2SO4_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, H2SO4_sfgaex1, "long_name", 50,
+                        "H2SO4 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, H2SO4_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = H2SO4_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ICEFRAC", MPI_FLOAT, 2,
+                                  dimids, &ICEFRAC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ICEFRAC, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ICEFRAC, "long_name", 39, "Fraction of sfc area covered by sea-ice");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ICEFRAC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ICEFRAC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ICIMR", MPI_FLOAT, 3,
+                                  dimids, &ICIMR);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, ICIMR, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ICIMR, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ICIMR, "long_name", 36, "Prognostic in-cloud ice mixing ratio");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ICIMR, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ICIMR;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ICWMR", MPI_FLOAT, 3,
+                                  dimids, &ICWMR);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, ICWMR, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ICWMR, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ICWMR, "long_name", 38, "Prognostic in-cloud water mixing ratio");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ICWMR, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ICWMR;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "IWC", MPI_FLOAT, 3,
+                                  dimids, &IWC);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, IWC, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, IWC, "units", 5, "kg/m3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, IWC, "long_name", 34, "Grid box average ice water content");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, IWC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = IWC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LANDFRAC", MPI_FLOAT,
+                                  2, dimids, &LANDFRAC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LANDFRAC, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LANDFRAC, "long_name", 36, "Fraction of sfc area covered by land");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LANDFRAC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LANDFRAC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LHFLX", MPI_FLOAT, 2,
+                                  dimids, &LHFLX);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LHFLX, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LHFLX, "long_name", 24, "Surface latent heat flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LHFLX, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LHFLX;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_DO3", MPI_FLOAT,
+                                  3, dimids, &LINOZ_DO3);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, LINOZ_DO3, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_DO3, "units", 2, "/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_DO3, "long_name", 48,
+                        "ozone vmr tendency by linearized ozone chemistry");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_DO3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LINOZ_DO3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_DO3_PSC",
+                                  MPI_FLOAT, 3, dimids, &LINOZ_DO3_PSC);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, LINOZ_DO3_PSC, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_DO3_PSC, "units", 2, "/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_DO3_PSC, "long_name", 50,
+                        "ozone vmr loss by PSCs using Carille et al. (1990)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_DO3_PSC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LINOZ_DO3_PSC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_O3CLIM",
+                                  MPI_FLOAT, 3, dimids, &LINOZ_O3CLIM);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, LINOZ_O3CLIM, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_O3CLIM, "units", 7, "mol/mol");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_O3CLIM, "long_name", 29, "climatology of ozone in LINOZ");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_O3CLIM, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LINOZ_O3CLIM;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_O3COL",
+                                  MPI_FLOAT, 3, dimids, &LINOZ_O3COL);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, LINOZ_O3COL, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_O3COL, "units", 2, "DU");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_O3COL, "long_name", 18, "ozone column above");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_O3COL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LINOZ_O3COL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_SFCSINK",
+                                  MPI_FLOAT, 2, dimids, &LINOZ_SFCSINK);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_SFCSINK, "units", 8, "Tg/yr/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_SFCSINK, "long_name", 64,
+                        "surface o3 sink in LINOZ with an e-fold to a fixed concentration");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_SFCSINK, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LINOZ_SFCSINK;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_SSO3", MPI_FLOAT,
+                                  3, dimids, &LINOZ_SSO3);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, LINOZ_SSO3, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_SSO3, "units", 2, "kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_SSO3, "long_name", 27, "steady state ozone in LINOZ");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_SSO3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LINOZ_SSO3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_SZA", MPI_FLOAT,
+                                  2, dimids, &LINOZ_SZA);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_SZA, "units", 7, "degrees");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_SZA, "long_name", 27, "solar zenith angle in LINOZ");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LINOZ_SZA, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LINOZ_SZA;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LND_MBL", MPI_FLOAT, 2,
+                                  dimids, &LND_MBL);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LND_MBL, "units", 4, "frac");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LND_MBL, "long_name", 23, "Soil erodibility factor");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LND_MBL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LND_MBL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LWCF", MPI_FLOAT, 2,
+                                  dimids, &LWCF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LWCF, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LWCF, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LWCF, "long_name", 22, "Longwave cloud forcing");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LWCF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = LWCF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_bc", MPI_FLOAT, 3,
+                                  dimids, &Mass_bc);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, Mass_bc, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_bc, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_bc, "long_name", 64,
+                        "sum of bc mass concentration bc_a1+bc_c1+bc_a3+bc_c3+bc_a4+bc_c4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_bc, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = Mass_bc;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_dst", MPI_FLOAT,
+                                  3, dimids, &Mass_dst);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, Mass_dst, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_dst, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_dst, "long_name", 57,
+                        "sum of dst mass concentration dst_a1+dst_c1+dst_a3+dst_c3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_dst, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = Mass_dst;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_mom", MPI_FLOAT,
+                                  3, dimids, &Mass_mom);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, Mass_mom, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_mom, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (
+        ncid, Mass_mom, "long_name", 85,
+        "sum of mom mass concentration mom_a1+mom_c1+mom_a2+mom_c2+mom_a3+mom_c3+mom_a4+mom_c4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_mom, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = Mass_mom;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_ncl", MPI_FLOAT,
+                                  3, dimids, &Mass_ncl);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, Mass_ncl, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_ncl, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_ncl, "long_name", 71,
+                        "sum of ncl mass concentration ncl_a1+ncl_c1+ncl_a2+ncl_c2+ncl_a3+ncl_c3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_ncl, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = Mass_ncl;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_pom", MPI_FLOAT,
+                                  3, dimids, &Mass_pom);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, Mass_pom, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_pom, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_pom, "long_name", 71,
+                        "sum of pom mass concentration pom_a1+pom_c1+pom_a3+pom_c3+pom_a4+pom_c4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_pom, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = Mass_pom;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_so4", MPI_FLOAT,
+                                  3, dimids, &Mass_so4);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, Mass_so4, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_so4, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_so4, "long_name", 71,
+                        "sum of so4 mass concentration so4_a1+so4_c1+so4_a2+so4_c2+so4_a3+so4_c3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_so4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = Mass_so4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_soa", MPI_FLOAT,
+                                  3, dimids, &Mass_soa);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, Mass_soa, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_soa, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_soa, "long_name", 71,
+                        "sum of soa mass concentration soa_a1+soa_c1+soa_a2+soa_c2+soa_a3+soa_c3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Mass_soa, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = Mass_soa;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "NUMICE", MPI_FLOAT, 3,
+                                  dimids, &NUMICE);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, NUMICE, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMICE, "units", 4, "1/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMICE, "mixing_ratio", 3, "wet");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMICE, "long_name", 34, "Grid box averaged cloud ice number");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMICE, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = NUMICE;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "NUMLIQ", MPI_FLOAT, 3,
+                                  dimids, &NUMLIQ);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, NUMLIQ, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMLIQ, "units", 4, "1/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMLIQ, "mixing_ratio", 3, "wet");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMLIQ, "long_name", 37, "Grid box averaged cloud liquid number");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMLIQ, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = NUMLIQ;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "NUMRAI", MPI_FLOAT, 3,
+                                  dimids, &NUMRAI);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, NUMRAI, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMRAI, "units", 4, "1/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMRAI, "mixing_ratio", 3, "wet");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMRAI, "long_name", 29, "Grid box averaged rain number");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMRAI, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = NUMRAI;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "NUMSNO", MPI_FLOAT, 3,
+                                  dimids, &NUMSNO);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, NUMSNO, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMSNO, "units", 4, "1/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMSNO, "mixing_ratio", 3, "wet");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMSNO, "long_name", 29, "Grid box averaged snow number");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, NUMSNO, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = NUMSNO;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "O3", MPI_FLOAT, 3,
+                                  dimids, &O3);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, O3, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, O3, "units", 7, "mol/mol");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, O3, "mixing_ratio", 3, "dry");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, O3, "long_name", 16, "O3 concentration");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, O3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = O3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "O3_SRF", MPI_FLOAT, 2,
+                                  dimids, &O3_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, O3_SRF, "units", 7, "mol/mol");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, O3_SRF, "long_name", 18, "O3 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, O3_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = O3_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OCNFRAC", MPI_FLOAT, 2,
+                                  dimids, &OCNFRAC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OCNFRAC, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OCNFRAC, "long_name", 37, "Fraction of sfc area covered by ocean");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OCNFRAC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = OCNFRAC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OMEGA", MPI_FLOAT, 3,
+                                  dimids, &OMEGA);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, OMEGA, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGA, "units", 4, "Pa/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGA, "long_name", 28, "Vertical velocity (pressure)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGA, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = OMEGA;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OMEGA500", MPI_FLOAT,
+                                  2, dimids, &OMEGA500);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGA500, "units", 4, "Pa/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGA500, "long_name", 46,
+                        "Vertical velocity at 500 mbar pressure surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGA500, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = OMEGA500;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OMEGAT", MPI_FLOAT, 3,
+                                  dimids, &OMEGAT);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, OMEGAT, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGAT, "units", 6, "K Pa/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGAT, "long_name", 18, "Vertical heat flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGAT, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = OMEGAT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PBLH", MPI_FLOAT, 2,
+                                  dimids, &PBLH);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PBLH, "units", 1, "m");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PBLH, "long_name", 10, "PBL height");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PBLH, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = PBLH;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PHIS", MPI_FLOAT, 2,
+                                  dimids, &PHIS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PHIS, "units", 5, "m2/s2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PHIS, "long_name", 20, "Surface geopotential");
+    CHECK_ERR
+    varids[i++] = PHIS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PRECC", MPI_FLOAT, 2,
+                                  dimids, &PRECC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECC, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECC, "long_name", 41, "Convective precipitation rate (liq + ice)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = PRECC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PRECL", MPI_FLOAT, 2,
+                                  dimids, &PRECL);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECL, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECL, "long_name", 51,
+                        "Large-scale (stable) precipitation rate (liq + ice)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = PRECL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PRECSC", MPI_FLOAT, 2,
+                                  dimids, &PRECSC);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECSC, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECSC, "long_name", 39, "Convective snow rate (water equivalent)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECSC, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = PRECSC;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PRECSL", MPI_FLOAT, 2,
+                                  dimids, &PRECSL);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECSL, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECSL, "long_name", 49,
+                        "Large-scale (stable) snow rate (water equivalent)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECSL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = PRECSL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PS", MPI_FLOAT, 2,
+                                  dimids, &PS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PS, "units", 2, "Pa");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PS, "long_name", 16, "Surface pressure");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = PS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PSL", MPI_FLOAT, 2,
+                                  dimids, &PSL);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PSL, "units", 2, "Pa");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PSL, "long_name", 18, "Sea level pressure");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PSL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = PSL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Q", MPI_FLOAT, 3,
+                                  dimids, &Q);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, Q, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Q, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Q, "mixing_ratio", 3, "wet");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Q, "long_name", 17, "Specific humidity");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Q, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = Q;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "QFLX", MPI_FLOAT, 2,
+                                  dimids, &QFLX);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QFLX, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QFLX, "long_name", 18, "Surface water flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QFLX, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = QFLX;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "QREFHT", MPI_FLOAT, 2,
+                                  dimids, &QREFHT);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QREFHT, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QREFHT, "long_name", 25, "Reference height humidity");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QREFHT, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = QREFHT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "QRL", MPI_FLOAT, 3,
+                                  dimids, &QRL);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, QRL, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QRL, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QRL, "units", 3, "K/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QRL, "long_name", 21, "Longwave heating rate");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QRL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = QRL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "QRS", MPI_FLOAT, 3,
+                                  dimids, &QRS);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, QRS, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QRS, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QRS, "units", 3, "K/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QRS, "long_name", 18, "Solar heating rate");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, QRS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = QRS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "RAINQM", MPI_FLOAT, 3,
+                                  dimids, &RAINQM);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, RAINQM, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, RAINQM, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, RAINQM, "mixing_ratio", 3, "wet");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, RAINQM, "long_name", 29, "Grid box averaged rain amount");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, RAINQM, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = RAINQM;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "RAM1", MPI_FLOAT, 2,
+                                  dimids, &RAM1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, RAM1, "units", 4, "frac");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, RAM1, "long_name", 4, "RAM1");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, RAM1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = RAM1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "RELHUM", MPI_FLOAT, 3,
+                                  dimids, &RELHUM);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, RELHUM, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, RELHUM, "units", 7, "percent");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, RELHUM, "long_name", 17, "Relative humidity");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, RELHUM, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = RELHUM;
+
+    /* 
+        dimids[0] = dim_time;
+        dimids[1] = dim_ncol;
+        err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SCO", MPI_FLOAT, 2,
+                                      dimids, &SCO);
+        CHECK_ERR
+        err = PUT_ATT_TEXT (ncid, SCO, "units", 3, "DU");
+        CHECK_ERR
+        err = PUT_ATT_TEXT (ncid, SCO, "long_name", 56,
+                            "Stratospheric column ozone based on chemistry tropopause");
+        CHECK_ERR
+
+        err = PUT_ATT_TEXT (ncid, SCO, "cell_methods", 10, "time: mean");
+        CHECK_ERR
+        varids[i++] = SCO;
+    */
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFDMS", MPI_FLOAT, 2,
+                                  dimids, &SFDMS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFDMS, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFDMS, "long_name", 16, "DMS surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFDMS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFDMS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFH2O2", MPI_FLOAT, 2,
+                                  dimids, &SFH2O2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFH2O2, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFH2O2, "long_name", 17, "H2O2 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFH2O2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFH2O2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFH2SO4", MPI_FLOAT, 2,
+                                  dimids, &SFH2SO4);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFH2SO4, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFH2SO4, "long_name", 18, "H2SO4 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFH2SO4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFH2SO4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFO3", MPI_FLOAT, 2,
+                                  dimids, &SFO3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFO3, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFO3, "long_name", 15, "O3 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFO3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFO3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFSO2", MPI_FLOAT, 2,
+                                  dimids, &SFSO2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFSO2, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFSO2, "long_name", 16, "SO2 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFSO2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFSO2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFSOAG", MPI_FLOAT, 2,
+                                  dimids, &SFSOAG);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFSOAG, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFSOAG, "long_name", 17, "SOAG surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFSOAG, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFSOAG;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFbc_a1", MPI_FLOAT, 2,
+                                  dimids, &SFbc_a1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFbc_a1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFbc_a1, "long_name", 18, "bc_a1 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFbc_a1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFbc_a1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFbc_a3", MPI_FLOAT, 2,
+                                  dimids, &SFbc_a3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFbc_a3, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFbc_a3, "long_name", 18, "bc_a3 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFbc_a3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFbc_a3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFbc_a4", MPI_FLOAT, 2,
+                                  dimids, &SFbc_a4);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFbc_a4, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFbc_a4, "long_name", 18, "bc_a4 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFbc_a4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFbc_a4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFdst_a1", MPI_FLOAT,
+                                  2, dimids, &SFdst_a1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFdst_a1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFdst_a1, "long_name", 19, "dst_a1 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFdst_a1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFdst_a1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFdst_a3", MPI_FLOAT,
+                                  2, dimids, &SFdst_a3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFdst_a3, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFdst_a3, "long_name", 19, "dst_a3 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFdst_a3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFdst_a3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFmom_a1", MPI_FLOAT,
+                                  2, dimids, &SFmom_a1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a1, "long_name", 19, "mom_a1 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFmom_a1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFmom_a2", MPI_FLOAT,
+                                  2, dimids, &SFmom_a2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a2, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a2, "long_name", 19, "mom_a2 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFmom_a2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFmom_a3", MPI_FLOAT,
+                                  2, dimids, &SFmom_a3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a3, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a3, "long_name", 19, "mom_a3 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFmom_a3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFmom_a4", MPI_FLOAT,
+                                  2, dimids, &SFmom_a4);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a4, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a4, "long_name", 19, "mom_a4 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFmom_a4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFmom_a4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFncl_a1", MPI_FLOAT,
+                                  2, dimids, &SFncl_a1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFncl_a1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFncl_a1, "long_name", 19, "ncl_a1 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFncl_a1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFncl_a1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFncl_a2", MPI_FLOAT,
+                                  2, dimids, &SFncl_a2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFncl_a2, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFncl_a2, "long_name", 19, "ncl_a2 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFncl_a2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFncl_a2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFncl_a3", MPI_FLOAT,
+                                  2, dimids, &SFncl_a3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFncl_a3, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFncl_a3, "long_name", 19, "ncl_a3 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFncl_a3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFncl_a3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFnum_a1", MPI_FLOAT,
+                                  2, dimids, &SFnum_a1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a1, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a1, "long_name", 19, "num_a1 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFnum_a1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFnum_a2", MPI_FLOAT,
+                                  2, dimids, &SFnum_a2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a2, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a2, "long_name", 19, "num_a2 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFnum_a2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFnum_a3", MPI_FLOAT,
+                                  2, dimids, &SFnum_a3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a3, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a3, "long_name", 19, "num_a3 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFnum_a3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFnum_a4", MPI_FLOAT,
+                                  2, dimids, &SFnum_a4);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a4, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a4, "long_name", 19, "num_a4 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFnum_a4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFnum_a4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFpom_a1", MPI_FLOAT,
+                                  2, dimids, &SFpom_a1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFpom_a1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFpom_a1, "long_name", 19, "pom_a1 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFpom_a1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFpom_a1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFpom_a3", MPI_FLOAT,
+                                  2, dimids, &SFpom_a3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFpom_a3, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFpom_a3, "long_name", 19, "pom_a3 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFpom_a3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFpom_a3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFpom_a4", MPI_FLOAT,
+                                  2, dimids, &SFpom_a4);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFpom_a4, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFpom_a4, "long_name", 19, "pom_a4 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFpom_a4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFpom_a4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFso4_a1", MPI_FLOAT,
+                                  2, dimids, &SFso4_a1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFso4_a1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFso4_a1, "long_name", 19, "so4_a1 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFso4_a1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFso4_a1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFso4_a2", MPI_FLOAT,
+                                  2, dimids, &SFso4_a2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFso4_a2, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFso4_a2, "long_name", 19, "so4_a2 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFso4_a2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFso4_a2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFso4_a3", MPI_FLOAT,
+                                  2, dimids, &SFso4_a3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFso4_a3, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFso4_a3, "long_name", 19, "so4_a3 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFso4_a3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFso4_a3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFsoa_a1", MPI_FLOAT,
+                                  2, dimids, &SFsoa_a1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFsoa_a1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFsoa_a1, "long_name", 19, "soa_a1 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFsoa_a1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFsoa_a1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFsoa_a2", MPI_FLOAT,
+                                  2, dimids, &SFsoa_a2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFsoa_a2, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFsoa_a2, "long_name", 19, "soa_a2 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFsoa_a2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFsoa_a2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFsoa_a3", MPI_FLOAT,
+                                  2, dimids, &SFsoa_a3);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFsoa_a3, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFsoa_a3, "long_name", 19, "soa_a3 surface flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SFsoa_a3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SFsoa_a3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SHFLX", MPI_FLOAT, 2,
+                                  dimids, &SHFLX);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SHFLX, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SHFLX, "long_name", 26, "Surface sensible heat flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SHFLX, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SHFLX;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SH_KCLDBASE",
+                                  MPI_FLOAT, 2, dimids, &SH_KCLDBASE);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SH_KCLDBASE, "units", 1, "1");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SH_KCLDBASE, "long_name", 35, "Shallow conv. cloudbase level index");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SH_KCLDBASE, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SH_KCLDBASE;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SH_MFUP_MAX",
+                                  MPI_FLOAT, 2, dimids, &SH_MFUP_MAX);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SH_MFUP_MAX, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SH_MFUP_MAX, "long_name", 42,
+                        "Shallow conv. column-max updraft mass flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SH_MFUP_MAX, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SH_MFUP_MAX;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SH_WCLDBASE",
+                                  MPI_FLOAT, 2, dimids, &SH_WCLDBASE);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SH_WCLDBASE, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SH_WCLDBASE, "long_name", 41,
+                        "Shallow conv. cloudbase vertical velocity");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SH_WCLDBASE, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SH_WCLDBASE;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SNOWHICE", MPI_FLOAT,
+                                  2, dimids, &SNOWHICE);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SNOWHICE, "units", 1, "m");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SNOWHICE, "long_name", 19, "Snow depth over ice");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SNOWHICE, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SNOWHICE;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SNOWHLND", MPI_FLOAT,
+                                  2, dimids, &SNOWHLND);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SNOWHLND, "units", 1, "m");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SNOWHLND, "long_name", 27, "Water equivalent snow depth");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SNOWHLND, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SNOWHLND;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SNOWQM", MPI_FLOAT, 3,
+                                  dimids, &SNOWQM);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, SNOWQM, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SNOWQM, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SNOWQM, "mixing_ratio", 3, "wet");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SNOWQM, "long_name", 29, "Grid box averaged snow amount");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SNOWQM, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SNOWQM;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SO2", MPI_FLOAT, 3,
+                                  dimids, &SO2);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, SO2, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SO2, "units", 7, "mol/mol");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SO2, "mixing_ratio", 3, "dry");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SO2, "long_name", 17, "SO2 concentration");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SO2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SO2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SO2_CLXF", MPI_FLOAT,
+                                  2, dimids, &SO2_CLXF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SO2_CLXF, "units", 11, "molec/cm2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SO2_CLXF, "long_name", 47,
+                        "vertically intergrated external forcing for SO2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SO2_CLXF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SO2_CLXF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SO2_SRF", MPI_FLOAT, 2,
+                                  dimids, &SO2_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SO2_SRF, "units", 7, "mol/mol");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SO2_SRF, "long_name", 19, "SO2 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SO2_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SO2_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SOAG_CLXF", MPI_FLOAT,
+                                  2, dimids, &SOAG_CLXF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOAG_CLXF, "units", 11, "molec/cm2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOAG_CLXF, "long_name", 48,
+                        "vertically intergrated external forcing for SOAG");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOAG_CLXF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SOAG_CLXF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SOAG_SRF", MPI_FLOAT,
+                                  2, dimids, &SOAG_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOAG_SRF, "units", 7, "mol/mol");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOAG_SRF, "long_name", 20, "SOAG in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOAG_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SOAG_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SOAG_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &SOAG_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOAG_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOAG_sfgaex1, "long_name", 49,
+                        "SOAG gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOAG_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SOAG_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SOLIN", MPI_FLOAT, 2,
+                                  dimids, &SOLIN);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOLIN, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOLIN, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOLIN, "long_name", 16, "Solar insolation");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SOLIN, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SOLIN;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SSAVIS", MPI_FLOAT, 2,
+                                  dimids, &SSAVIS);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, SSAVIS, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, SSAVIS, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SSAVIS, "long_name", 29, "Aerosol singel-scatter albedo");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SSAVIS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SSAVIS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SSTSFMBL", MPI_FLOAT,
+                                  2, dimids, &SSTSFMBL);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SSTSFMBL, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SSTSFMBL, "long_name", 28, "Mobilization flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SSTSFMBL, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SSTSFMBL;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SSTSFMBL_OM",
+                                  MPI_FLOAT, 2, dimids, &SSTSFMBL_OM);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SSTSFMBL_OM, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SSTSFMBL_OM, "long_name", 53,
+                        "Mobilization flux of marine organic matter at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SSTSFMBL_OM, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SSTSFMBL_OM;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SWCF", MPI_FLOAT, 2,
+                                  dimids, &SWCF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SWCF, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SWCF, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SWCF, "long_name", 23, "Shortwave cloud forcing");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SWCF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = SWCF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "T", MPI_FLOAT, 3,
+                                  dimids, &T);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, T, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, T, "units", 1, "K");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, T, "long_name", 11, "Temperature");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, T, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = T;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TAUGWX", MPI_FLOAT, 2,
+                                  dimids, &TAUGWX);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUGWX, "units", 4, "N/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUGWX, "long_name", 33, "Zonal gravity wave surface stress");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUGWX, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TAUGWX;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TAUGWY", MPI_FLOAT, 2,
+                                  dimids, &TAUGWY);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUGWY, "units", 4, "N/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUGWY, "long_name", 38, "Meridional gravity wave surface stress");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUGWY, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TAUGWY;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TAUX", MPI_FLOAT, 2,
+                                  dimids, &TAUX);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUX, "units", 4, "N/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUX, "long_name", 20, "Zonal surface stress");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUX, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TAUX;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TAUY", MPI_FLOAT, 2,
+                                  dimids, &TAUY);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUY, "units", 4, "N/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUY, "long_name", 25, "Meridional surface stress");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TAUY, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TAUY;
+
+    /*
+        dimids[0] = dim_time;
+        dimids[1] = dim_ncol;
+        err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TCO", MPI_FLOAT, 2,
+                                      dimids, &TCO);
+        CHECK_ERR
+        err = PUT_ATT_TEXT (ncid, TCO, "units", 2, "DU");
+        CHECK_ERR
+        err = PUT_ATT_TEXT (ncid, TCO, "long_name", 55,
+                            "Tropospheric column ozone based on chemistry tropopause");
+        CHECK_ERR
+        err = PUT_ATT_TEXT (ncid, TCO, "cell_methods", 10, "time: mean");
+        CHECK_ERR
+        varids[i++] = TCO;
+    */
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TGCLDCWP", MPI_FLOAT,
+                                  2, dimids, &TGCLDCWP);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TGCLDCWP, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TGCLDCWP, "long_name", 48,
+                        "Total grid-box cloud water path (liquid and ice)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TGCLDCWP, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TGCLDCWP;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TGCLDIWP", MPI_FLOAT,
+                                  2, dimids, &TGCLDIWP);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TGCLDIWP, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TGCLDIWP, "long_name", 35, "Total grid-box cloud ice water path");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TGCLDIWP, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TGCLDIWP;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TGCLDLWP", MPI_FLOAT,
+                                  2, dimids, &TGCLDLWP);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TGCLDLWP, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TGCLDLWP, "long_name", 38, "Total grid-box cloud liquid water path");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TGCLDLWP, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TGCLDLWP;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TH7001000", MPI_FLOAT,
+                                  2, dimids, &TH7001000);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TH7001000, "units", 1, "K");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TH7001000, "long_name", 33, "Theta difference 700 mb - 1000 mb");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TH7001000, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TH7001000;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TMQ", MPI_FLOAT, 2,
+                                  dimids, &TMQ);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TMQ, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TMQ, "long_name", 48,
+                        "Total (vertically integrated) precipitable water");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TMQ, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TMQ;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TREFHT", MPI_FLOAT, 2,
+                                  dimids, &TREFHT);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TREFHT, "units", 1, "K");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TREFHT, "long_name", 28, "Reference height temperature");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TREFHT, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TREFHT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TROP_P", MPI_FLOAT, 2,
+                                  dimids, &TROP_P);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, TROP_P, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, TROP_P, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TROP_P, "units", 2, "Pa");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TROP_P, "long_name", 19, "Tropopause Pressure");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TROP_P, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TROP_P;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TROP_T", MPI_FLOAT, 2,
+                                  dimids, &TROP_T);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, TROP_T, _FillValue, MPI_FLOAT, 1, &fillv);
+    CHECK_ERR
+    err = PUT_ATT_FLOAT (ncid, TROP_T, "missing_value", MPI_FLOAT, 1, &missv);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TROP_T, "units", 1, "K");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TROP_T, "long_name", 22, "Tropopause Temperature");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TROP_T, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TROP_T;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TS", MPI_FLOAT, 2,
+                                  dimids, &TS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TS, "units", 1, "K");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TS, "long_name", 31, "Surface temperature (radiative)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TS, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TSMN", MPI_FLOAT, 2,
+                                  dimids, &TSMN);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TSMN, "units", 1, "K");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TSMN, "long_name", 46,
+                        "Minimum surface temperature over output period");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TSMN, "cell_methods", 13, "time: minimum");
+    CHECK_ERR
+    varids[i++] = TSMN;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TSMX", MPI_FLOAT, 2,
+                                  dimids, &TSMX);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TSMX, "units", 1, "K");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TSMX, "long_name", 46,
+                        "Maximum surface temperature over output period");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TSMX, "cell_methods", 13, "time: maximum");
+    CHECK_ERR
+    varids[i++] = TSMX;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TUH", MPI_FLOAT, 2,
+                                  dimids, &TUH);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TUH, "units", 3, "W/m");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TUH, "long_name", 44, "Total (vertically integrated) zonal MSE flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TUH, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TUH;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TUQ", MPI_FLOAT, 2,
+                                  dimids, &TUQ);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TUQ, "units", 6, "kg/m/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, TUQ, "long_name", 46, "Total (vertically integrated) zonal water flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TUQ, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TUQ;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TVH", MPI_FLOAT, 2,
+                                  dimids, &TVH);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TVH, "units", 3, "W/m");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TVH, "long_name", 49,
+                        "Total (vertically integrated) meridional MSE flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TVH, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TVH;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TVQ", MPI_FLOAT, 2,
+                                  dimids, &TVQ);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TVQ, "units", 6, "kg/m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TVQ, "long_name", 51,
+                        "Total (vertically integrated) meridional water flux");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TVQ, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = TVQ;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "U", MPI_FLOAT, 3,
+                                  dimids, &U);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, U, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U, "long_name", 10, "Zonal wind");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = U;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "U10", MPI_FLOAT, 2,
+                                  dimids, &U10);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U10, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U10, "long_name", 14, "10m wind speed");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U10, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = U10;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "UU", MPI_FLOAT, 3,
+                                  dimids, &UU);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, UU, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, UU, "units", 5, "m2/s2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, UU, "long_name", 22, "Zonal velocity squared");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, UU, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = UU;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "V", MPI_FLOAT, 3,
+                                  dimids, &V);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, V, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, V, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, V, "long_name", 15, "Meridional wind");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, V, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = V;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "VQ", MPI_FLOAT, 3,
+                                  dimids, &VQ);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, VQ, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VQ, "units", 8, "m/skg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VQ, "long_name", 26, "Meridional water transport");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VQ, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = VQ;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "VT", MPI_FLOAT, 3,
+                                  dimids, &VT);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, VT, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VT, "units", 5, "K m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VT, "long_name", 25, "Meridional heat transport");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VT, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = VT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "VU", MPI_FLOAT, 3,
+                                  dimids, &VU);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, VU, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VU, "units", 5, "m2/s2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VU, "long_name", 33, "Meridional flux of zonal momentum");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VU, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = VU;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "VV", MPI_FLOAT, 3,
+                                  dimids, &VV);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, VV, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VV, "units", 5, "m2/s2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VV, "long_name", 27, "Meridional velocity squared");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VV, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = VV;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "WD_H2O2", MPI_FLOAT, 2,
+                                  dimids, &WD_H2O2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WD_H2O2, "units", 4, "kg/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WD_H2O2, "long_name", 31, "H2O2             wet deposition");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WD_H2O2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = WD_H2O2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "WD_H2SO4", MPI_FLOAT,
+                                  2, dimids, &WD_H2SO4);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WD_H2SO4, "units", 4, "kg/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WD_H2SO4, "long_name", 31, "H2SO4            wet deposition");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WD_H2SO4, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = WD_H2SO4;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "WD_SO2", MPI_FLOAT, 2,
+                                  dimids, &WD_SO2);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WD_SO2, "units", 4, "kg/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WD_SO2, "long_name", 31, "SO2              wet deposition");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WD_SO2, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = WD_SO2;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "WSUB", MPI_FLOAT, 3,
+                                  dimids, &WSUB);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, WSUB, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WSUB, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WSUB, "long_name", 37, "Diagnostic sub-grid vertical velocity");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, WSUB, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = WSUB;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Z3", MPI_FLOAT, 3,
+                                  dimids, &Z3);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, Z3, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Z3, "units", 1, "m");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Z3, "long_name", 37, "Geopotential Height (above sea level)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Z3, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = Z3;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "aero_water", MPI_FLOAT,
+                                  3, dimids, &aero_water);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, aero_water, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, aero_water, "units", 1, "m");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, aero_water, "long_name", 70,
+                        "sum of aerosol water of interstitial modes wat_a1+wat_a2+wat_a3+wat_a4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, aero_water, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = aero_water;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "airFV", MPI_FLOAT, 2,
+                                  dimids, &airFV);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, airFV, "units", 4, "frac");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, airFV, "long_name", 2, "FV");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, airFV, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = airFV;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a1DDF", MPI_FLOAT,
+                                  2, dimids, &bc_a1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1DDF, "long_name", 49,
+                        "bc_a1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a1SFWET", MPI_FLOAT,
+                                  2, dimids, &bc_a1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a1_SRF", MPI_FLOAT,
+                                  2, dimids, &bc_a1_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1_SRF, "long_name", 21, "bc_a1 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a1_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a1_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &bc_a1_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1_sfgaex1, "long_name", 50,
+                        "bc_a1 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a1_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a1_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a3DDF", MPI_FLOAT,
+                                  2, dimids, &bc_a3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a3DDF, "long_name", 49,
+                        "bc_a3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a3SFWET", MPI_FLOAT,
+                                  2, dimids, &bc_a3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a3SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a3_SRF", MPI_FLOAT,
+                                  2, dimids, &bc_a3_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a3_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a3_SRF, "long_name", 21, "bc_a3 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a3_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a3_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a4DDF", MPI_FLOAT,
+                                  2, dimids, &bc_a4DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4DDF, "long_name", 49,
+                        "bc_a4 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a4DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a4SFWET", MPI_FLOAT,
+                                  2, dimids, &bc_a4SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a4SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a4_CLXF", MPI_FLOAT,
+                                  2, dimids, &bc_a4_CLXF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4_CLXF, "units", 11, "molec/cm2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4_CLXF, "long_name", 49,
+                        "vertically intergrated external forcing for bc_a4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4_CLXF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a4_CLXF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a4_SRF", MPI_FLOAT,
+                                  2, dimids, &bc_a4_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4_SRF, "long_name", 21, "bc_a4 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a4_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a4_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &bc_a4_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4_sfgaex1, "long_name", 50,
+                        "bc_a4 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_a4_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_a4_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c1DDF", MPI_FLOAT,
+                                  2, dimids, &bc_c1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c1DDF, "long_name", 49,
+                        "bc_c1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_c1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c1SFWET", MPI_FLOAT,
+                                  2, dimids, &bc_c1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c1SFWET, "long_name", 36, "bc_c1 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_c1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c3DDF", MPI_FLOAT,
+                                  2, dimids, &bc_c3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c3DDF, "long_name", 49,
+                        "bc_c3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_c3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c3SFWET", MPI_FLOAT,
+                                  2, dimids, &bc_c3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c3SFWET, "long_name", 36, "bc_c3 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_c3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c4DDF", MPI_FLOAT,
+                                  2, dimids, &bc_c4DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c4DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c4DDF, "long_name", 49,
+                        "bc_c4 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c4DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_c4DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c4SFWET", MPI_FLOAT,
+                                  2, dimids, &bc_c4SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c4SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c4SFWET, "long_name", 36, "bc_c4 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, bc_c4SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = bc_c4SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "chla", MPI_FLOAT, 2,
+                                  dimids, &chla);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, chla, "units", 6, "mg L-1");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, chla, "long_name", 22, "ocean input data: chla");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, chla, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = chla;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a1DDF", MPI_FLOAT,
+                                  2, dimids, &dst_a1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1DDF, "long_name", 50,
+                        "dst_a1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_a1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a1SF", MPI_FLOAT,
+                                  2, dimids, &dst_a1SF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1SF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1SF, "long_name", 28, "dst_a1 dust surface emission");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1SF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_a1SF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a1SFWET",
+                                  MPI_FLOAT, 2, dimids, &dst_a1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_a1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a1_SRF", MPI_FLOAT,
+                                  2, dimids, &dst_a1_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1_SRF, "long_name", 22, "dst_a1 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a1_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_a1_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a3DDF", MPI_FLOAT,
+                                  2, dimids, &dst_a3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3DDF, "long_name", 50,
+                        "dst_a3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_a3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a3SF", MPI_FLOAT,
+                                  2, dimids, &dst_a3SF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3SF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3SF, "long_name", 28, "dst_a3 dust surface emission");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3SF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_a3SF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a3SFWET",
+                                  MPI_FLOAT, 2, dimids, &dst_a3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_a3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a3_SRF", MPI_FLOAT,
+                                  2, dimids, &dst_a3_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3_SRF, "long_name", 22, "dst_a3 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_a3_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_a3_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_c1DDF", MPI_FLOAT,
+                                  2, dimids, &dst_c1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_c1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_c1DDF, "long_name", 50,
+                        "dst_c1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_c1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_c1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_c1SFWET",
+                                  MPI_FLOAT, 2, dimids, &dst_c1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_c1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, dst_c1SFWET, "long_name", 37, "dst_c1 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_c1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_c1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_c3DDF", MPI_FLOAT,
+                                  2, dimids, &dst_c3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_c3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_c3DDF, "long_name", 50,
+                        "dst_c3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_c3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_c3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_c3SFWET",
+                                  MPI_FLOAT, 2, dimids, &dst_c3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_c3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, dst_c3SFWET, "long_name", 37, "dst_c3 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, dst_c3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = dst_c3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hstobie_linoz",
+                                  MPI_FLOAT, 3, dimids, &hstobie_linoz);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, hstobie_linoz, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, hstobie_linoz, "units", 22, "fraction of model time");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, hstobie_linoz, "long_name", 27, "Lowest possible Linoz level");
+    CHECK_ERR
+    varids[i++] = hstobie_linoz;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mlip", MPI_FLOAT, 2,
+                                  dimids, &mlip);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mlip, "units", 4, "uM C");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mlip, "long_name", 22, "ocean input data: mlip");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mlip, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mlip;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a1DDF", MPI_FLOAT,
+                                  2, dimids, &mom_a1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1DDF, "long_name", 50,
+                        "mom_a1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a1SF", MPI_FLOAT,
+                                  2, dimids, &mom_a1SF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1SF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1SF, "long_name", 31, "mom_a1 seasalt surface emission");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1SF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a1SF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a1SFWET",
+                                  MPI_FLOAT, 2, dimids, &mom_a1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a1_SRF", MPI_FLOAT,
+                                  2, dimids, &mom_a1_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1_SRF, "long_name", 22, "mom_a1 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a1_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a1_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &mom_a1_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1_sfgaex1, "long_name", 51,
+                        "mom_a1 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a1_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a1_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a2DDF", MPI_FLOAT,
+                                  2, dimids, &mom_a2DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2DDF, "long_name", 50,
+                        "mom_a2 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a2DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a2SF", MPI_FLOAT,
+                                  2, dimids, &mom_a2SF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2SF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2SF, "long_name", 31, "mom_a2 seasalt surface emission");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2SF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a2SF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a2SFWET",
+                                  MPI_FLOAT, 2, dimids, &mom_a2SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a2SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a2_SRF", MPI_FLOAT,
+                                  2, dimids, &mom_a2_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2_SRF, "long_name", 22, "mom_a2 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a2_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a2_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a3DDF", MPI_FLOAT,
+                                  2, dimids, &mom_a3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a3DDF, "long_name", 50,
+                        "mom_a3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a3SFWET",
+                                  MPI_FLOAT, 2, dimids, &mom_a3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a3SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a3_SRF", MPI_FLOAT,
+                                  2, dimids, &mom_a3_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a3_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a3_SRF, "long_name", 22, "mom_a3 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a3_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a3_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a4DDF", MPI_FLOAT,
+                                  2, dimids, &mom_a4DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4DDF, "long_name", 50,
+                        "mom_a4 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a4DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a4SF", MPI_FLOAT,
+                                  2, dimids, &mom_a4SF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4SF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4SF, "long_name", 31, "mom_a4 seasalt surface emission");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4SF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a4SF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a4SFWET",
+                                  MPI_FLOAT, 2, dimids, &mom_a4SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a4SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a4_SRF", MPI_FLOAT,
+                                  2, dimids, &mom_a4_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4_SRF, "long_name", 22, "mom_a4 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a4_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a4_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &mom_a4_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4_sfgaex1, "long_name", 51,
+                        "mom_a4 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_a4_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_a4_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c1DDF", MPI_FLOAT,
+                                  2, dimids, &mom_c1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c1DDF, "long_name", 50,
+                        "mom_c1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_c1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c1SFWET",
+                                  MPI_FLOAT, 2, dimids, &mom_c1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, mom_c1SFWET, "long_name", 37, "mom_c1 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_c1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c2DDF", MPI_FLOAT,
+                                  2, dimids, &mom_c2DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c2DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c2DDF, "long_name", 50,
+                        "mom_c2 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c2DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_c2DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c2SFWET",
+                                  MPI_FLOAT, 2, dimids, &mom_c2SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c2SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, mom_c2SFWET, "long_name", 37, "mom_c2 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c2SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_c2SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c3DDF", MPI_FLOAT,
+                                  2, dimids, &mom_c3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c3DDF, "long_name", 50,
+                        "mom_c3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_c3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c3SFWET",
+                                  MPI_FLOAT, 2, dimids, &mom_c3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, mom_c3SFWET, "long_name", 37, "mom_c3 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_c3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c4DDF", MPI_FLOAT,
+                                  2, dimids, &mom_c4DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c4DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c4DDF, "long_name", 50,
+                        "mom_c4 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c4DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_c4DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c4SFWET",
+                                  MPI_FLOAT, 2, dimids, &mom_c4SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c4SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, mom_c4SFWET, "long_name", 37, "mom_c4 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mom_c4SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mom_c4SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mpoly", MPI_FLOAT, 2,
+                                  dimids, &mpoly);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mpoly, "units", 4, "uM C");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mpoly, "long_name", 23, "ocean input data: mpoly");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mpoly, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mpoly;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mprot", MPI_FLOAT, 2,
+                                  dimids, &mprot);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mprot, "units", 4, "uM C");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mprot, "long_name", 23, "ocean input data: mprot");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mprot, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = mprot;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a1DDF", MPI_FLOAT,
+                                  2, dimids, &ncl_a1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1DDF, "long_name", 50,
+                        "ncl_a1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a1SF", MPI_FLOAT,
+                                  2, dimids, &ncl_a1SF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1SF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1SF, "long_name", 31, "ncl_a1 seasalt surface emission");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1SF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a1SF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a1SFWET",
+                                  MPI_FLOAT, 2, dimids, &ncl_a1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a1_SRF", MPI_FLOAT,
+                                  2, dimids, &ncl_a1_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1_SRF, "long_name", 22, "ncl_a1 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a1_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a1_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a2DDF", MPI_FLOAT,
+                                  2, dimids, &ncl_a2DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2DDF, "long_name", 50,
+                        "ncl_a2 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a2DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a2SF", MPI_FLOAT,
+                                  2, dimids, &ncl_a2SF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2SF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2SF, "long_name", 31, "ncl_a2 seasalt surface emission");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2SF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a2SF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a2SFWET",
+                                  MPI_FLOAT, 2, dimids, &ncl_a2SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a2SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a2_SRF", MPI_FLOAT,
+                                  2, dimids, &ncl_a2_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2_SRF, "long_name", 22, "ncl_a2 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a2_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a2_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a3DDF", MPI_FLOAT,
+                                  2, dimids, &ncl_a3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3DDF, "long_name", 50,
+                        "ncl_a3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a3SF", MPI_FLOAT,
+                                  2, dimids, &ncl_a3SF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3SF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3SF, "long_name", 31, "ncl_a3 seasalt surface emission");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3SF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a3SF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a3SFWET",
+                                  MPI_FLOAT, 2, dimids, &ncl_a3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a3_SRF", MPI_FLOAT,
+                                  2, dimids, &ncl_a3_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3_SRF, "long_name", 22, "ncl_a3 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_a3_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_a3_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c1DDF", MPI_FLOAT,
+                                  2, dimids, &ncl_c1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c1DDF, "long_name", 50,
+                        "ncl_c1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_c1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c1SFWET",
+                                  MPI_FLOAT, 2, dimids, &ncl_c1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, ncl_c1SFWET, "long_name", 37, "ncl_c1 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_c1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c2DDF", MPI_FLOAT,
+                                  2, dimids, &ncl_c2DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c2DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c2DDF, "long_name", 50,
+                        "ncl_c2 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c2DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_c2DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c2SFWET",
+                                  MPI_FLOAT, 2, dimids, &ncl_c2SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c2SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, ncl_c2SFWET, "long_name", 37, "ncl_c2 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c2SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_c2SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c3DDF", MPI_FLOAT,
+                                  2, dimids, &ncl_c3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c3DDF, "long_name", 50,
+                        "ncl_c3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_c3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c3SFWET",
+                                  MPI_FLOAT, 2, dimids, &ncl_c3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, ncl_c3SFWET, "long_name", 37, "ncl_c3 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ncl_c3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = ncl_c3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1DDF", MPI_FLOAT,
+                                  2, dimids, &num_a1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1DDF, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1DDF, "long_name", 50,
+                        "num_a1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1SF", MPI_FLOAT,
+                                  2, dimids, &num_a1SF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1SF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1SF, "long_name", 28, "num_a1 dust surface emission");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1SF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a1SF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1SFWET",
+                                  MPI_FLOAT, 2, dimids, &num_a1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1SFWET, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1_CLXF",
+                                  MPI_FLOAT, 2, dimids, &num_a1_CLXF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1_CLXF, "units", 11, "molec/cm2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1_CLXF, "long_name", 50,
+                        "vertically intergrated external forcing for num_a1");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1_CLXF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a1_CLXF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1_SRF", MPI_FLOAT,
+                                  2, dimids, &num_a1_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1_SRF, "units", 5, " 1/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1_SRF, "long_name", 22, "num_a1 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a1_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &num_a1_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1_sfgaex1, "long_name", 51,
+                        "num_a1 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a1_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a1_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a2DDF", MPI_FLOAT,
+                                  2, dimids, &num_a2DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2DDF, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2DDF, "long_name", 50,
+                        "num_a2 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a2DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a2SFWET",
+                                  MPI_FLOAT, 2, dimids, &num_a2SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2SFWET, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a2SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a2_CLXF",
+                                  MPI_FLOAT, 2, dimids, &num_a2_CLXF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2_CLXF, "units", 11, "molec/cm2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2_CLXF, "long_name", 50,
+                        "vertically intergrated external forcing for num_a2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2_CLXF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a2_CLXF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a2_SRF", MPI_FLOAT,
+                                  2, dimids, &num_a2_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2_SRF, "units", 5, " 1/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2_SRF, "long_name", 22, "num_a2 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a2_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a2_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a3DDF", MPI_FLOAT,
+                                  2, dimids, &num_a3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3DDF, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3DDF, "long_name", 50,
+                        "num_a3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a3SF", MPI_FLOAT,
+                                  2, dimids, &num_a3SF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3SF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3SF, "long_name", 28, "num_a3 dust surface emission");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3SF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a3SF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a3SFWET",
+                                  MPI_FLOAT, 2, dimids, &num_a3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3SFWET, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a3_SRF", MPI_FLOAT,
+                                  2, dimids, &num_a3_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3_SRF, "units", 5, " 1/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3_SRF, "long_name", 22, "num_a3 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a3_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a3_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a4DDF", MPI_FLOAT,
+                                  2, dimids, &num_a4DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4DDF, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4DDF, "long_name", 50,
+                        "num_a4 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a4DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a4SFWET",
+                                  MPI_FLOAT, 2, dimids, &num_a4SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4SFWET, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a4SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a4_CLXF",
+                                  MPI_FLOAT, 2, dimids, &num_a4_CLXF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4_CLXF, "units", 11, "molec/cm2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4_CLXF, "long_name", 50,
+                        "vertically intergrated external forcing for num_a4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4_CLXF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a4_CLXF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a4_SRF", MPI_FLOAT,
+                                  2, dimids, &num_a4_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4_SRF, "units", 5, " 1/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4_SRF, "long_name", 22, "num_a4 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a4_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a4_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &num_a4_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4_sfgaex1, "long_name", 51,
+                        "num_a4 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_a4_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_a4_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c1DDF", MPI_FLOAT,
+                                  2, dimids, &num_c1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c1DDF, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c1DDF, "long_name", 50,
+                        "num_c1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_c1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c1SFWET",
+                                  MPI_FLOAT, 2, dimids, &num_c1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c1SFWET, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, num_c1SFWET, "long_name", 37, "num_c1 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_c1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c2DDF", MPI_FLOAT,
+                                  2, dimids, &num_c2DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c2DDF, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c2DDF, "long_name", 50,
+                        "num_c2 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c2DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_c2DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c2SFWET",
+                                  MPI_FLOAT, 2, dimids, &num_c2SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c2SFWET, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, num_c2SFWET, "long_name", 37, "num_c2 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c2SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_c2SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c3DDF", MPI_FLOAT,
+                                  2, dimids, &num_c3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c3DDF, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c3DDF, "long_name", 50,
+                        "num_c3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_c3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c3SFWET",
+                                  MPI_FLOAT, 2, dimids, &num_c3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c3SFWET, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, num_c3SFWET, "long_name", 37, "num_c3 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_c3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c4DDF", MPI_FLOAT,
+                                  2, dimids, &num_c4DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c4DDF, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c4DDF, "long_name", 50,
+                        "num_c4 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c4DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_c4DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c4SFWET",
+                                  MPI_FLOAT, 2, dimids, &num_c4SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c4SFWET, "units", 7, " 1/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, num_c4SFWET, "long_name", 37, "num_c4 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, num_c4SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = num_c4SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a1DDF", MPI_FLOAT,
+                                  2, dimids, &pom_a1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1DDF, "long_name", 50,
+                        "pom_a1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a1SFWET",
+                                  MPI_FLOAT, 2, dimids, &pom_a1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a1_SRF", MPI_FLOAT,
+                                  2, dimids, &pom_a1_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1_SRF, "long_name", 22, "pom_a1 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a1_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a1_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &pom_a1_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1_sfgaex1, "long_name", 51,
+                        "pom_a1 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a1_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a1_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a3DDF", MPI_FLOAT,
+                                  2, dimids, &pom_a3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a3DDF, "long_name", 50,
+                        "pom_a3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a3SFWET",
+                                  MPI_FLOAT, 2, dimids, &pom_a3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a3SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a3_SRF", MPI_FLOAT,
+                                  2, dimids, &pom_a3_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a3_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a3_SRF, "long_name", 22, "pom_a3 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a3_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a3_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a4DDF", MPI_FLOAT,
+                                  2, dimids, &pom_a4DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4DDF, "long_name", 50,
+                        "pom_a4 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a4DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a4SFWET",
+                                  MPI_FLOAT, 2, dimids, &pom_a4SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a4SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a4_CLXF",
+                                  MPI_FLOAT, 2, dimids, &pom_a4_CLXF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4_CLXF, "units", 11, "molec/cm2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4_CLXF, "long_name", 50,
+                        "vertically intergrated external forcing for pom_a4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4_CLXF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a4_CLXF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a4_SRF", MPI_FLOAT,
+                                  2, dimids, &pom_a4_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4_SRF, "long_name", 22, "pom_a4 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a4_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a4_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &pom_a4_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4_sfgaex1, "long_name", 51,
+                        "pom_a4 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_a4_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_a4_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c1DDF", MPI_FLOAT,
+                                  2, dimids, &pom_c1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c1DDF, "long_name", 50,
+                        "pom_c1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_c1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c1SFWET",
+                                  MPI_FLOAT, 2, dimids, &pom_c1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, pom_c1SFWET, "long_name", 37, "pom_c1 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_c1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c3DDF", MPI_FLOAT,
+                                  2, dimids, &pom_c3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c3DDF, "long_name", 50,
+                        "pom_c3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_c3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c3SFWET",
+                                  MPI_FLOAT, 2, dimids, &pom_c3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, pom_c3SFWET, "long_name", 37, "pom_c3 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_c3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c4DDF", MPI_FLOAT,
+                                  2, dimids, &pom_c4DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c4DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c4DDF, "long_name", 50,
+                        "pom_c4 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c4DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_c4DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c4SFWET",
+                                  MPI_FLOAT, 2, dimids, &pom_c4SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c4SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, pom_c4SFWET, "long_name", 37, "pom_c4 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, pom_c4SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = pom_c4SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a1DDF", MPI_FLOAT,
+                                  2, dimids, &so4_a1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1DDF, "long_name", 50,
+                        "so4_a1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a1SFWET",
+                                  MPI_FLOAT, 2, dimids, &so4_a1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a1_CLXF",
+                                  MPI_FLOAT, 2, dimids, &so4_a1_CLXF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1_CLXF, "units", 11, "molec/cm2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1_CLXF, "long_name", 50,
+                        "vertically intergrated external forcing for so4_a1");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1_CLXF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a1_CLXF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a1_SRF", MPI_FLOAT,
+                                  2, dimids, &so4_a1_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1_SRF, "long_name", 22, "so4_a1 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a1_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a1_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &so4_a1_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1_sfgaex1, "long_name", 51,
+                        "so4_a1 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a1_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a1_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a2DDF", MPI_FLOAT,
+                                  2, dimids, &so4_a2DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2DDF, "long_name", 50,
+                        "so4_a2 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a2DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a2SFWET",
+                                  MPI_FLOAT, 2, dimids, &so4_a2SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a2SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a2_CLXF",
+                                  MPI_FLOAT, 2, dimids, &so4_a2_CLXF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2_CLXF, "units", 11, "molec/cm2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2_CLXF, "long_name", 50,
+                        "vertically intergrated external forcing for so4_a2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2_CLXF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a2_CLXF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a2_SRF", MPI_FLOAT,
+                                  2, dimids, &so4_a2_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2_SRF, "long_name", 22, "so4_a2 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a2_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a2_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &so4_a2_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2_sfgaex1, "long_name", 51,
+                        "so4_a2 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a2_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a2_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a3DDF", MPI_FLOAT,
+                                  2, dimids, &so4_a3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3DDF, "long_name", 50,
+                        "so4_a3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a3SFWET",
+                                  MPI_FLOAT, 2, dimids, &so4_a3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a3_SRF", MPI_FLOAT,
+                                  2, dimids, &so4_a3_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3_SRF, "long_name", 22, "so4_a3 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a3_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a3_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &so4_a3_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3_sfgaex1, "long_name", 51,
+                        "so4_a3 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_a3_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_a3_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c1DDF", MPI_FLOAT,
+                                  2, dimids, &so4_c1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c1DDF, "long_name", 50,
+                        "so4_c1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_c1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c1SFWET",
+                                  MPI_FLOAT, 2, dimids, &so4_c1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, so4_c1SFWET, "long_name", 37, "so4_c1 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_c1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c2DDF", MPI_FLOAT,
+                                  2, dimids, &so4_c2DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c2DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c2DDF, "long_name", 50,
+                        "so4_c2 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c2DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_c2DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c2SFWET",
+                                  MPI_FLOAT, 2, dimids, &so4_c2SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c2SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, so4_c2SFWET, "long_name", 37, "so4_c2 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c2SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_c2SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c3DDF", MPI_FLOAT,
+                                  2, dimids, &so4_c3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c3DDF, "long_name", 50,
+                        "so4_c3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_c3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c3SFWET",
+                                  MPI_FLOAT, 2, dimids, &so4_c3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, so4_c3SFWET, "long_name", 37, "so4_c3 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, so4_c3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = so4_c3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a1DDF", MPI_FLOAT,
+                                  2, dimids, &soa_a1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1DDF, "long_name", 50,
+                        "soa_a1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a1SFWET",
+                                  MPI_FLOAT, 2, dimids, &soa_a1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a1_SRF", MPI_FLOAT,
+                                  2, dimids, &soa_a1_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1_SRF, "long_name", 22, "soa_a1 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a1_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a1_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &soa_a1_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1_sfgaex1, "long_name", 51,
+                        "soa_a1 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a1_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a1_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a2DDF", MPI_FLOAT,
+                                  2, dimids, &soa_a2DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2DDF, "long_name", 50,
+                        "soa_a2 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a2DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a2SFWET",
+                                  MPI_FLOAT, 2, dimids, &soa_a2SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a2SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a2_SRF", MPI_FLOAT,
+                                  2, dimids, &soa_a2_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2_SRF, "long_name", 22, "soa_a2 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a2_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a2_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &soa_a2_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2_sfgaex1, "long_name", 51,
+                        "soa_a2 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a2_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a2_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a3DDF", MPI_FLOAT,
+                                  2, dimids, &soa_a3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3DDF, "long_name", 50,
+                        "soa_a3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a3SFWET",
+                                  MPI_FLOAT, 2, dimids, &soa_a3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3SFWET, "long_name", 30, "Wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a3SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a3_SRF", MPI_FLOAT,
+                                  2, dimids, &soa_a3_SRF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3_SRF, "units", 5, "kg/kg");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3_SRF, "long_name", 22, "soa_a3 in bottom layer");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3_SRF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a3_SRF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a3_sfgaex1",
+                                  MPI_FLOAT, 2, dimids, &soa_a3_sfgaex1);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3_sfgaex1, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3_sfgaex1, "long_name", 51,
+                        "soa_a3 gas-aerosol-exchange primary column tendency");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_a3_sfgaex1, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_a3_sfgaex1;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c1DDF", MPI_FLOAT,
+                                  2, dimids, &soa_c1DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c1DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c1DDF, "long_name", 50,
+                        "soa_c1 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c1DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_c1DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c1SFWET",
+                                  MPI_FLOAT, 2, dimids, &soa_c1SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c1SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, soa_c1SFWET, "long_name", 37, "soa_c1 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c1SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_c1SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c2DDF", MPI_FLOAT,
+                                  2, dimids, &soa_c2DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c2DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c2DDF, "long_name", 50,
+                        "soa_c2 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c2DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_c2DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c2SFWET",
+                                  MPI_FLOAT, 2, dimids, &soa_c2SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c2SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, soa_c2SFWET, "long_name", 37, "soa_c2 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c2SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_c2SFWET;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c3DDF", MPI_FLOAT,
+                                  2, dimids, &soa_c3DDF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c3DDF, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c3DDF, "long_name", 50,
+                        "soa_c3 dry deposition flux at bottom (grav + turb)");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c3DDF, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_c3DDF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c3SFWET",
+                                  MPI_FLOAT, 2, dimids, &soa_c3SFWET);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c3SFWET, "units", 7, "kg/m2/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, soa_c3SFWET, "long_name", 37, "soa_c3 wet deposition flux at surface");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, soa_c3SFWET, "cell_methods", 10, "time: mean");
+    CHECK_ERR
+    varids[i++] = soa_c3SFWET;
+
+    assert (i == nvars);
+
+err_out:
+    return nerrs;
+}
+
+/*----< def_F_case_h1_pio() >----------------------------------------------------*/
+int def_F_case_h1_pio (e3sm_io_driver &driver,
+                       e3sm_io_decom &decom,
+                       int ncid,                 /* file ID */
+                       const MPI_Offset dims[2], /* dimension sizes */
+                       int nvars,                /* number of variables */
+                       std::vector<int> &decomids,
+                       e3sm_io_pio_var *varids, /* variable IDs */
+                       int *piovars) {
+    /* Total 51 variables */
+    e3sm_io_pio_var lat, lon, area, lev, hyam, hybm, P0, ilev, hyai, hybi, time, date, datesec,
+        time_bnds, date_written, time_written, ndbase, nsbase, nbdate, nbsec, mdt, ndcur, nscur,
+        co2vmr, ch4vmr, n2ovmr, f11vmr, f12vmr, sol_tsi, nsteph, CLDHGH, CLDLOW, CLDMED, FLNT, LWCF,
+        OMEGA500, OMEGA850, PRECT, PS, SWCF, T850, TMQ, TS, U, U250, U850, UBOT, V250, V850, VBOT,
+        Z500;
+
+    int i, j, k, err, nerrs = 0, dimids[3], iattr, mdims = 1;
+    int dim_ncol, dim_time, dim_nbnd, dim_chars, dim_lev, dim_ilev;
+    std::map<int, std::string> dnames;
+    char name[128];
+
+    /* global attributes: */
+    iattr = 4;
+    err   = e3sm_io_pio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR, "ne", MPI_INT, 1, &iattr);
+    CHECK_ERR
+    err = e3sm_io_pio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR, "np", MPI_INT, 1, &iattr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "Conventions", 6, "CF-1.0");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "source", 3, "CAM");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "case", 20, "FC5AV1C-H01B_ne4_ne4");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "title", 5, "UNSET");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "logname", 6, "wkliao");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "host", 10, "compute001");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "Version", 6, "$Name$");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "revision_Id", 4, "$Id$");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (
+        ncid, E3SM_IO_GLOBAL_ATTR, "initial_file", 86,
+        "/home/climate1/acme/inputdata/atm/cam/inic/homme/cami_mam3_Linoz_ne4np4_L72_c160909.nc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (
+        ncid, E3SM_IO_GLOBAL_ATTR, "topography_file", 79,
+        "/home/climate1/acme/inputdata/atm/cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "time_period_freq", 6, "hour_2");
+    CHECK_ERR
+
+    // PIO attributes
+    k   = 256;
+    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "/__e3sm_io__/fillmode", MPI_INT, 1, &k);
+    CHECK_ERR
+
+    /* define dimensions */
+    err = e3sm_io_pio_define_dim (driver, ncid, "ncol", dims[1], dnames, &dim_ncol);
+    CHECK_ERR
+    err = e3sm_io_pio_define_dim (driver, ncid, "time", NC_UNLIMITED, dnames, &dim_time);
+    CHECK_ERR
+    err = e3sm_io_pio_define_dim (driver, ncid, "nbnd", 2, dnames, &dim_nbnd);
+    CHECK_ERR
+    err = e3sm_io_pio_define_dim (driver, ncid, "chars", 8, dnames, &dim_chars);
+    CHECK_ERR
+    err = e3sm_io_pio_define_dim (driver, ncid, "lev", dims[0], dnames, &dim_lev);
+    CHECK_ERR
+    err = e3sm_io_pio_define_dim (driver, ncid, "ilev", dims[0] + 1, dnames, &dim_ilev);
+    CHECK_ERR
+
+    /* define pio decom map variables */
+    for (j = 0; j < 5; j++) {
+        int piodecomid[] = {0, 1, 1, 1, 2};
+        k                = 6;
+        sprintf (name, "/__e3sm_io__/decomp/%d", (j + 512));
+        err = driver.def_local_var (ncid, name, MPI_LONG_LONG, 1, decom.raw_nreqs + piodecomid[j],
+                                    piovars + j);
+        CHECK_ERR
+        err = driver.put_att (ncid, piovars[j], "dimlen", MPI_INT, decom.ndims[piodecomid[j]],
+                              decom.dims + piodecomid[j]);
+        CHECK_ERR
+        err = driver.put_att (ncid, piovars[j], "ndims", MPI_INT, 1, decom.ndims + piodecomid[j]);
+        CHECK_ERR
+        err = driver.put_att (ncid, piovars[j], "piotype", MPI_INT, 1, &k);
+        CHECK_ERR
+    }
+
+    // TODO: only the first subfile contain nproc
+    err = driver.def_local_var (ncid, "/__e3sm_io__/info/nproc", MPI_INT, 0, NULL, piovars + (j++));
+    CHECK_ERR
+
+    i = 0;
+    /* define variables */
+    dimids[0] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lat", MPI_DOUBLE, 1,
+                                  dimids, &lat);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lat, "long_name", 8, "latitude");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lat, "units", 13, "degrees_north");
+    CHECK_ERR
+    varids[i++] = lat;
+
+    dimids[0] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lon", MPI_DOUBLE, 1,
+                                  dimids, &lon);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lon, "long_name", 9, "longitude");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lon, "units", 12, "degrees_east");
+    CHECK_ERR
+    varids[i++] = lon;
+
+    dimids[0] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "area", MPI_DOUBLE, 1,
+                                  dimids, &area);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, area, "long_name", 14, "gll grid areas");
+    CHECK_ERR
+    varids[i++] = area;
+
+    dimids[0] = dim_lev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lev", MPI_DOUBLE, 1,
+                                  dimids, &lev);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lev, "long_name", 38, "hybrid level at midpoints (1000*(A+B))");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lev, "units", 3, "hPa");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lev, "positive", 4, "down");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lev, "standard_name", 43,
+                        "atmosphere_hybrid_sigma_pressure_coordinate");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, lev, "formula_terms", 29, "a: hyam b: hybm p0: P0 ps: PS");
+    CHECK_ERR
+    varids[i++] = lev;
+
+    dimids[0] = dim_lev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hyam", MPI_DOUBLE, 1,
+                                  dimids, &hyam);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, hyam, "long_name", 39, "hybrid A coefficient at layer midpoints");
+    CHECK_ERR
+    varids[i++] = hyam;
+
+    dimids[0] = dim_lev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hybm", MPI_DOUBLE, 1,
+                                  dimids, &hybm);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, hybm, "long_name", 39, "hybrid B coefficient at layer midpoints");
+    CHECK_ERR
+    varids[i++] = hybm;
+
+    dimids[0] = dim_lev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "P0", MPI_DOUBLE, 0,
+                                  NULL, &P0);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, P0, "long_name", 18, "reference pressure");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, P0, "units", 2, "Pa");
+    CHECK_ERR
+    varids[i++] = P0;
+
+    dimids[0] = dim_ilev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ilev", MPI_DOUBLE, 1,
+                                  dimids, &ilev);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ilev, "long_name", 39, "hybrid level at interfaces (1000*(A+B))");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ilev, "units", 3, "hPa");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ilev, "positive", 4, "down");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ilev, "standard_name", 43,
+                        "atmosphere_hybrid_sigma_pressure_coordinate");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ilev, "formula_terms", 29, "a: hyai b: hybi p0: P0 ps: PS");
+    CHECK_ERR
+    varids[i++] = ilev;
+
+    dimids[0] = dim_ilev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hyai", MPI_DOUBLE, 1,
+                                  dimids, &hyai);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, hyai, "long_name", 40, "hybrid A coefficient at layer interfaces");
+    CHECK_ERR
+    varids[i++] = hyai;
+
+    dimids[0] = dim_ilev;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hybi", MPI_DOUBLE, 1,
+                                  dimids, &hybi);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, hybi, "long_name", 40, "hybrid B coefficient at layer interfaces");
+    CHECK_ERR
+    varids[i++] = hybi;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time", MPI_DOUBLE, 1,
+                                  dimids, &time);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, time, "long_name", 4, "time");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, time, "units", 30, "days since 0001-01-01 00:00:00");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, time, "calendar", 6, "noleap");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, time, "bounds", 9, "time_bnds");
+    CHECK_ERR
+    varids[i++] = time;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "date", MPI_INT, 1,
+                                  dimids, &date);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, date, "long_name", 23, "current date (YYYYMMDD)");
+    CHECK_ERR
+    varids[i++] = date;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "datesec", MPI_INT, 1,
+                                  dimids, &datesec);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, datesec, "long_name", 31, "current seconds of current date");
+    CHECK_ERR
+    varids[i++] = datesec;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_nbnd;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time_bnds", MPI_DOUBLE,
+                                  2, dimids, &time_bnds);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, time_bnds, "long_name", 23, "time interval endpoints");
+    CHECK_ERR
+    varids[i++] = time_bnds;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_chars;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "date_written",
+                                  MPI_CHAR, 2, dimids, &date_written);
+    CHECK_ERR
+    varids[i++] = date_written;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_chars;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time_written",
+                                  MPI_CHAR, 2, dimids, &time_written);
+    CHECK_ERR
+    varids[i++] = time_written;
+
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ndbase", MPI_INT, 0,
+                                  NULL, &ndbase);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ndbase, "long_name", 8, "base day");
+    CHECK_ERR
+    varids[i++] = ndbase;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nsbase", MPI_INT, 0,
+                                  NULL, &nsbase);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, nsbase, "long_name", 19, "seconds of base day");
+    CHECK_ERR
+    varids[i++] = nsbase;
+
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nbdate", MPI_INT, 0,
+                                  NULL, &nbdate);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, nbdate, "long_name", 20, "base date (YYYYMMDD)");
+    CHECK_ERR
+    varids[i++] = nbdate;
+
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nbsec", MPI_INT, 0,
+                                  NULL, &nbsec);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, nbsec, "long_name", 20, "seconds of base date");
+    CHECK_ERR
+    varids[i++] = nbsec;
+
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mdt", MPI_INT, 0, NULL,
+                                  &mdt);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mdt, "long_name", 8, "timestep");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, mdt, "units", 1, "s");
+    CHECK_ERR
+    varids[i++] = mdt;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ndcur", MPI_INT, 1,
+                                  dimids, &ndcur);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ndcur, "long_name", 27, "current day (from base day)");
+    CHECK_ERR
+    varids[i++] = ndcur;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nscur", MPI_INT, 1,
+                                  dimids, &nscur);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, nscur, "long_name", 30, "current seconds of current day");
+    CHECK_ERR
+    varids[i++] = nscur;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "co2vmr", MPI_DOUBLE, 1,
+                                  dimids, &co2vmr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, co2vmr, "long_name", 23, "co2 volume mixing ratio");
+    CHECK_ERR
+    varids[i++] = co2vmr;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ch4vmr", MPI_DOUBLE, 1,
+                                  dimids, &ch4vmr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, ch4vmr, "long_name", 23, "ch4 volume mixing ratio");
+    CHECK_ERR
+    varids[i++] = ch4vmr;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "n2ovmr", MPI_DOUBLE, 1,
+                                  dimids, &n2ovmr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, n2ovmr, "long_name", 23, "n2o volume mixing ratio");
+    CHECK_ERR
+    varids[i++] = n2ovmr;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "f11vmr", MPI_DOUBLE, 1,
+                                  dimids, &f11vmr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, f11vmr, "long_name", 23, "f11 volume mixing ratio");
+    CHECK_ERR
+    varids[i++] = f11vmr;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "f12vmr", MPI_DOUBLE, 1,
+                                  dimids, &f12vmr);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, f12vmr, "long_name", 23, "f12 volume mixing ratio");
+    CHECK_ERR
+    varids[i++] = f12vmr;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "sol_tsi", MPI_DOUBLE,
+                                  1, dimids, &sol_tsi);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, sol_tsi, "long_name", 22, "total solar irradiance");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, sol_tsi, "units", 4, "W/m2");
+    CHECK_ERR
+    varids[i++] = sol_tsi;
+
+    dimids[0] = dim_time;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nsteph", MPI_INT, 1,
+                                  dimids, &nsteph);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, nsteph, "long_name", 16, "current timestep");
+    CHECK_ERR
+    varids[i++] = nsteph;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDHGH", MPI_FLOAT, 2,
+                                  dimids, &CLDHGH);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDHGH, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDHGH, "long_name", 32, "Vertically-integrated high cloud");
+    CHECK_ERR
+    varids[i++] = CLDHGH;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDLOW", MPI_FLOAT, 2,
+                                  dimids, &CLDLOW);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDLOW, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDLOW, "long_name", 31, "Vertically-integrated low cloud");
+    CHECK_ERR
+    varids[i++] = CLDLOW;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDMED", MPI_FLOAT, 2,
+                                  dimids, &CLDMED);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDMED, "units", 8, "fraction");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, CLDMED, "long_name", 37, "Vertically-integrated mid-level cloud");
+    CHECK_ERR
+    varids[i++] = CLDMED;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLNT", MPI_FLOAT, 2,
+                                  dimids, &FLNT);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNT, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNT, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, FLNT, "long_name", 33, "Net longwave flux at top of model");
+    CHECK_ERR
+    varids[i++] = FLNT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LWCF", MPI_FLOAT, 2,
+                                  dimids, &LWCF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LWCF, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LWCF, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, LWCF, "long_name", 22, "Longwave cloud forcing");
+    CHECK_ERR
+    varids[i++] = LWCF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OMEGA500", MPI_FLOAT,
+                                  2, dimids, &OMEGA500);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGA500, "units", 4, "Pa/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGA500, "long_name", 46,
+                        "Vertical velocity at 500 mbar pressure surface");
+    CHECK_ERR
+    varids[i++] = OMEGA500;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OMEGA850", MPI_FLOAT,
+                                  2, dimids, &OMEGA850);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGA850, "units", 4, "Pa/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, OMEGA850, "long_name", 46,
+                        "Vertical velocity at 850 mbar pressure surface");
+    CHECK_ERR
+    varids[i++] = OMEGA850;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PRECT", MPI_FLOAT, 2,
+                                  dimids, &PRECT);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECT, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PRECT, "long_name", 65,
+                        "Total (convective and large-scale) precipitation rate (liq + ice)");
+    CHECK_ERR
+    varids[i++] = PRECT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PS", MPI_FLOAT, 2,
+                                  dimids, &PS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PS, "units", 2, "Pa");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, PS, "long_name", 16, "Surface pressure");
+    CHECK_ERR
+    varids[i++] = PS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SWCF", MPI_FLOAT, 2,
+                                  dimids, &SWCF);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SWCF, "Sampling_Sequence", 8, "rad_lwsw");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SWCF, "units", 4, "W/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, SWCF, "long_name", 23, "Shortwave cloud forcing");
+    CHECK_ERR
+    varids[i++] = SWCF;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "T850", MPI_FLOAT, 2,
+                                  dimids, &T850);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, T850, "units", 1, "K");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, T850, "long_name", 40, "Temperature at 850 mbar pressure surface");
+    CHECK_ERR
+    varids[i++] = T850;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TMQ", MPI_FLOAT, 2,
+                                  dimids, &TMQ);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TMQ, "units", 5, "kg/m2");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TMQ, "long_name", 48,
+                        "Total (vertically integrated) precipitable water");
+    CHECK_ERR
+    varids[i++] = TMQ;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TS", MPI_FLOAT, 2,
+                                  dimids, &TS);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TS, "units", 1, "K");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, TS, "long_name", 31, "Surface temperature (radiative)");
+    CHECK_ERR
+    varids[i++] = TS;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_lev;
+    dimids[2] = dim_ncol;
+    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "U", MPI_FLOAT, 3,
+                                  dimids, &U);
+    CHECK_ERR
+    err = PUT_ATT_INT (ncid, U, "mdims", MPI_INT, 1, &mdims);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U, "long_name", 10, "Zonal wind");
+    CHECK_ERR
+    varids[i++] = U;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "U250", MPI_FLOAT, 2,
+                                  dimids, &U250);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U250, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U250, "long_name", 39, "Zonal wind at 250 mbar pressure surface");
+    CHECK_ERR
+    varids[i++] = U250;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "U850", MPI_FLOAT, 2,
+                                  dimids, &U850);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U850, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, U850, "long_name", 39, "Zonal wind at 850 mbar pressure surface");
+    CHECK_ERR
+    varids[i++] = U850;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "UBOT", MPI_FLOAT, 2,
+                                  dimids, &UBOT);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, UBOT, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, UBOT, "long_name", 29, "Lowest model level zonal wind");
+    CHECK_ERR
+    varids[i++] = UBOT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "V250", MPI_FLOAT, 2,
+                                  dimids, &V250);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, V250, "units", 3, "m/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, V250, "long_name", 44, "Meridional wind at 250 mbar pressure surface");
+    CHECK_ERR
+    varids[i++] = V250;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "V850", MPI_FLOAT, 2,
+                                  dimids, &V850);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, V850, "units", 3, "m/s");
+    CHECK_ERR
+    err =
+        PUT_ATT_TEXT (ncid, V850, "long_name", 44, "Meridional wind at 850 mbar pressure surface");
+    CHECK_ERR
+    varids[i++] = V850;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "VBOT", MPI_FLOAT, 2,
+                                  dimids, &VBOT);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VBOT, "units", 3, "m/s");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, VBOT, "long_name", 34, "Lowest model level meridional wind");
+    CHECK_ERR
+    varids[i++] = VBOT;
+
+    dimids[0] = dim_time;
+    dimids[1] = dim_ncol;
+    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Z500", MPI_FLOAT, 2,
+                                  dimids, &Z500);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Z500, "units", 1, "m");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, Z500, "long_name", 43, "Geopotential Z at 500 mbar pressure surface");
+    CHECK_ERR
+    varids[i++] = Z500;
+
+    assert (i == nvars);
+
+err_out:
+    return nerrs;
+}

--- a/src/cases/var_io_F_case_pio.cpp
+++ b/src/cases/var_io_F_case_pio.cpp
@@ -1,0 +1,902 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+//
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <string>
+//
+#include <unistd.h> /* unlink() */
+//
+#include <mpi.h>
+//
+#include <e3sm_io.h>
+#include <e3sm_io_err.h>
+
+#include <e3sm_io_case_F.hpp>
+#include <e3sm_io_case_F_pio.hpp>
+#include <e3sm_io_case_pio.hpp>
+#include <e3sm_io_driver.hpp>
+
+#define IPUT_VAR_DOUBLE(F, D, B, R) e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_DOUBLE, B, nb);
+#define IPUT_VAR_FLOAT(F, D, B, R)  e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_FLOAT, B, nb);
+#define IPUT_VAR_INT(F, D, B, R)    e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_INT, B, nb);
+#define IPUT_VAR_CHAR(F, D, B, R)   e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_CHAR, B, nb);
+#define IPUT_VAR1_DOUBLE(F, D, S, B, R) \
+    e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_DOUBLE, B, nb);
+#define IPUT_VAR1_FLOAT(F, D, S, B, R) \
+    e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_FLOAT, B, nb);
+#define IPUT_VAR1_INT(F, D, S, B, R)  e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_INT, B, nb);
+#define IPUT_VAR1_CHAR(F, D, S, B, R) e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_CHAR, B, nb);
+#define IPUT_VARA_DOUBLE(F, D, S, C, B, R) \
+    e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_DOUBLE, B, nb);
+#define IPUT_VARA_FLOAT(F, D, S, C, B, R) \
+    e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_FLOAT, B, nb);
+#define IPUT_VARA_INT(F, D, S, C, B, R) \
+    e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_INT, B, nb);
+#define IPUT_VARA_CHAR(F, D, S, C, B, R) \
+    e3sm_io_pio_write_var (driver, rec_no, F, D, MPI_CHAR, B, nb);
+#define IPUT_VARN(F, D, N, S, C, B, BC, BT, R) \
+    e3sm_io_pio_write_var (driver, rec_no, F, D, BT, B, nb);
+
+#define WAIT_ALL_REQS(F, D, B, R) driver.wait (F);
+
+/*----< write_small_vars_F_case() >------------------------------------------*/
+static int write_small_vars_F_case_pio (e3sm_io_driver &driver,
+                                        int ncid,
+                                        int vid, /* starting variable ID */
+                                        e3sm_io_pio_var *varids,
+                                        int rec_no,
+                                        int gap,
+                                        MPI_Offset lev,
+                                        MPI_Offset ilev,
+                                        MPI_Offset nbnd,
+                                        MPI_Offset nchars,
+                                        int **int_buf,
+                                        char **txt_buf,
+                                        double **dbl_buf) {
+    int i, err, nerrs = 0;
+    MPI_Offset start[2], count[2];
+
+    /* scalar and small variables are written by rank 0 only */
+    i = vid;
+
+    if (rec_no == 0) {
+        /* lev */
+        err = IPUT_VAR_DOUBLE (ncid, varids[i++], *dbl_buf, NULL);
+        CHECK_ERR
+        *dbl_buf += lev + gap;
+        /* hyam */
+        err = IPUT_VAR_DOUBLE (ncid, varids[i++], *dbl_buf, NULL);
+        CHECK_ERR
+        *dbl_buf += lev + gap;
+        /* hybm */
+        err = IPUT_VAR_DOUBLE (ncid, varids[i++], *dbl_buf, NULL);
+        CHECK_ERR
+        *dbl_buf += lev + gap;
+        /* P0 */
+        err = IPUT_VAR_DOUBLE (ncid, varids[i++], *dbl_buf, NULL);
+        CHECK_ERR
+        *dbl_buf += 1 + gap;
+        /* ilev */
+        err = IPUT_VAR_DOUBLE (ncid, varids[i++], *dbl_buf, NULL);
+        CHECK_ERR
+        *dbl_buf += ilev + gap;
+        /* hyai */
+        err = IPUT_VAR_DOUBLE (ncid, varids[i++], *dbl_buf, NULL);
+        CHECK_ERR
+        *dbl_buf += ilev + gap;
+        /* hybi */
+        err = IPUT_VAR_DOUBLE (ncid, varids[i++], *dbl_buf, NULL);
+        CHECK_ERR
+        *dbl_buf += ilev + gap;
+    } else
+        i += 7;
+
+    /* time */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_DOUBLE (ncid, varids[i++], start, *dbl_buf, NULL);
+    CHECK_ERR
+    *dbl_buf += 1 + gap;
+    /* date */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_INT (ncid, varids[i++], start, *int_buf, NULL);
+    CHECK_ERR
+    *int_buf += 1;
+    /* datesec */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_INT (ncid, varids[i++], start, *int_buf, NULL);
+    CHECK_ERR
+    *int_buf += 1;
+    /* time_bnds */
+    start[0] = rec_no;
+    start[1] = 0;
+    count[0] = 1;
+    count[1] = nbnd;
+    err      = IPUT_VARA_DOUBLE (ncid, varids[i++], start, count, *dbl_buf, NULL);
+    CHECK_ERR
+    *dbl_buf += nbnd + gap;
+    /* date_written */
+    start[0] = rec_no;
+    start[1] = 0;
+    count[0] = 1;
+    count[1] = nchars;
+    err      = IPUT_VARA_CHAR (ncid, varids[i++], start, count, *txt_buf, NULL);
+    CHECK_ERR
+    *txt_buf += nchars;
+    /* time_written */
+    start[0] = rec_no;
+    start[1] = 0;
+    count[0] = 1;
+    count[1] = nchars;
+    err      = IPUT_VARA_CHAR (ncid, varids[i++], start, count, *txt_buf, NULL);
+    CHECK_ERR
+    *txt_buf += nchars;
+
+    if (rec_no == 0) {
+        /* ndbase */
+        err = IPUT_VAR_INT (ncid, varids[i++], *int_buf, NULL);
+        CHECK_ERR
+        *int_buf += 1;
+        /* nsbase */
+        err = IPUT_VAR_INT (ncid, varids[i++], *int_buf, NULL);
+        CHECK_ERR
+        *int_buf += 1;
+        /* nbdate */
+        err = IPUT_VAR_INT (ncid, varids[i++], *int_buf, NULL);
+        CHECK_ERR
+        *int_buf += 1;
+        /* nbsec */
+        err = IPUT_VAR_INT (ncid, varids[i++], *int_buf, NULL);
+        CHECK_ERR
+        *int_buf += 1;
+        /* mdt */
+        err = IPUT_VAR_INT (ncid, varids[i++], *int_buf, NULL);
+        CHECK_ERR
+        *int_buf += 1;
+    } else
+        i += 5;
+
+    /* ndcur */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_INT (ncid, varids[i++], start, *int_buf, NULL);
+    CHECK_ERR
+    *int_buf += 1;
+    /* nscur */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_INT (ncid, varids[i++], start, *int_buf, NULL);
+    CHECK_ERR
+    *int_buf += 1;
+    /* co2vmr */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_DOUBLE (ncid, varids[i++], start, *dbl_buf, NULL);
+    CHECK_ERR
+    *dbl_buf += 1 + gap;
+    /* ch4vmr */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_DOUBLE (ncid, varids[i++], start, *dbl_buf, NULL);
+    CHECK_ERR
+    *dbl_buf += 1 + gap;
+    /* n2ovmr */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_DOUBLE (ncid, varids[i++], start, *dbl_buf, NULL);
+    CHECK_ERR
+    *dbl_buf += 1 + gap;
+    /* f11vmr */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_DOUBLE (ncid, varids[i++], start, *dbl_buf, NULL);
+    CHECK_ERR
+    *dbl_buf += 1 + gap;
+    /* f12vmr */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_DOUBLE (ncid, varids[i++], start, *dbl_buf, NULL);
+    CHECK_ERR
+    *dbl_buf += 1 + gap;
+    /* sol_tsi */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_DOUBLE (ncid, varids[i++], start, *dbl_buf, NULL);
+    CHECK_ERR
+    *dbl_buf += 1 + gap;
+    /* nsteph */
+    start[0] = rec_no;
+    err      = IPUT_VAR1_INT (ncid, varids[i++], start, *int_buf, NULL);
+    CHECK_ERR
+    *int_buf += 1;
+err_out:
+    return err;
+}
+
+static inline void FIX_1D_VAR_STARTS_COUNTS (
+    MPI_Offset **&starts, MPI_Offset **&counts, int nreq, int *disps, int *blocklens) {
+    int j;
+
+    starts    = (MPI_Offset **)malloc (2 * nreq * sizeof (MPI_Offset *));
+    counts    = starts + nreq;
+    starts[0] = (MPI_Offset *)malloc (2 * nreq * sizeof (MPI_Offset));
+    counts[0] = starts[0] + nreq;
+
+    for (j = 1; j < nreq; j++) {
+        starts[j] = starts[j - 1] + 1;
+        counts[j] = counts[j - 1] + 1;
+    }
+
+    for (j = 0; j < nreq; j++) {
+        starts[j][0] = disps[j];
+        counts[j][0] = blocklens[j];
+    }
+}
+
+static inline void FIX_2D_VAR_STARTS_COUNTS (MPI_Offset **&starts,
+                                             MPI_Offset **&counts,
+                                             int &nreq,
+                                             int *disps,
+                                             int *blocklens,
+                                             MPI_Offset last_dimlen) {
+    int j, k;
+
+    starts    = (MPI_Offset **)malloc (2 * nreq * sizeof (MPI_Offset *));
+    counts    = starts + nreq;
+    starts[0] = (MPI_Offset *)malloc (2 * nreq * 2 * sizeof (MPI_Offset));
+    counts[0] = starts[0] + nreq * 2;
+
+    for (j = 1; j < nreq; j++) {
+        starts[j] = starts[j - 1] + 2;
+        counts[j] = counts[j - 1] + 2;
+    }
+
+    k            = 0;
+    starts[0][0] = disps[0] / last_dimlen;
+    starts[0][1] = disps[0] % last_dimlen; /* decomposition is 2D */
+    counts[0][0] = 1;
+    counts[0][1] = blocklens[0]; /* each blocklens[j] is no bigger than last_dimlen */
+    for (j = 1; j < nreq; j++) {
+        MPI_Offset _start[2];
+        _start[0] = disps[j] / last_dimlen;
+        _start[1] = disps[j] % last_dimlen;
+        if (_start[0] == starts[k][0] + counts[k][0] && _start[1] == starts[k][1] &&
+            blocklens[j] == counts[k][1])
+            counts[k][0]++;
+        else {
+            k++;
+            starts[k][0] = _start[0];
+            starts[k][1] = _start[1];
+            counts[k][0] = 1;
+            counts[k][1] = blocklens[j]; /* each blocklens[j] is no bigger than last_dimlen */
+        }
+    }
+    nreq = k + 1;
+}
+
+static inline void REC_2D_VAR_STARTS_COUNTS (MPI_Offset rec,
+                                             MPI_Offset **&starts,
+                                             MPI_Offset **&counts,
+                                             int nreq,
+                                             int *disps,
+                                             int *blocklens) {
+    int j;
+
+    starts    = (MPI_Offset **)malloc (2 * nreq * sizeof (MPI_Offset *));
+    counts    = starts + nreq;
+    starts[0] = (MPI_Offset *)malloc (2 * nreq * 2 * sizeof (MPI_Offset));
+    counts[0] = starts[0] + nreq * 2;
+
+    for (j = 1; j < nreq; j++) {
+        starts[j] = starts[j - 1] + 2;
+        counts[j] = counts[j - 1] + 2;
+    }
+
+    for (j = 0; j < nreq; j++) {
+        starts[j][1] = disps[j]; /* decomposition is 1D */
+        counts[j][1] = blocklens[j];
+
+        starts[j][0] = rec; /* record ID */
+        counts[j][0] = 1;   /* one record only */
+    }
+}
+
+static inline void REC_3D_VAR_STARTS_COUNTS (MPI_Offset rec,
+                                             MPI_Offset **&starts,
+                                             MPI_Offset **&counts,
+                                             int &nreq,
+                                             int *disps,
+                                             int *blocklens,
+                                             MPI_Offset last_dimlen) {
+    int j, k;
+
+    starts    = (MPI_Offset **)malloc (2 * nreq * sizeof (MPI_Offset *));
+    counts    = starts + nreq;
+    starts[0] = (MPI_Offset *)malloc (2 * nreq * 3 * sizeof (MPI_Offset));
+    counts[0] = starts[0] + nreq * 3;
+
+    for (j = 1; j < nreq; j++) {
+        starts[j] = starts[j - 1] + 3;
+        counts[j] = counts[j - 1] + 3;
+    }
+
+    k            = 0;
+    starts[0][0] = rec; /* record ID */
+    starts[0][1] = disps[0] / last_dimlen;
+    starts[0][2] = disps[0] % last_dimlen; /* decomposition is 2D */
+    counts[0][0] = 1;                      /* one record only */
+    counts[0][1] = 1;
+    counts[0][2] = blocklens[0]; /* each blocklens[j] is no bigger than last_dimlen */
+    for (j = 1; j < nreq; j++) {
+        MPI_Offset _start[2];
+        _start[0] = disps[j] / last_dimlen;
+        _start[1] = disps[j] % last_dimlen;
+        if (starts[k][0] == rec && _start[0] == starts[k][1] + counts[k][1] &&
+            _start[1] == starts[k][2] && blocklens[j] == counts[k][2])
+            counts[k][1]++;
+        else {
+            k++;
+            starts[k][0] = rec;
+            starts[k][1] = _start[0];
+            starts[k][2] = _start[1];
+            counts[k][0] = 1;
+            counts[k][1] = 1;
+            counts[k][2] = blocklens[j]; /* each blocklens[j] is no bigger than last_dimlen */
+        }
+    }
+    nreq = k + 1;
+}
+
+#define POST_VARN(k, num, vid)                                                           \
+    for (j = 0; j < num; j++) {                                                          \
+        err = IPUT_VARN (ncid, varids[vid + j], xnreqs[k - 1], starts_D##k, counts_D##k, \
+                         rec_buf_ptr, -1, REC_ITYPE, NULL);                              \
+        CHECK_ERR                                                                        \
+        rec_buf_ptr += nelems[k - 1] + gap;                                              \
+        my_nreqs += xnreqs[k - 1];                                                       \
+        if (rec_no == 0) nvars_D[k - 1]++;                                               \
+    }
+
+#define ASSIGN_DECOMID(k, num, vid) \
+    for (j = 0; j < num; j++) { decomids[vid + j] = k - 1; }
+
+/*----< run_varn_F_case() >--------------------------------------------------*/
+int run_varn_F_case_pio (e3sm_io_config &cfg,
+                         e3sm_io_decom &decom,
+                         e3sm_io_driver &driver,
+                         std::string outfile, /* output file name */
+                         double *dbl_bufp,    /* buffer for fixed size double var */
+                         itype *rec_bufp,     /* buffer for rec floating point var */
+                         char *txt_buf,       /* buffer for char var */
+                         int *int_buf)        /* buffer for int var */
+{
+    std::string targetfname;
+    char *txt_buf_ptr;
+    int i, j, k, err, nerrs = 0, rank, ncid, cmode, nvars_D[3];
+    e3sm_io_pio_var *varids;
+    int piovars[6];
+    int rec_no, gap = 0, my_nreqs, *int_buf_ptr, xnreqs[3];
+    size_t dbl_buflen, rec_buflen, nelems[3];
+    itype *rec_buf  = NULL, *rec_buf_ptr;
+    double *dbl_buf = NULL, *dbl_buf_ptr;
+    double pre_timing, open_timing, post_timing, wait_timing, close_timing;
+    double timing, total_timing, max_timing;
+    MPI_Offset tmp, metadata_size, put_size, total_size, max_nreqs, total_nreqs;
+    MPI_Offset **starts_D2 = NULL, **counts_D2 = NULL;
+    MPI_Offset **starts_D3 = NULL, **counts_D3 = NULL;
+    MPI_Info info_used = MPI_INFO_NULL;
+    MPI_Offset malloc_size, sum_size;
+    MPI_Offset m_alloc = 0, max_alloc;
+    long long lbuf;
+    std::vector<int> decomids;
+
+    MPI_Barrier (cfg.io_comm); /*-----------------------------------------*/
+    total_timing = pre_timing = MPI_Wtime ();
+
+    open_timing  = 0.0;
+    post_timing  = 0.0;
+    wait_timing  = 0.0;
+    close_timing = 0.0;
+
+    MPI_Comm_rank (cfg.io_comm, &rank);
+
+    if (cfg.non_contig_buf) gap = 10;
+
+    varids = (e3sm_io_pio_var *)malloc (cfg.nvars * sizeof (e3sm_io_pio_var));
+    decomids.resize (cfg.nvars);
+
+    for (i = 0; i < 3; i++) {
+        xnreqs[i]  = decom.contig_nreqs[i];
+        nvars_D[i] = 0; /* number of variables using decomposition i */
+    }
+
+    /* calculate number of variable elements from 3 decompositions */
+    my_nreqs = 0;
+    for (i = 0; i < 3; i++) {
+        for (nelems[i] = 0, k = 0; k < xnreqs[i]; k++) nelems[i] += decom.blocklens[i][k];
+    }
+    if (cfg.verbose && rank == 0) printf ("nelems=%zd %zd %zd\n", nelems[0], nelems[1], nelems[2]);
+
+    /* allocate and initialize write buffer for small variables */
+    dbl_buflen = nelems[1] * 2 + nelems[0] + 3 * decom.dims[2][0] + 3 * (decom.dims[2][0] + 1) + 8 +
+                 2 + 20 * gap;
+    if (dbl_bufp != NULL) {
+        dbl_buf = dbl_bufp;
+    } else {
+        dbl_buf = (double *)malloc (dbl_buflen * sizeof (double));
+        for (i = 0; i < dbl_buflen; i++) dbl_buf[i] = rank;
+    }
+
+    /* allocate and initialize write buffer for large variables */
+    if (cfg.nvars == 414)
+        rec_buflen = nelems[1] * 321 + nelems[2] * 63 + (321 + 63) * gap;
+    else
+        rec_buflen = nelems[1] * 20 + nelems[2] + (20 + 1) * gap;
+
+    if (rec_bufp != NULL) {
+        rec_buf = rec_bufp;
+    } else {
+        rec_buf = (itype *)malloc (rec_buflen * sizeof (itype));
+
+        for (i = 0; i < rec_buflen; i++) rec_buf[i] = rank;
+        for (i = 0; i < 10; i++) int_buf[i] = rank;
+        for (i = 0; i < 16; i++) txt_buf[i] = 'a' + rank;
+    }
+
+    // Assign decom ID
+    i = 0;
+    if (xnreqs[1] > 0) {
+        /* lat */
+        decomids[i++] = 1;
+        /* lon */
+        decomids[i++] = 1;
+    } else
+        i += 2;
+
+    /* area */
+    if (xnreqs[0] > 0) {
+        decomids[i++] = 0;
+    } else
+        i++;
+
+    /* 27 small variables has no decomposition map */
+    for (; i < 30; i++) { decomids[i] = -1; }
+
+    if (cfg.nvars == 414) {
+        ASSIGN_DECOMID (2, 1, 30)    /* AEROD_v */
+        ASSIGN_DECOMID (3, 2, 31)    /* ANRAIN and ANSNOW */
+        ASSIGN_DECOMID (2, 19, 33)   /* AODABS ... AODVIS */
+        ASSIGN_DECOMID (3, 2, 52)    /* AQRAIN and AQSNOW */
+        ASSIGN_DECOMID (2, 6, 54)    /* AQ_DMS ... AQ_SOAG */
+        ASSIGN_DECOMID (3, 4, 60)    /* AREI ... AWNI */
+        ASSIGN_DECOMID (2, 4, 64)    /* BURDEN1 ... BURDEN4 */
+        ASSIGN_DECOMID (3, 1, 68)    /* CCN3 */
+        ASSIGN_DECOMID (2, 2, 69)    /* CDNUMC and CLDHGH */
+        ASSIGN_DECOMID (3, 2, 71)    /* CLDICE and CLDLIQ */
+        ASSIGN_DECOMID (2, 3, 73)    /* CLDLOW ... CLDTOT */
+        ASSIGN_DECOMID (3, 4, 76)    /* CLOUD ... DCQ */
+        ASSIGN_DECOMID (2, 11, 80)   /* DF_DMS ... DSTSFMBL */
+        ASSIGN_DECOMID (3, 1, 91)    /* DTCOND */
+        ASSIGN_DECOMID (2, 2, 92)    /* DTENDTH and DTENDTQ */
+        ASSIGN_DECOMID (3, 2, 94)    /* EXTINCT and FICE */
+        ASSIGN_DECOMID (2, 7, 96)    /* FLDS ... FLUTC */
+        ASSIGN_DECOMID (3, 4, 103)   /* FREQI ... FREQS */
+        ASSIGN_DECOMID (2, 15, 107)  /* FSDS ... ICEFRAC */
+        ASSIGN_DECOMID (3, 3, 122)   /* ICIMR ... IWC */
+        ASSIGN_DECOMID (2, 2, 125)   /* LANDFRAC and LHFLX */
+        ASSIGN_DECOMID (3, 4, 127)   /* LINOZ_DO3 ... LINOZ_O3COL */
+        ASSIGN_DECOMID (2, 1, 131)   /* LINOZ_SFCSINK */
+        ASSIGN_DECOMID (3, 1, 132)   /* LINOZ_SSO3 */
+        ASSIGN_DECOMID (2, 3, 133)   /* LINOZ_SZA ... LWCF */
+        ASSIGN_DECOMID (3, 12, 136)  /* Mass_bc ... O3 */
+        ASSIGN_DECOMID (2, 2, 148)   /* O3_SRF and OCNFRAC */
+        ASSIGN_DECOMID (3, 1, 150)   /* OMEGA */
+        ASSIGN_DECOMID (2, 1, 151)   /* OMEGA500 */
+        ASSIGN_DECOMID (3, 1, 152)   /* OMEGAT */
+        ASSIGN_DECOMID (2, 8, 153)   /* PBLH ... PSL */
+        ASSIGN_DECOMID (3, 1, 161)   /* Q */
+        ASSIGN_DECOMID (2, 2, 162)   /* QFLX and QREFHT */
+        ASSIGN_DECOMID (3, 3, 164)   /* QRL ... RAINQM */
+        ASSIGN_DECOMID (2, 1, 167)   /* RAM1 */
+        ASSIGN_DECOMID (3, 1, 168)   /* RELHUM */
+        ASSIGN_DECOMID (2, 37, 169)  /* SFDMS ... SNOWHLND */
+        ASSIGN_DECOMID (3, 2, 206)   /* SNOWQM and SO2 */
+        ASSIGN_DECOMID (2, 10, 208)  /* SO2_CLXF ... SWCF */
+        ASSIGN_DECOMID (3, 1, 218)   /* T */
+        ASSIGN_DECOMID (2, 19, 219)  /* TAUGWX ... TVQ */
+        ASSIGN_DECOMID (3, 1, 238)   /* U */
+        ASSIGN_DECOMID (2, 1, 239)   /* U10 */
+        ASSIGN_DECOMID (3, 6, 240)   /* UU ... VV */
+        ASSIGN_DECOMID (2, 3, 246)   /* WD_H2O2 ... WD_SO2 */
+        ASSIGN_DECOMID (3, 3, 249)   /* WSUB ... aero_water */
+        ASSIGN_DECOMID (2, 32, 252)  /* airFV ... dst_c3SFWET */
+        ASSIGN_DECOMID (3, 1, 284)   /* hstobie_linoz */
+        ASSIGN_DECOMID (2, 129, 285) /* mlip ... soa_c3SFWET */
+    } else {
+        ASSIGN_DECOMID (2, 13, 30) /* CLDHGH ... T5 */
+        ASSIGN_DECOMID (3, 1, 43)  /* U */
+        ASSIGN_DECOMID (2, 7, 44)  /* U250 ... Z500 */
+    }
+
+    pre_timing = MPI_Wtime () - pre_timing;
+
+    MPI_Barrier (cfg.io_comm); /*-----------------------------------------*/
+    timing = MPI_Wtime ();
+
+    /* set output file name */
+    targetfname = std::string (cfg.targetdir) + '/' + outfile;
+
+    /* create a new CDF-5 file for writing */
+    err = driver.create (targetfname, cfg.io_comm, cfg.info, &ncid);
+    CHECK_ERR
+
+    /* define dimensions, variables, and attributes */
+    if (cfg.nvars == 414) {
+        /* for h0 file */
+        err = def_F_case_h0_pio (driver, decom, ncid, decom.dims[2], cfg.nvars, decomids, varids,
+                                 piovars);
+        CHECK_ERR
+    } else {
+        /* for h1 file */
+        err = def_F_case_h1_pio (driver, decom, ncid, decom.dims[2], cfg.nvars, decomids, varids,
+                                 piovars);
+        CHECK_ERR
+    }
+
+    /* exit define mode and enter data mode */
+    err = driver.enddef (ncid);
+    CHECK_ERR
+
+    /* I/O amount so far */
+    err = driver.inq_put_size (ncid, &metadata_size);
+    CHECK_ERR
+    err = driver.inq_file_info (ncid, &info_used);
+    CHECK_ERR
+    open_timing += MPI_Wtime () - timing;
+
+    MPI_Barrier (cfg.io_comm); /*-----------------------------------------*/
+    timing = MPI_Wtime ();
+
+    // Write pio scalar vars (one time)
+    // TODO: only the first subfile contain nproc
+    // nproc
+    err = driver.put_varl (ncid, piovars[5], MPI_LONG_LONG, &(cfg.np), nb);
+    CHECK_ERR
+
+    i           = 0;
+    dbl_buf_ptr = dbl_buf;
+
+    if (xnreqs[1] > 0) {
+        /* lat */
+        MPI_Offset **fix_starts_D2, **fix_counts_D2;
+
+        /* construct varn API arguments starts[][] and counts[][] */
+        int num = xnreqs[1];
+        FIX_1D_VAR_STARTS_COUNTS (fix_starts_D2, fix_counts_D2, num, decom.disps[1],
+                                  decom.blocklens[1]);
+
+        REC_2D_VAR_STARTS_COUNTS (0, starts_D2, counts_D2, xnreqs[1], decom.disps[1],
+                                  decom.blocklens[1]);
+
+        err = IPUT_VARN (ncid, varids[i++], xnreqs[1], fix_starts_D2, fix_counts_D2, dbl_buf_ptr,
+                         nelems[1], MPI_DOUBLE, NULL);
+        CHECK_ERR
+        dbl_buf_ptr += nelems[1] + gap;
+        my_nreqs += xnreqs[1];
+        nvars_D[1]++;
+
+        /* lon */
+        err = IPUT_VARN (ncid, varids[i++], xnreqs[1], fix_starts_D2, fix_counts_D2, dbl_buf_ptr,
+                         nelems[1], MPI_DOUBLE, NULL);
+        CHECK_ERR
+        dbl_buf_ptr += nelems[1] + gap;
+        my_nreqs += xnreqs[1];
+        nvars_D[1]++;
+
+        free (fix_starts_D2[0]);
+        free (fix_starts_D2);
+    } else
+        i += 2;
+
+    /* area */
+    if (xnreqs[0] > 0) {
+        MPI_Offset **fix_starts_D1, **fix_counts_D1;
+
+        /* construct varn API arguments starts[][] and counts[][] */
+        FIX_1D_VAR_STARTS_COUNTS (fix_starts_D1, fix_counts_D1, xnreqs[0], decom.disps[0],
+                                  decom.blocklens[0]);
+
+        err = IPUT_VARN (ncid, varids[i++], xnreqs[0], fix_starts_D1, fix_counts_D1, dbl_buf_ptr,
+                         nelems[0], MPI_DOUBLE, NULL);
+        CHECK_ERR
+        dbl_buf_ptr += nelems[0] + gap;
+        my_nreqs += xnreqs[0];
+        nvars_D[0]++;
+
+        free (fix_starts_D1[0]);
+        free (fix_starts_D1);
+    } else
+        i++;
+
+    /* construct varn API arguments starts[][] and counts[][] */
+    if (xnreqs[2] > 0)
+        REC_3D_VAR_STARTS_COUNTS (0, starts_D3, counts_D3, xnreqs[2], decom.disps[2],
+                                  decom.blocklens[2], decom.dims[2][1]);
+
+    post_timing += MPI_Wtime () - timing;
+
+    for (rec_no = 0; rec_no < cfg.nrec; rec_no++) {
+        MPI_Barrier (cfg.io_comm); /*-----------------------------------------*/
+        timing = MPI_Wtime ();
+
+        // Write PIO decom vars
+        for (j = 0; j < 5; j++) {
+            int piodecomid[] = {0, 1, 1, 1, 2};
+
+            err = driver.put_varl (ncid, piovars[j], MPI_LONG_LONG,
+                                   decom.raw_offsets[piodecomid[j]], nb);
+            CHECK_ERR
+        }
+
+        i           = 3;
+        dbl_buf_ptr = dbl_buf + nelems[1] * 2 + nelems[0] + gap * 3;
+        int_buf_ptr = int_buf;
+        txt_buf_ptr = txt_buf;
+
+        /* next 27 small variables are written by rank 0 only */
+        if (rank == 0) {
+            my_nreqs += 27;
+            /* post nonblocking requests using IPUT_VARN() */
+            err = write_small_vars_F_case_pio (driver, ncid, i, varids, rec_no, gap,
+                                               decom.dims[2][0], decom.dims[2][0] + 1, 2, 8,
+                                               &int_buf_ptr, &txt_buf_ptr, &dbl_buf_ptr);
+            CHECK_ERR
+        }
+        i += 27;
+
+        post_timing += MPI_Wtime () - timing;
+
+        MPI_Barrier (cfg.io_comm); /*-----------------------------------------*/
+        timing = MPI_Wtime ();
+
+        /* flush fixed-size and small variables */
+        err = WAIT_ALL_REQS (ncid, NC_REQ_ALL, NULL, NULL);
+        CHECK_ERR
+
+        wait_timing += MPI_Wtime () - timing;
+
+        MPI_Barrier (cfg.io_comm); /*-----------------------------------------*/
+        timing = MPI_Wtime ();
+
+        rec_buf_ptr = rec_buf;
+
+        for (j = 0; j < xnreqs[1]; j++) starts_D2[j][0] = rec_no;
+        for (j = 0; j < xnreqs[2]; j++) starts_D3[j][0] = rec_no;
+
+        if (cfg.nvars == 414) {
+            if (cfg.two_buf) {
+                /* write 2D variables */
+                POST_VARN (2, 1, 30)    /* AEROD_v */
+                POST_VARN (2, 19, 33)   /* AODABS ... AODVIS */
+                POST_VARN (2, 6, 54)    /* AQ_DMS ... AQ_SOAG */
+                POST_VARN (2, 4, 64)    /* BURDEN1 ... BURDEN4 */
+                POST_VARN (2, 2, 69)    /* CDNUMC and CLDHGH */
+                POST_VARN (2, 3, 73)    /* CLDLOW ... CLDTOT */
+                POST_VARN (2, 11, 80)   /* DF_DMS ... DSTSFMBL */
+                POST_VARN (2, 2, 92)    /* DTENDTH and DTENDTQ */
+                POST_VARN (2, 7, 96)    /* FLDS ... FLUTC */
+                POST_VARN (2, 15, 107)  /* FSDS ... ICEFRAC */
+                POST_VARN (2, 2, 125)   /* LANDFRAC and LHFLX */
+                POST_VARN (2, 1, 131)   /* LINOZ_SFCSINK */
+                POST_VARN (2, 3, 133)   /* LINOZ_SZA ... LWCF */
+                POST_VARN (2, 2, 148)   /* O3_SRF and OCNFRAC */
+                POST_VARN (2, 1, 151)   /* OMEGA500 */
+                POST_VARN (2, 8, 153)   /* PBLH ... PSL */
+                POST_VARN (2, 2, 162)   /* QFLX and QREFHT */
+                POST_VARN (2, 1, 167)   /* RAM1 */
+                POST_VARN (2, 37, 169)  /* SCO ... SNOWHLND */
+                POST_VARN (2, 10, 208)  /* SO2_CLXF ... SWCF */
+                POST_VARN (2, 19, 219)  /* TAUGWX ... TVQ */
+                POST_VARN (2, 1, 239)   /* U10 */
+                POST_VARN (2, 3, 246)   /* WD_H2O2 ... WD_SO2 */
+                POST_VARN (2, 32, 252)  /* airFV ... dst_c3SFWET */
+                POST_VARN (2, 129, 285) /* mlip ... soa_c3SFWET */
+                /* write 3D variables */
+                POST_VARN (3, 2, 31)   /* ANRAIN and ANSNOW */
+                POST_VARN (3, 2, 52)   /* AQRAIN and AQSNOW */
+                POST_VARN (3, 4, 60)   /* AREI ... AWNI */
+                POST_VARN (3, 1, 68)   /* CCN3 */
+                POST_VARN (3, 2, 71)   /* CLDICE and CLDLIQ */
+                POST_VARN (3, 4, 76)   /* CLOUD ... DCQ */
+                POST_VARN (3, 1, 91)   /* DTCOND */
+                POST_VARN (3, 2, 94)   /* EXTINCT and FICE */
+                POST_VARN (3, 4, 103)  /* FREQI ... FREQS */
+                POST_VARN (3, 3, 122)  /* ICIMR ... IWC */
+                POST_VARN (3, 4, 127)  /* LINOZ_DO3 ... LINOZ_O3COL */
+                POST_VARN (3, 1, 132)  /* LINOZ_SSO3 */
+                POST_VARN (3, 12, 136) /* Mass_bc ... O3 */
+                POST_VARN (3, 1, 150)  /* OMEGA */
+                POST_VARN (3, 1, 152)  /* OMEGAT */
+                POST_VARN (3, 1, 161)  /* Q */
+                POST_VARN (3, 3, 164)  /* QRL ... RAINQM */
+                POST_VARN (3, 1, 168)  /* RELHUM */
+                POST_VARN (3, 2, 206)  /* SNOWQM and SO2 */
+                POST_VARN (3, 1, 218)  /* T */
+                POST_VARN (3, 1, 238)  /* U */
+                POST_VARN (3, 6, 240)  /* UU ... VV */
+                POST_VARN (3, 3, 249)  /* WSUB ... aero_water */
+                POST_VARN (3, 1, 284)  /* hstobie_linoz */
+            } else {
+                /* write variables in the same order as they defined */
+                POST_VARN (2, 1, 30)    /* AEROD_v */
+                POST_VARN (3, 2, 31)    /* ANRAIN and ANSNOW */
+                POST_VARN (2, 19, 33)   /* AODABS ... AODVIS */
+                POST_VARN (3, 2, 52)    /* AQRAIN and AQSNOW */
+                POST_VARN (2, 6, 54)    /* AQ_DMS ... AQ_SOAG */
+                POST_VARN (3, 4, 60)    /* AREI ... AWNI */
+                POST_VARN (2, 4, 64)    /* BURDEN1 ... BURDEN4 */
+                POST_VARN (3, 1, 68)    /* CCN3 */
+                POST_VARN (2, 2, 69)    /* CDNUMC and CLDHGH */
+                POST_VARN (3, 2, 71)    /* CLDICE and CLDLIQ */
+                POST_VARN (2, 3, 73)    /* CLDLOW ... CLDTOT */
+                POST_VARN (3, 4, 76)    /* CLOUD ... DCQ */
+                POST_VARN (2, 11, 80)   /* DF_DMS ... DSTSFMBL */
+                POST_VARN (3, 1, 91)    /* DTCOND */
+                POST_VARN (2, 2, 92)    /* DTENDTH and DTENDTQ */
+                POST_VARN (3, 2, 94)    /* EXTINCT and FICE */
+                POST_VARN (2, 7, 96)    /* FLDS ... FLUTC */
+                POST_VARN (3, 4, 103)   /* FREQI ... FREQS */
+                POST_VARN (2, 15, 107)  /* FSDS ... ICEFRAC */
+                POST_VARN (3, 3, 122)   /* ICIMR ... IWC */
+                POST_VARN (2, 2, 125)   /* LANDFRAC and LHFLX */
+                POST_VARN (3, 4, 127)   /* LINOZ_DO3 ... LINOZ_O3COL */
+                POST_VARN (2, 1, 131)   /* LINOZ_SFCSINK */
+                POST_VARN (3, 1, 132)   /* LINOZ_SSO3 */
+                POST_VARN (2, 3, 133)   /* LINOZ_SZA ... LWCF */
+                POST_VARN (3, 12, 136)  /* Mass_bc ... O3 */
+                POST_VARN (2, 2, 148)   /* O3_SRF and OCNFRAC */
+                POST_VARN (3, 1, 150)   /* OMEGA */
+                POST_VARN (2, 1, 151)   /* OMEGA500 */
+                POST_VARN (3, 1, 152)   /* OMEGAT */
+                POST_VARN (2, 8, 153)   /* PBLH ... PSL */
+                POST_VARN (3, 1, 161)   /* Q */
+                POST_VARN (2, 2, 162)   /* QFLX and QREFHT */
+                POST_VARN (3, 3, 164)   /* QRL ... RAINQM */
+                POST_VARN (2, 1, 167)   /* RAM1 */
+                POST_VARN (3, 1, 168)   /* RELHUM */
+                POST_VARN (2, 37, 169)  /* SFDMS ... SNOWHLND */
+                POST_VARN (3, 2, 206)   /* SNOWQM and SO2 */
+                POST_VARN (2, 10, 208)  /* SO2_CLXF ... SWCF */
+                POST_VARN (3, 1, 218)   /* T */
+                POST_VARN (2, 19, 219)  /* TAUGWX ... TVQ */
+                POST_VARN (3, 1, 238)   /* U */
+                POST_VARN (2, 1, 239)   /* U10 */
+                POST_VARN (3, 6, 240)   /* UU ... VV */
+                POST_VARN (2, 3, 246)   /* WD_H2O2 ... WD_SO2 */
+                POST_VARN (3, 3, 249)   /* WSUB ... aero_water */
+                POST_VARN (2, 32, 252)  /* airFV ... dst_c3SFWET */
+                POST_VARN (3, 1, 284)   /* hstobie_linoz */
+                POST_VARN (2, 129, 285) /* mlip ... soa_c3SFWET */
+            }
+        } else {
+            if (cfg.two_buf) {
+                /* write 2D variables followed by 3D variables */
+                POST_VARN (2, 13, 30) /* CLDHGH ... T5 */
+                POST_VARN (2, 7, 44)  /* U250 ... Z500 */
+                POST_VARN (3, 1, 43)  /* U */
+            } else {
+                /* write variables in the same order as they defined */
+                POST_VARN (2, 13, 30) /* CLDHGH ... T5 */
+                POST_VARN (3, 1, 43)  /* U */
+                POST_VARN (2, 7, 44)  /* U250 ... Z500 */
+            }
+        }
+
+        post_timing += MPI_Wtime () - timing;
+
+        MPI_Barrier (cfg.io_comm); /*-----------------------------------------*/
+        timing = MPI_Wtime ();
+
+        err = WAIT_ALL_REQS (ncid, NC_REQ_ALL, NULL, NULL);
+        CHECK_ERR
+
+        wait_timing += MPI_Wtime () - timing;
+    }
+
+    MPI_Barrier (cfg.io_comm); /*-----------------------------------------*/
+    timing = MPI_Wtime ();
+
+    err = driver.inq_put_size (ncid, &total_size);
+    CHECK_ERR
+    put_size = total_size - metadata_size;
+    err      = driver.close (ncid);
+    CHECK_ERR
+    close_timing += MPI_Wtime () - timing;
+
+    if (starts_D3 != NULL) {
+        free (starts_D3[0]);
+        free (starts_D3);
+    }
+    if (starts_D2 != NULL) {
+        free (starts_D2[0]);
+        free (starts_D2);
+    }
+    if (rec_buf != NULL) free (rec_buf);
+    if (dbl_buf != NULL) free (dbl_buf);
+    free (varids);
+
+    total_timing = MPI_Wtime () - total_timing;
+
+    tmp = my_nreqs;
+    MPI_Reduce (&tmp, &max_nreqs, 1, MPI_OFFSET, MPI_MAX, 0, cfg.io_comm);
+    MPI_Reduce (&tmp, &total_nreqs, 1, MPI_OFFSET, MPI_SUM, 0, cfg.io_comm);
+    MPI_Reduce (&put_size, &tmp, 1, MPI_OFFSET, MPI_SUM, 0, cfg.io_comm);
+    put_size = tmp;
+    MPI_Reduce (&total_size, &tmp, 1, MPI_OFFSET, MPI_SUM, 0, cfg.io_comm);
+    total_size = tmp;
+    MPI_Reduce (&open_timing, &max_timing, 1, MPI_DOUBLE, MPI_MAX, 0, cfg.io_comm);
+    open_timing = max_timing;
+    MPI_Reduce (&pre_timing, &max_timing, 1, MPI_DOUBLE, MPI_MAX, 0, cfg.io_comm);
+    pre_timing = max_timing;
+    MPI_Reduce (&post_timing, &max_timing, 1, MPI_DOUBLE, MPI_MAX, 0, cfg.io_comm);
+    post_timing = max_timing;
+    MPI_Reduce (&wait_timing, &max_timing, 1, MPI_DOUBLE, MPI_MAX, 0, cfg.io_comm);
+    wait_timing = max_timing;
+    MPI_Reduce (&close_timing, &max_timing, 1, MPI_DOUBLE, MPI_MAX, 0, cfg.io_comm);
+    close_timing = max_timing;
+    MPI_Reduce (&total_timing, &max_timing, 1, MPI_DOUBLE, MPI_MAX, 0, cfg.io_comm);
+    total_timing = max_timing;
+
+    /* check if there is any PnetCDF internal malloc residue */
+    err = driver.inq_malloc_size (&malloc_size);
+    if (err == NC_NOERR) {
+        MPI_Reduce (&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, cfg.io_comm);
+        if (rank == 0 && sum_size > 0) {
+            printf ("-----------------------------------------------------------\n");
+            printf (
+                "heap memory allocated by PnetCDF internally has %lld bytes yet to be "
+                "freed\n",
+                sum_size);
+        }
+    }
+    driver.inq_malloc_max_size (&m_alloc);
+    MPI_Reduce (&m_alloc, &max_alloc, 1, MPI_OFFSET, MPI_MAX, 0, cfg.io_comm);
+
+    if (rank == 0) {
+        int nvars_noD = cfg.nvars;
+        for (i = 0; i < 3; i++) nvars_noD -= nvars_D[i];
+        printf ("History output file                = %s\n", outfile.c_str ());
+        printf ("No. variables use no decomposition = %3d\n", nvars_noD);
+        printf ("No. variables use decomposition D1 = %3d\n", nvars_D[0]);
+        printf ("No. variables use decomposition D2 = %3d\n", nvars_D[1]);
+        printf ("No. variables use decomposition D3 = %3d\n", nvars_D[2]);
+        printf ("Total number of variables          = %3d\n", cfg.nvars);
+        printf ("MAX heap memory allocated by PnetCDF internally is %.2f MiB\n",
+                (float)max_alloc / 1048576);
+        printf ("Total write amount                 = %.2f MiB = %.2f GiB\n",
+                (double)total_size / 1048576, (double)total_size / 1073741824);
+        printf ("Total number of requests           = %lld\n", total_nreqs);
+        printf ("Max number of requests             = %lld\n", max_nreqs);
+        printf ("Max Time of open + metadata define = %.4f sec\n", open_timing);
+        printf ("Max Time of I/O preparing          = %.4f sec\n", pre_timing);
+        printf ("Max Time of IPUT_VARN              = %.4f sec\n", post_timing);
+        printf ("Max Time of WAIT_ALL_REQS          = %.4f sec\n", wait_timing);
+        printf ("Max Time of close                  = %.4f sec\n", close_timing);
+        printf ("Max Time of TOTAL                  = %.4f sec\n", total_timing);
+        printf ("I/O bandwidth (open-to-close)      = %.4f MiB/sec\n",
+                (double)total_size / 1048576.0 / total_timing);
+        printf ("I/O bandwidth (write-only)         = %.4f MiB/sec\n",
+                (double)put_size / 1048576.0 / wait_timing);
+        if (cfg.verbose) print_info (&info_used);
+        printf ("-----------------------------------------------------------\n");
+    }
+
+err_out:
+    if (info_used != MPI_INFO_NULL) MPI_Info_free (&info_used);
+    if (!cfg.keep_outfile) unlink (targetfname.c_str ());
+    fflush (stdout);
+    MPI_Barrier (cfg.io_comm);
+    return nerrs;
+}

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -46,7 +46,16 @@ typedef float itype; /* internal data type of buffer in memory */
 #define REC_XTYPE NC_FLOAT
 #endif
 
-typedef enum e3sm_io_api { pnc, hdf5_native, hdf5_multi, hdf5_logvol, adios2, adios2_bp3 } e3sm_io_api;
+typedef enum e3sm_io_api {
+    pnc,
+    hdf5_native,
+    hdf5_multi,
+    hdf5_logvol,
+    adios2,
+    adios2_bp3
+} e3sm_io_api;
+
+typedef enum e3sm_io_strate { canonical, blob, log } e3sm_io_strate;
 
 typedef enum e3sm_io_filter { none, deflate, bzip2 } e3sm_io_filter;
 
@@ -67,6 +76,7 @@ typedef struct e3sm_io_config {
     int rd;
     int nvars;
 
+    e3sm_io_strate strate;
     e3sm_io_api api;
     e3sm_io_filter filter;
     size_t chunksize;
@@ -84,7 +94,10 @@ typedef struct e3sm_io_decom {
     int num_decomp;
     int contig_nreqs[MAX_NUM_DECOMP], *disps[MAX_NUM_DECOMP];
     int *blocklens[MAX_NUM_DECOMP];
+    int ndims[MAX_NUM_DECOMP];
     MPI_Offset dims[MAX_NUM_DECOMP][2];
+    MPI_Offset raw_nreqs[MAX_NUM_DECOMP];  // For pio output style
+    MPI_Offset *raw_offsets[MAX_NUM_DECOMP];
 } e3sm_io_decom;
 
 #ifdef __cplusplus
@@ -95,9 +108,12 @@ extern int read_decomp (int verbose,
                         const char *infname,
                         int *num_decomp,
                         MPI_Offset dims[][2],
-                        int contig_nreqs[3],
-                        int *disps[3],
-                        int *blocklens[3]);
+                        int contig_nreqs[],
+                        int var_ndims[],
+                        int *disps[],
+                        int *blocklens[],
+                        MPI_Offset raw_nreqs[],
+                        MPI_Offset *raw_offsets[]);
 
 extern void print_info (MPI_Info *info_used);
 int e3sm_io_core (e3sm_io_config *cfg, e3sm_io_decom *decom);

--- a/src/e3sm_io_core.cpp
+++ b/src/e3sm_io_core.cpp
@@ -60,7 +60,14 @@ extern "C" int e3sm_io_core (e3sm_io_config *cfg, e3sm_io_decom *decom) {
     /* F case has 3 decompositions, G case has 6 */
     if (decom->num_decomp == 3) {
         cfg->nvars = 414;
-        tcase      = new e3sm_io_case_F ();
+        switch (cfg->strate) {
+            case canonical:
+                tcase = new e3sm_io_case_F ();
+                break;
+            case blob:
+                tcase = new e3sm_io_case_F_pio ();
+                break;
+        }
     } else if (decom->num_decomp == 6) {
         cfg->nvars = 52;
         tcase      = new e3sm_io_case_G ();
@@ -77,7 +84,7 @@ err_out:
 
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_TOTAL)
 
-    e3sm_io_print_profile(cfg);
+    e3sm_io_print_profile (cfg);
 
     return nerrs;
 }

--- a/src/read_decomp.c
+++ b/src/read_decomp.c
@@ -111,12 +111,16 @@ int read_decomp(int verbose,
                 int *num_decomp,      /* OUT: */
                 MPI_Offset  dims[][2],/* OUT: [num_decomp][2] */
                 int contig_nreqs[],   /* OUT: [num_decomp] */
+                int var_ndims[],   /* OUT */
                 int *disps[],         /* OUT: [num_decomp][contig_nreqs[]] */
-                int *blocklens[])     /* OUT: [num_decomp][contig_nreqs[]] */
+                int *blocklens[],     /* OUT: [num_decomp][contig_nreqs[]] */
+                MPI_Offset raw_nreqs[],    /* OUT */
+                 MPI_Offset *raw_offsets[]) /* OUT: to be freed by caller */
 {
     char name[128];
     int err, nerrs = 0, rank, nprocs, ncid, varid, proc_start, proc_count;
     int i, j, nreqs, *all_nreqs, ndims, dimids[2], decomp_id;
+    int64_t k;
     MPI_Offset num, decomp_nprocs, total_nreqs, start, count;
     struct off_len *myreqs;
 
@@ -169,6 +173,10 @@ int read_decomp(int verbose,
         contig_nreqs[decomp_id] = 0;
         disps[decomp_id]        = NULL;
         blocklens[decomp_id]    = NULL;
+        if(raw_nreqs){
+            raw_nreqs[decomp_id]    = 0;
+            raw_offsets[decomp_id]  = NULL;
+        }
 
         /* total number of noncontiguous requests of all processes */
         sprintf(name, "D%d.total_nreqs", decomp_id + 1);
@@ -186,10 +194,17 @@ int read_decomp(int verbose,
         err = ncmpi_inq_attlen(ncid, NC_GLOBAL, name, &num);
         CHECK_ERR
         ndims=num;
+        var_ndims[decomp_id] = ndims;
         /* obtain the dimension lengths of this decomposition */
         err = ncmpi_get_att_longlong(ncid, NC_GLOBAL, name, dims[decomp_id]);
         CHECK_ERR
 
+        /*
+                sprintf (name, "D%d.max_raw_nreqs", decomp_id + 1);
+                /* obtain the number of requests before merging
+                err = ncmpi_get_att_longlong (ncid, NC_GLOBAL, name, raw_nreqs + decomp_id);
+                CHECK_ERR
+        */
         /* obtain varid of request variable Dx.nreqs */
         sprintf(name, "D%d.nreqs", decomp_id + 1);
         err = ncmpi_inq_varid(ncid, name, &varid);
@@ -244,6 +259,11 @@ int read_decomp(int verbose,
         for (i = 0; i < nreqs; i++) {
             disps[decomp_id][i]     = myreqs[i].off;
             blocklens[decomp_id][i] = myreqs[i].len;
+
+            // Count number of offsets without merge
+            if(raw_nreqs){
+                raw_nreqs[decomp_id] += blocklens[decomp_id][i];
+            }
         }
         free(myreqs);
 
@@ -263,6 +283,18 @@ int read_decomp(int verbose,
         }
         /* update number of true noncontiguous requests */
         if (nreqs > 0) contig_nreqs[decomp_id] = j + 1;
+
+        /* Generate (simualted) raw decomposition map */
+        if(raw_offsets){
+            raw_offsets[decomp_id] =
+                (MPI_Offset *)malloc ((size_t) (raw_nreqs[decomp_id]) * sizeof (MPI_Offset));
+            memset (raw_offsets[decomp_id], 0, (size_t) (raw_nreqs[decomp_id]) * sizeof (MPI_Offset));
+            for (i = j = 0; i < contig_nreqs[decomp_id]; i++) {
+                for (k = disps[decomp_id][i]; k < disps[decomp_id][i] + blocklens[decomp_id][i]; k++) {
+                    raw_offsets[decomp_id][j++] = k;
+                }
+            }
+        }
 
         if (verbose) {
             int min_blocklen = blocklens[decomp_id][0];

--- a/utils/dat2nc.c
+++ b/utils/dat2nc.c
@@ -137,8 +137,8 @@ static int add_decomp (int ncid, const char *infname, int label) {
             nreqs[rank++] = 0;
 
         nreqs[rank] = atoi (strtok (NULL, " ")); /* number of requests */
-        if (nreqs[rank] == 0)                    /* this rank has zero request */
-            continue;                            /* loop of rank */
+        if (nreqs[rank] == 0) /* this rank has zero request */
+            continue;         /* loop of rank */
 
         off = (int *)malloc (nreqs[rank] * sizeof (int));
         fgets (buf, LINE_SIZE + 1, fd); /* 2nd line: list of offsets */


### PR DESCRIPTION
Simulate raw decomposition map when reading parsed decomposition file; Add command line option of I/O strategy (native/pio); Record dimensions as scalar variables instead of attribute in adios2 driver to match the behavior of scorpio;