### PR TITLE
Fix valgrind warning

### DIFF
--- a/src/cases/var_io_F_case.cpp
+++ b/src/cases/var_io_F_case.cpp
@@ -1026,9 +1026,9 @@ int run_varn_F_case (e3sm_io_config &cfg,
 
     /* allocate and initialize write buffer for large variables */
     if (cfg.nvars == 414)
-        rec_buflen = nelems[1] * 321 + nelems[2] * 63 + (321 + 63) * gap;
+        rec_buflen = nelems[1] * 323 + nelems[2] * 63 + (323 + 63) * gap;
     else
-        rec_buflen = nelems[1] * 20 + nelems[2] + (20 + 1) * gap;
+        rec_buflen = nelems[1] * 22 + nelems[2] + (20 + 1) * gap;
 
     if (rec_bufp != NULL) {
         rec_buf = rec_bufp;

--- a/src/cases/var_io_F_case_pio.cpp
+++ b/src/cases/var_io_F_case_pio.cpp
@@ -431,9 +431,9 @@ int run_varn_F_case_pio (e3sm_io_config &cfg,
 
     /* allocate and initialize write buffer for large variables */
     if (cfg.nvars == 414)
-        rec_buflen = nelems[1] * 321 + nelems[2] * 63 + (321 + 63) * gap;
+        rec_buflen = nelems[1] * 323 + nelems[2] * 63 + (323 + 63) * gap;
     else
-        rec_buflen = nelems[1] * 20 + nelems[2] + (20 + 1) * gap;
+        rec_buflen = nelems[1] * 22 + nelems[2] + (20 + 1) * gap;
 
     if (rec_bufp != NULL) {
         rec_buf = rec_bufp;

--- a/src/drivers/e3sm_io_driver.hpp
+++ b/src/drivers/e3sm_io_driver.hpp
@@ -14,6 +14,7 @@ class e3sm_io_driver {
 
    public:
     e3sm_io_driver (e3sm_io_config *cfg) : cfg (cfg) {};
+    virtual ~e3sm_io_driver (){   };
     virtual int create (std::string path, MPI_Comm comm, MPI_Info info, int *fid) = 0;
     virtual int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid)   = 0;
     virtual int close (int fid)                                                   = 0;
@@ -27,29 +28,25 @@ class e3sm_io_driver {
         int fid, std::string name, MPI_Datatype type, int ndim, int *dimids, int *did) = 0;
     virtual int def_local_var (
         int fid, std::string name, MPI_Datatype type, int ndim, MPI_Offset *dsize, int *did) = 0;
-    virtual int inq_var (int fid, std::string name, int *did)                          = 0;
-    virtual int inq_var_off (int fid, int vid, MPI_Offset *off)                        = 0;
-    virtual int def_dim (int fid, std::string name, MPI_Offset size, int *dimid)       = 0;
-    virtual int inq_dim (int fid, std::string name, int *dimid)                        = 0;
-    virtual int inq_dimlen (int fid, int dimid, MPI_Offset *size)                      = 0;
-    virtual int enddef (int fid)                                                       = 0;
-    virtual int redef (int fid)                                                        = 0;
-    virtual int wait (int fid)                                                         = 0;
+    virtual int inq_var (int fid, std::string name, int *did)                                = 0;
+    virtual int inq_var_off (int fid, int vid, MPI_Offset *off)                              = 0;
+    virtual int def_dim (int fid, std::string name, MPI_Offset size, int *dimid)             = 0;
+    virtual int inq_dim (int fid, std::string name, int *dimid)                              = 0;
+    virtual int inq_dimlen (int fid, int dimid, MPI_Offset *size)                            = 0;
+    virtual int enddef (int fid)                                                             = 0;
+    virtual int redef (int fid)                                                              = 0;
+    virtual int wait (int fid)                                                               = 0;
     virtual int put_att (
-        int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf) = 0;
-    virtual int get_att (int fid, int vid, std::string name, void *buf)                    = 0;
-    virtual int put_varl (int fid,
-                          int vid,
-                          MPI_Datatype type,
-                          void *buf,
-                          e3sm_io_op_mode mode)                                            = 0;
+        int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf)      = 0;
+    virtual int get_att (int fid, int vid, std::string name, void *buf)                         = 0;
+    virtual int put_varl (int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode) = 0;
     virtual int put_vara (int fid,
                           int vid,
                           MPI_Datatype type,
                           MPI_Offset *start,
                           MPI_Offset *count,
                           void *buf,
-                          e3sm_io_op_mode mode)                                            = 0;
+                          e3sm_io_op_mode mode)                                                 = 0;
     virtual int put_vars (int fid,
                           int vid,
                           MPI_Datatype type,
@@ -57,7 +54,7 @@ class e3sm_io_driver {
                           MPI_Offset *count,
                           MPI_Offset *stride,
                           void *buf,
-                          e3sm_io_op_mode mode)                                            = 0;
+                          e3sm_io_op_mode mode)                                                 = 0;
     virtual int put_varn (int fid,
                           int vid,
                           MPI_Datatype type,
@@ -65,21 +62,21 @@ class e3sm_io_driver {
                           MPI_Offset **starts,
                           MPI_Offset **counts,
                           void *buf,
-                          e3sm_io_op_mode mode)                                            = 0;
+                          e3sm_io_op_mode mode)                                                 = 0;
     virtual int put_vard (int fid,
                           int vid,
                           MPI_Datatype type,
                           MPI_Offset nelem,
                           MPI_Datatype ftype,
                           void *buf,
-                          e3sm_io_op_mode mode)                                            = 0;
+                          e3sm_io_op_mode mode)                                                 = 0;
     virtual int get_vara (int fid,
                           int vid,
                           MPI_Datatype type,
                           MPI_Offset *start,
                           MPI_Offset *count,
                           void *buf,
-                          e3sm_io_op_mode mode)                                            = 0;
+                          e3sm_io_op_mode mode)                                                 = 0;
     virtual int get_vars (int fid,
                           int vid,
                           MPI_Datatype type,
@@ -87,7 +84,7 @@ class e3sm_io_driver {
                           MPI_Offset *count,
                           MPI_Offset *stride,
                           void *buf,
-                          e3sm_io_op_mode mode)                                            = 0;
+                          e3sm_io_op_mode mode)                                                 = 0;
     virtual int get_varn (int fid,
                           int vid,
                           MPI_Datatype type,
@@ -95,12 +92,12 @@ class e3sm_io_driver {
                           MPI_Offset **starts,
                           MPI_Offset **counts,
                           void *buf,
-                          e3sm_io_op_mode mode)                                            = 0;
+                          e3sm_io_op_mode mode)                                                 = 0;
     virtual int get_vard (int fid,
                           int vid,
                           MPI_Datatype type,
                           MPI_Offset nelem,
                           MPI_Datatype ftype,
                           void *buf,
-                          e3sm_io_op_mode mode)                                            = 0;
+                          e3sm_io_op_mode mode)                                                 = 0;
 };

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -17,6 +17,7 @@
 #include <unistd.h>
 //
 #include <adios2_c.h>
