### PR TITLE
fix bug of setting info before reading decom files

### DIFF
--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -272,11 +272,6 @@ int main (int argc, char **argv) {
     PRINT_MSG (1, "Target folder name =%s\n", cfg.targetdir);
     if (cfg.datadir[0] != '\0') { PRINT_MSG (1, "Input folder name =%s\n", cfg.datadir); }
 
-    err = MPI_Info_create (&(cfg.info));
-    CHECK_MPIERR
-    nerrs += set_info (&cfg, &decom);
-    CHECK_NERR
-
     /* read request information from decompositions 1, 2 and 3 */
     if (cfg.strate == log) {
         err = read_decomp (cfg.verbose, cfg.io_comm, cfg.cfgpath, &(decom.num_decomp), decom.dims,
@@ -289,6 +284,11 @@ int main (int argc, char **argv) {
                          decom.contig_nreqs, decom.ndims, decom.disps, decom.blocklens, NULL, NULL);
     }
     CHECK_ERR
+
+    err = MPI_Info_create (&(cfg.info));
+    CHECK_MPIERR
+    nerrs += set_info (&cfg, &decom);
+    CHECK_NERR
 
     nerrs += e3sm_io_core (&cfg, &decom);
 


### PR DESCRIPTION
Some MPI info depends on the decomposition map. It has to be calculated after the decomposition map is read.