### PR TITLE
Remove command-line subfiling option '-g'

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,6 @@ sharing Decomposition 4, 2 sharing Decomposition 5, and 4 sharing Decomposition
        [-f num] File number to run in F case (-1 (both) (default), 0, 1)
        [-r num] Number of records (default 1)
        [-s num] Stride between IO tasks (default 1)
-       [-g num] Number of IO groups (subfiles) (default 1)
        [-o output_dir] Output directory name (default ./)
        [-i target_dir] Path to directory containing the input files
        [-a api] Underlying API to test (pnc (default), hdf5, hdf5_logvol, hdf5_multi, adios2, adios2_bp3)

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -116,9 +116,7 @@ int e3sm_io_driver_adios2::create (std::string path, MPI_Comm comm, MPI_Info inf
         aerr = adios2_set_engine (fp->iop, "BP4");
     }
     CHECK_AERR
-
-    sprintf (ng, "%d", cfg->num_group);
-    aerr = adios2_set_parameter (fp->iop, "substreams", ng);
+    aerr = adios2_set_parameter (fp->iop, "substreams", "1");
     CHECK_AERR
     aerr = adios2_set_parameter (fp->iop, "CollectiveMetadata", "OFF");
     CHECK_AERR

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -89,8 +89,6 @@ e3sm_io_driver_hdf5::e3sm_io_driver_hdf5 (e3sm_io_config *cfg) : e3sm_io_driver 
         throw "Fitler requries chunking in HDF5";
     }
 
-    if (cfg->num_group != 1) { throw "Subfiling not supported by HDF5 driver"; }
-
     /*
     env = getenv ("E3SM_IO_HDF5_ENABLE_LOGVOL");
     if (env) {

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -46,12 +46,6 @@ int e3sm_io_driver_pnc::create (std::string path, MPI_Comm comm, MPI_Info info, 
         MPI_Info_set (info, "nc_zip_comm_unit", "chunk");
     }
 
-    if (cfg->num_group > 1) {
-        char ng[32];
-        sprintf (ng, "%d", cfg->num_group);
-        MPI_Info_set (info, "nc_num_subfiles", ng);
-    }
-
     err = ncmpi_create (comm, path.c_str (), NC_CLOBBER | NC_64BIT_DATA, info, fid);
     CHECK_NCERR
 

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -88,7 +88,6 @@ static void usage (char *argv0) {
         "       [-f num] File number to run in F case (-1 (both) (default), 0, 1)\n"
         "       [-r num] Number of records (default 1)\n"
         "       [-s num] Stride between IO tasks (default 1)\n"
-        "       [-g num] Number of IO groups (subfiles) (default 1)\n"
         "       [-o output_dir] Output directory name (default ./)\n"
         "       [-i target_dir] Path to directory containing the input files\n"
         "       [-a api] Underlying API to test (pnc (default), hdf5, hdf5_logvol, hdf5_multi, "
@@ -118,7 +117,6 @@ int main (int argc, char **argv) {
     cfg.io_comm        = MPI_COMM_WORLD;
     cfg.info           = MPI_INFO_NULL;
     cfg.num_iotasks    = cfg.np;
-    cfg.num_group      = 1;
     cfg.targetdir      = targetdir;
     cfg.datadir        = datadir;
     cfg.cfgpath        = cfgpath;
@@ -206,7 +204,6 @@ int main (int argc, char **argv) {
                     RET_ERR ("Unknown I/O strategy")
                 }
                 break;
-
             case 'o':
                 strncpy (cfg.targetdir, optarg, E3SM_IO_MAX_PATH);
                 break;

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -65,7 +65,6 @@ typedef struct e3sm_io_config {
     MPI_Comm io_comm;
     MPI_Info info;
     int num_iotasks;
-    int num_group;
 
     char *targetdir;
     char *datadir;


### PR DESCRIPTION
E3SM does not directly control subfiling setting.
Subfiling is enabled by Scorpio library when ADIOS method is used and the setting is
one subfile per compute node, i.e. all MPI processes running on the same compute
node write to the same subfile.

To match with this behavior, this PR removes the command-line option '-g'.
Thus, subfiling will be enabled when 'blob' I/O strategy is enabled and the
underlying I/O methods support it.