### PR TITLE
Fix some small bugs

### DIFF
--- a/src/cases/e3sm_io_case_F.cpp
+++ b/src/cases/e3sm_io_case_F.cpp
@@ -88,7 +88,7 @@ int e3sm_io_case_F::wr_test (e3sm_io_config &cfg, e3sm_io_decom &decom, e3sm_io_
                                       this->rec_buf_h0, this->txt_buf[0], this->int_buf[0]);
         }
 
-        if (cfg.hx == 0 || cfg.hx == -1) {
+        if (cfg.hx == 1 || cfg.hx == -1) {
             MPI_Barrier (cfg.io_comm);
             cfg.nvars = 51;
             nerrs += run_varn_F_case (cfg, decom, driver, "f_case_h1_varn.nc", this->dbl_buf_h0,

--- a/src/cases/e3sm_io_case_F_pio.cpp
+++ b/src/cases/e3sm_io_case_F_pio.cpp
@@ -71,7 +71,7 @@ int e3sm_io_case_F_pio::wr_test (e3sm_io_config &cfg,
                                           this->rec_buf_h0, this->txt_buf[0], this->int_buf[0]);
         }
 
-        if (cfg.hx == 0 || cfg.hx == -1) {
+        if (cfg.hx == 1 || cfg.hx == -1) {
             MPI_Barrier (cfg.io_comm);
             cfg.nvars = 51;
             nerrs += run_varn_F_case_pio (cfg, decom, driver, "f_case_h1_varn.nc", this->dbl_buf_h0,

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -550,6 +550,8 @@ int e3sm_io_driver_adios2::put_varl (
 
     did = fp->dids[vid];
 
+    te = MPI_Wtime ();
+
     switch (mode) {
         case indep:
         case coll: {

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -57,7 +57,7 @@ int e3sm_io_driver_pnc::create (std::string path, MPI_Comm comm, MPI_Info info, 
 
     put_buffer_size_limit = 10485760;
     err                   = ncmpi_buffer_attach (*fid, put_buffer_size_limit);
-    CHECK_ERR
+    CHECK_NCERR
 
 err_out:;
     return nerrs;
@@ -77,7 +77,7 @@ int e3sm_io_driver_pnc::close (int fid) {
     int err, nerrs = 0;
 
     err = ncmpi_buffer_detach (fid);
-    CHECK_ERR
+    CHECK_NCERR
 
     err = ncmpi_close (fid);
     CHECK_NCERR
@@ -173,7 +173,7 @@ int e3sm_io_driver_pnc::def_var (
 
         if (csize > 0) {
             err = ncmpi_put_att_int (fid, *did, "_chunkdim", NC_INT, ndim, cdim);
-            CHECK_ERR
+            CHECK_NCERR
 
             switch (cfg->filter) {
                 case none:
@@ -181,7 +181,7 @@ int e3sm_io_driver_pnc::def_var (
                 case deflate:
                     tsize = 2;  // TODO: Use formal PnetCDF filter ID
                     err   = ncmpi_put_att_int (fid, *did, "_zipdriver", NC_INT, 1, &tsize);
-                    CHECK_ERR
+                    CHECK_NCERR
                     break;
                 default:
                     RET_ERR ("Unknown filter")

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -122,7 +122,7 @@ int main (int argc, char **argv) {
     cfg.targetdir      = targetdir;
     cfg.datadir        = datadir;
     cfg.cfgpath        = cfgpath;
-    cfg.hx             = 0;
+    cfg.hx             = -1;
     cfg.nrec           = 1;
     cfg.wr             = 0;
     cfg.rd             = 0;

--- a/src/read_decomp.c
+++ b/src/read_decomp.c
@@ -120,7 +120,6 @@ int read_decomp(int verbose,
     char name[128];
     int err, nerrs = 0, rank, nprocs, ncid, varid, proc_start, proc_count;
     int i, j, nreqs, *all_nreqs, ndims, dimids[2], decomp_id;
-    int64_t k;
     MPI_Offset num, decomp_nprocs, total_nreqs, start, count;
     struct off_len *myreqs;
 
@@ -199,12 +198,6 @@ int read_decomp(int verbose,
         err = ncmpi_get_att_longlong(ncid, NC_GLOBAL, name, dims[decomp_id]);
         CHECK_ERR
 
-        /*
-                sprintf (name, "D%d.max_raw_nreqs", decomp_id + 1);
-                /* obtain the number of requests before merging
-                err = ncmpi_get_att_longlong (ncid, NC_GLOBAL, name, raw_nreqs + decomp_id);
-                CHECK_ERR
-        */
         /* obtain varid of request variable Dx.nreqs */
         sprintf(name, "D%d.nreqs", decomp_id + 1);
         err = ncmpi_inq_varid(ncid, name, &varid);
@@ -286,9 +279,14 @@ int read_decomp(int verbose,
 
         /* Generate (simualted) raw decomposition map */
         if(raw_offsets){
+            int k;
+            
             raw_offsets[decomp_id] =
                 (MPI_Offset *)malloc ((size_t) (raw_nreqs[decomp_id]) * sizeof (MPI_Offset));
+            CHECK_PTR(raw_offsets[decomp_id])
+            
             memset (raw_offsets[decomp_id], 0, (size_t) (raw_nreqs[decomp_id]) * sizeof (MPI_Offset));
+            
             for (i = j = 0; i < contig_nreqs[decomp_id]; i++) {
                 for (k = disps[decomp_id][i]; k < disps[decomp_id][i] + blocklens[decomp_id][i]; k++) {
                     raw_offsets[decomp_id][j++] = k;


### PR DESCRIPTION
F case should run both H1 and dH0 by default.
Correct the condition to run H1.
PnetCDF return value should be NC_NOERR instead of 0.
Fix a bug in adios2 local variable write profiling timers not initialized.
Add memory allocation check in read_decomp.