+#include <mpi.h>
 //
 #include <e3sm_io.h>
 #include <e3sm_io_err.h>
@@ -60,12 +61,16 @@ size_t adios2_type_size (adios2_type type) {
     return 0;
 }
 
-e3sm_io_driver_adios2::e3sm_io_driver_adios2 (e3sm_io_config *cfg) : e3sm_io_driver (cfg) {}
+e3sm_io_driver_adios2::e3sm_io_driver_adios2 (e3sm_io_config *cfg) : e3sm_io_driver (cfg) {
+    twrite = tsel = text = 0;
+}
 
 e3sm_io_driver_adios2::~e3sm_io_driver_adios2 () {
     int nerrs = 0;
     int rank;
     double tsel_all, twrite_all, text_all;
+
+    // printf("adios2 destructor\n");
 
     MPI_Allreduce (&twrite, &twrite_all, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
     MPI_Allreduce (&tsel, &tsel_all, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
@@ -219,6 +224,7 @@ static MPI_Offset get_dir_size (std::string path) {
                 total_size += (MPI_Offset)size;
             }
         }
+        closedir (dir);
     } else {  // Try again as file
         struct stat file_stat;
         stat (path.c_str (), &file_stat);

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -34,6 +34,8 @@ e3sm_io_driver_pnc::e3sm_io_driver_pnc (e3sm_io_config *cfg) : e3sm_io_driver (c
     }
 }
 
+e3sm_io_driver_pnc::~e3sm_io_driver_pnc () {}
+
 int e3sm_io_driver_pnc::create (std::string path, MPI_Comm comm, MPI_Info info, int *fid) {
     int err, nerrs = 0;
     MPI_Offset put_buffer_size_limit;

--- a/src/drivers/e3sm_io_driver_pnc.hpp
+++ b/src/drivers/e3sm_io_driver_pnc.hpp
@@ -43,6 +43,7 @@ class e3sm_io_driver_pnc : public e3sm_io_driver {
 
    public:
     e3sm_io_driver_pnc (e3sm_io_config *cfg);
+    ~e3sm_io_driver_pnc ();
     int create (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
     int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
     int close (int fid);

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -129,6 +129,7 @@ int main (int argc, char **argv) {
     cfg.nvars          = 0;
     cfg.strate         = canonical;
     cfg.api            = pnc;
+    cfg.chunksize      = 0;
     cfg.filter         = none;
     cfg.vard           = 0;
     cfg.verbose        = 0;
@@ -273,6 +274,11 @@ int main (int argc, char **argv) {
     if (cfg.datadir[0] != '\0') { PRINT_MSG (1, "Input folder name =%s\n", cfg.datadir); }
 
     /* read request information from decompositions 1, 2 and 3 */
+    for (i = 0; i < MAX_NUM_DECOMP; i++) {
+        decom.blocklens[i]   = NULL;
+        decom.disps[i]       = NULL;
+        decom.raw_offsets[i] = NULL;
+    }
     if (cfg.strate == log) {
         err = read_decomp (cfg.verbose, cfg.io_comm, cfg.cfgpath, &(decom.num_decomp), decom.dims,
                            decom.contig_nreqs, decom.ndims, decom.disps, decom.blocklens,
@@ -296,6 +302,13 @@ err_out:;
     if (cfg.info != MPI_INFO_NULL) MPI_Info_free (&(cfg.info));
     if (cfg.io_comm != MPI_COMM_WORLD && cfg.io_comm != MPI_COMM_NULL) {
         MPI_Comm_free (&(cfg.io_comm));
+    }
+
+    // Free decom
+    for (i = 0; i < MAX_NUM_DECOMP; i++) {
+        if (decom.blocklens[i]) { free (decom.blocklens[i]); }
+        if (decom.disps[i]) { free (decom.disps[i]); }
+        if (decom.raw_offsets[i]) { free (decom.raw_offsets[i]); }
     }
 
     /* Non-IO tasks wait for IO tasks to complete */


### PR DESCRIPTION
 Fix valgrind warning in F case test:
    F case recently added some new variables.
    However, the data buffer size were still calculated based on old configuration.
    The bug cause the test to access beyond allocated data buffer, triggering valgrind warnings and potential segmentation faults.
    The fix calculate the data buffer size based on the latest F case variable counts.
    The blob version of the F case is also updated.

fix valgrind warning in API driver interface:
    The member contains in the driver object was not cleaned up when the driver is deleted.
    The destructor must present in the base class for C++ to call the destructor of
    member classes when deleting objects.
    The fix defines a destructor in each driver class, the destructor of
    member classes will then be called automatically when the driver is
    deleted.

fix valgrind warning in e3sm_io.c:
    Memory leak on decomposition map. The decomposition map must be freed by the caller. Free decomposition map if it is allocated before exit.
    Branch depends on un-initialized memory: some options does not have
    default value. Set a default value for all fields in variable "config" and "decom" in function "main".
