### PR TITLE
Fix a bug that fails blob I/O strategy:

### DIFF
--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -279,7 +279,7 @@ int main (int argc, char **argv) {
         decom.disps[i]       = NULL;
         decom.raw_offsets[i] = NULL;
     }
-    if (cfg.strate == log) {
+    if (cfg.strate == blob) {
         err = read_decomp (cfg.verbose, cfg.io_comm, cfg.cfgpath, &(decom.num_decomp), decom.dims,
                            decom.contig_nreqs, decom.ndims, decom.disps, decom.blocklens,
                            decom.raw_nreqs, decom.raw_offsets);


### PR DESCRIPTION
The condition to allocate raw  decomposition map when reading the decomposition file was wrong.
The raw decomposition map is needed by blob I/O strategy instead of log I/O strategy.
The bug causes segmentation fault as the raw decomposition is not allocated when the test case access it.
It is corrected in this commit.