### PR TITLE
Support sub-filing in F case blob strategy

### DIFF
--- a/src/cases/e3sm_io_case_F_pio.hpp
+++ b/src/cases/e3sm_io_case_F_pio.hpp
@@ -20,6 +20,7 @@
 #include <e3sm_io_driver.hpp>
 
 int def_F_case_h0_pio (e3sm_io_driver &driver,
+                       e3sm_io_config &cfg,
                        e3sm_io_decom &decom,
                        int ncid,                 /* file ID */
                        const MPI_Offset dims[2], /* dimension sizes */
@@ -29,6 +30,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
                        int *piovars);
 
 int def_F_case_h1_pio (e3sm_io_driver &driver,
+                       e3sm_io_config &cfg,
                        e3sm_io_decom &decom,
                        int ncid,                 /* file ID */
                        const MPI_Offset dims[2], /* dimension sizes */

--- a/src/cases/header_io_F_case_pio.cpp
+++ b/src/cases/header_io_F_case_pio.cpp
@@ -40,6 +40,7 @@ static char attbuf[4096];
 
 /*----< def_F_case_h0_pio() >----------------------------------------------------*/
 int def_F_case_h0_pio (e3sm_io_driver &driver,
+                       e3sm_io_config &cfg,
                        e3sm_io_decom &decom,
                        int ncid,                 /* file ID */
                        const MPI_Offset dims[2], /* dimension sizes */
@@ -181,7 +182,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     i = 0;
 
     dimids[0] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lat", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "lat", MPI_DOUBLE, 1,
                                   dimids, &lat);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, lat, "long_name", 8, "latitude");
@@ -191,7 +192,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = lat;
 
     dimids[0] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lon", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "lon", MPI_DOUBLE, 1,
                                   dimids, &lon);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, lon, "long_name", 9, "longitude");
@@ -201,7 +202,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = lon;
 
     dimids[0] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "area", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "area", MPI_DOUBLE, 1,
                                   dimids, &area);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, area, "long_name", 14, "gll grid areas");
@@ -209,7 +210,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = area;
 
     dimids[0] = dim_lev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lev", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "lev", MPI_DOUBLE, 1,
                                   dimids, &lev);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, lev, "long_name", 38, "hybrid level at midpoints (1000*(A+B))");
@@ -226,7 +227,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = lev;
 
     dimids[0] = dim_lev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hyam", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "hyam", MPI_DOUBLE, 1,
                                   dimids, &hyam);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, hyam, "long_name", 39, "hybrid A coefficient at layer midpoints");
@@ -234,7 +235,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = hyam;
 
     dimids[0] = dim_lev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hybm", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "hybm", MPI_DOUBLE, 1,
                                   dimids, &hybm);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, hybm, "long_name", 39, "hybrid B coefficient at layer midpoints");
@@ -242,7 +243,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = hybm;
 
     dimids[0] = dim_lev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "P0", MPI_DOUBLE, 0,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "P0", MPI_DOUBLE, 0,
                                   NULL, &P0);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, P0, "long_name", 18, "reference pressure");
@@ -252,7 +253,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = P0;
 
     dimids[0] = dim_ilev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ilev", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ilev", MPI_DOUBLE, 1,
                                   dimids, &ilev);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ilev, "long_name", 39, "hybrid level at interfaces (1000*(A+B))");
@@ -269,7 +270,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = ilev;
 
     dimids[0] = dim_ilev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hyai", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "hyai", MPI_DOUBLE, 1,
                                   dimids, &hyai);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, hyai, "long_name", 40, "hybrid A coefficient at layer interfaces");
@@ -277,7 +278,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = hyai;
 
     dimids[0] = dim_ilev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hybi", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "hybi", MPI_DOUBLE, 1,
                                   dimids, &hybi);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, hybi, "long_name", 40, "hybrid B coefficient at layer interfaces");
@@ -285,7 +286,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = hybi;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "time", MPI_DOUBLE, 1,
                                   dimids, &time);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, time, "long_name", 4, "time");
@@ -299,7 +300,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = time;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "date", MPI_INT, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "date", MPI_INT, 1,
                                   dimids, &date);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, date, "long_name", 23, "current date (YYYYMMDD)");
@@ -307,7 +308,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = date;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "datesec", MPI_INT, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "datesec", MPI_INT, 1,
                                   dimids, &datesec);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, datesec, "long_name", 31, "current seconds of current date");
@@ -316,7 +317,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_nbnd;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time_bnds", MPI_DOUBLE,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "time_bnds", MPI_DOUBLE,
                                   2, dimids, &time_bnds);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, time_bnds, "long_name", 23, "time interval endpoints");
@@ -325,46 +326,46 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_chars;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "date_written",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "date_written",
                                   MPI_CHAR, 2, dimids, &date_written);
     CHECK_ERR
     varids[i++] = date_written;
 
     dimids[0] = dim_time;
     dimids[1] = dim_chars;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time_written",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "time_written",
                                   MPI_CHAR, 2, dimids, &time_written);
     CHECK_ERR
     varids[i++] = time_written;
 
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ndbase", MPI_INT, 0,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ndbase", MPI_INT, 0,
                                   NULL, &ndbase);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ndbase, "long_name", 8, "base day");
     CHECK_ERR
     varids[i++] = ndbase;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nsbase", MPI_INT, 0,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "nsbase", MPI_INT, 0,
                                   NULL, &nsbase);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, nsbase, "long_name", 19, "seconds of base day");
     CHECK_ERR
     varids[i++] = nsbase;
 
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nbdate", MPI_INT, 0,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "nbdate", MPI_INT, 0,
                                   NULL, &nbdate);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, nbdate, "long_name", 20, "base date (YYYYMMDD)");
     CHECK_ERR
     varids[i++] = nbdate;
 
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nbsec", MPI_INT, 0,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "nbsec", MPI_INT, 0,
                                   NULL, &nbsec);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, nbsec, "long_name", 20, "seconds of base date");
     CHECK_ERR
     varids[i++] = nbsec;
 
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mdt", MPI_INT, 0, NULL,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mdt", MPI_INT, 0, NULL,
                                   &mdt);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mdt, "long_name", 8, "timestep");
@@ -374,7 +375,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = mdt;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ndcur", MPI_INT, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ndcur", MPI_INT, 1,
                                   dimids, &ndcur);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ndcur, "long_name", 27, "current day (from base day)");
@@ -382,7 +383,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = ndcur;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nscur", MPI_INT, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "nscur", MPI_INT, 1,
                                   dimids, &nscur);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, nscur, "long_name", 30, "current seconds of current day");
@@ -390,7 +391,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = nscur;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "co2vmr", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "co2vmr", MPI_DOUBLE, 1,
                                   dimids, &co2vmr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, co2vmr, "long_name", 23, "co2 volume mixing ratio");
@@ -398,7 +399,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = co2vmr;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ch4vmr", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ch4vmr", MPI_DOUBLE, 1,
                                   dimids, &ch4vmr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ch4vmr, "long_name", 23, "ch4 volume mixing ratio");
@@ -406,7 +407,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = ch4vmr;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "n2ovmr", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "n2ovmr", MPI_DOUBLE, 1,
                                   dimids, &n2ovmr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, n2ovmr, "long_name", 23, "n2o volume mixing ratio");
@@ -414,7 +415,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = n2ovmr;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "f11vmr", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "f11vmr", MPI_DOUBLE, 1,
                                   dimids, &f11vmr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, f11vmr, "long_name", 23, "f11 volume mixing ratio");
@@ -422,7 +423,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = f11vmr;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "f12vmr", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "f12vmr", MPI_DOUBLE, 1,
                                   dimids, &f12vmr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, f12vmr, "long_name", 23, "f12 volume mixing ratio");
@@ -430,7 +431,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = f12vmr;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "sol_tsi", MPI_DOUBLE,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "sol_tsi", MPI_DOUBLE,
                                   1, dimids, &sol_tsi);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, sol_tsi, "long_name", 22, "total solar irradiance");
@@ -440,7 +441,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     varids[i++] = sol_tsi;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nsteph", MPI_INT, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "nsteph", MPI_INT, 1,
                                   dimids, &nsteph);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, nsteph, "long_name", 16, "current timestep");
@@ -449,7 +450,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AEROD_v", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AEROD_v", MPI_FLOAT, 2,
                                   dimids, &AEROD_v);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AEROD_v, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -468,7 +469,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ANRAIN", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ANRAIN", MPI_FLOAT, 3,
                                   dimids, &ANRAIN);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, ANRAIN, "mdims", MPI_INT, 1, &mdims);
@@ -484,7 +485,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ANSNOW", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ANSNOW", MPI_FLOAT, 3,
                                   dimids, &ANSNOW);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, ANSNOW, "mdims", MPI_INT, 1, &mdims);
@@ -499,7 +500,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODABS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODABS", MPI_FLOAT, 2,
                                   dimids, &AODABS);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODABS, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -514,7 +515,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODABSBC", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODABSBC", MPI_FLOAT,
                                   2, dimids, &AODABSBC);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODABSBC, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -530,7 +531,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODALL", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODALL", MPI_FLOAT, 2,
                                   dimids, &AODALL);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODALL, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -545,7 +546,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODBC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODBC", MPI_FLOAT, 2,
                                   dimids, &AODBC);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODBC, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -560,7 +561,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODDUST", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODDUST", MPI_FLOAT, 2,
                                   dimids, &AODDUST);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODDUST, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -575,7 +576,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODDUST1", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODDUST1", MPI_FLOAT,
                                   2, dimids, &AODDUST1);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODDUST1, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -591,7 +592,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODDUST3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODDUST3", MPI_FLOAT,
                                   2, dimids, &AODDUST3);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODDUST3, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -607,7 +608,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODDUST4", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODDUST4", MPI_FLOAT,
                                   2, dimids, &AODDUST4);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODDUST4, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -623,7 +624,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODMODE1", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODMODE1", MPI_FLOAT,
                                   2, dimids, &AODMODE1);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODMODE1, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -638,7 +639,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODMODE2", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODMODE2", MPI_FLOAT,
                                   2, dimids, &AODMODE2);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODMODE2, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -653,7 +654,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODMODE3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODMODE3", MPI_FLOAT,
                                   2, dimids, &AODMODE3);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODMODE3, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -668,7 +669,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODMODE4", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODMODE4", MPI_FLOAT,
                                   2, dimids, &AODMODE4);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODMODE4, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -683,7 +684,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODNIR", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODNIR", MPI_FLOAT, 2,
                                   dimids, &AODNIR);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODNIR, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -698,7 +699,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODPOM", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODPOM", MPI_FLOAT, 2,
                                   dimids, &AODPOM);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODPOM, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -713,7 +714,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODSO4", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODSO4", MPI_FLOAT, 2,
                                   dimids, &AODSO4);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODSO4, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -728,7 +729,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODSOA", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODSOA", MPI_FLOAT, 2,
                                   dimids, &AODSOA);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODSOA, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -743,7 +744,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODSS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODSS", MPI_FLOAT, 2,
                                   dimids, &AODSS);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODSS, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -758,7 +759,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODUV", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODUV", MPI_FLOAT, 2,
                                   dimids, &AODUV);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODUV, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -773,7 +774,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AODVIS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AODVIS", MPI_FLOAT, 2,
                                   dimids, &AODVIS);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, AODVIS, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -789,7 +790,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQRAIN", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AQRAIN", MPI_FLOAT, 3,
                                   dimids, &AQRAIN);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, AQRAIN, "mdims", MPI_INT, 1, &mdims);
@@ -805,7 +806,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQSNOW", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AQSNOW", MPI_FLOAT, 3,
                                   dimids, &AQSNOW);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, AQSNOW, "mdims", MPI_INT, 1, &mdims);
@@ -820,7 +821,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_DMS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AQ_DMS", MPI_FLOAT, 2,
                                   dimids, &AQ_DMS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, AQ_DMS, "units", 7, "kg/m2/s");
@@ -833,7 +834,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_H2O2", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AQ_H2O2", MPI_FLOAT, 2,
                                   dimids, &AQ_H2O2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, AQ_H2O2, "units", 7, "kg/m2/s");
@@ -846,7 +847,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_H2SO4", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AQ_H2SO4", MPI_FLOAT,
                                   2, dimids, &AQ_H2SO4);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, AQ_H2SO4, "units", 7, "kg/m2/s");
@@ -860,7 +861,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_O3", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AQ_O3", MPI_FLOAT, 2,
                                   dimids, &AQ_O3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, AQ_O3, "units", 7, "kg/m2/s");
@@ -873,7 +874,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_SO2", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AQ_SO2", MPI_FLOAT, 2,
                                   dimids, &AQ_SO2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, AQ_SO2, "units", 7, "kg/m2/s");
@@ -886,7 +887,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AQ_SOAG", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AQ_SOAG", MPI_FLOAT, 2,
                                   dimids, &AQ_SOAG);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, AQ_SOAG, "units", 7, "kg/m2/s");
@@ -900,7 +901,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AREI", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AREI", MPI_FLOAT, 3,
                                   dimids, &AREI);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, AREI, "mdims", MPI_INT, 1, &mdims);
@@ -916,7 +917,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AREL", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AREL", MPI_FLOAT, 3,
                                   dimids, &AREL);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, AREL, "mdims", MPI_INT, 1, &mdims);
@@ -932,7 +933,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AWNC", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AWNC", MPI_FLOAT, 3,
                                   dimids, &AWNC);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, AWNC, "mdims", MPI_INT, 1, &mdims);
@@ -948,7 +949,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "AWNI", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "AWNI", MPI_FLOAT, 3,
                                   dimids, &AWNI);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, AWNI, "mdims", MPI_INT, 1, &mdims);
@@ -963,7 +964,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "BURDEN1", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "BURDEN1", MPI_FLOAT, 2,
                                   dimids, &BURDEN1);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, BURDEN1, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -980,7 +981,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "BURDEN2", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "BURDEN2", MPI_FLOAT, 2,
                                   dimids, &BURDEN2);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, BURDEN2, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -997,7 +998,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "BURDEN3", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "BURDEN3", MPI_FLOAT, 2,
                                   dimids, &BURDEN3);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, BURDEN3, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -1014,7 +1015,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "BURDEN4", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "BURDEN4", MPI_FLOAT, 2,
                                   dimids, &BURDEN4);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, BURDEN4, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -1032,7 +1033,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CCN3", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CCN3", MPI_FLOAT, 3,
                                   dimids, &CCN3);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, CCN3, "mdims", MPI_INT, 1, &mdims);
@@ -1047,7 +1048,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CDNUMC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CDNUMC", MPI_FLOAT, 2,
                                   dimids, &CDNUMC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, CDNUMC, "units", 4, "1/m2");
@@ -1061,7 +1062,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDHGH", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLDHGH", MPI_FLOAT, 2,
                                   dimids, &CLDHGH);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, CLDHGH, "units", 8, "fraction");
@@ -1075,7 +1076,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDICE", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLDICE", MPI_FLOAT, 3,
                                   dimids, &CLDICE);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, CLDICE, "mdims", MPI_INT, 1, &mdims);
@@ -1093,7 +1094,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDLIQ", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLDLIQ", MPI_FLOAT, 3,
                                   dimids, &CLDLIQ);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, CLDLIQ, "mdims", MPI_INT, 1, &mdims);
@@ -1110,7 +1111,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDLOW", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLDLOW", MPI_FLOAT, 2,
                                   dimids, &CLDLOW);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, CLDLOW, "units", 8, "fraction");
@@ -1123,7 +1124,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDMED", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLDMED", MPI_FLOAT, 2,
                                   dimids, &CLDMED);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, CLDMED, "units", 8, "fraction");
@@ -1136,7 +1137,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDTOT", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLDTOT", MPI_FLOAT, 2,
                                   dimids, &CLDTOT);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, CLDTOT, "units", 8, "fraction");
@@ -1150,7 +1151,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLOUD", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLOUD", MPI_FLOAT, 3,
                                   dimids, &CLOUD);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, CLOUD, "mdims", MPI_INT, 1, &mdims);
@@ -1166,7 +1167,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLOUDFRAC_CLUBB",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLOUDFRAC_CLUBB",
                                   MPI_FLOAT, 3, dimids, &CLOUDFRAC_CLUBB);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, CLOUDFRAC_CLUBB, "mdims", MPI_INT, 1, &mdims);
@@ -1182,7 +1183,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CONCLD", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CONCLD", MPI_FLOAT, 3,
                                   dimids, &CONCLD);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, CONCLD, "mdims", MPI_INT, 1, &mdims);
@@ -1198,7 +1199,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DCQ", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DCQ", MPI_FLOAT, 3,
                                   dimids, &DCQ);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, DCQ, "mdims", MPI_INT, 1, &mdims);
@@ -1213,7 +1214,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_DMS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DF_DMS", MPI_FLOAT, 2,
                                   dimids, &DF_DMS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DF_DMS, "units", 7, "kg/m2/s");
@@ -1226,7 +1227,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_H2O2", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DF_H2O2", MPI_FLOAT, 2,
                                   dimids, &DF_H2O2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DF_H2O2, "units", 7, "kg/m2/s");
@@ -1239,7 +1240,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_H2SO4", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DF_H2SO4", MPI_FLOAT,
                                   2, dimids, &DF_H2SO4);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DF_H2SO4, "units", 7, "kg/m2/s");
@@ -1252,7 +1253,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_O3", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DF_O3", MPI_FLOAT, 2,
                                   dimids, &DF_O3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DF_O3, "units", 7, "kg/m2/s");
@@ -1265,7 +1266,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_SO2", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DF_SO2", MPI_FLOAT, 2,
                                   dimids, &DF_SO2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DF_SO2, "units", 7, "kg/m2/s");
@@ -1278,7 +1279,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DF_SOAG", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DF_SOAG", MPI_FLOAT, 2,
                                   dimids, &DF_SOAG);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DF_SOAG, "units", 7, "kg/m2/s");
@@ -1291,7 +1292,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DMS_SRF", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DMS_SRF", MPI_FLOAT, 2,
                                   dimids, &DMS_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DMS_SRF, "units", 7, "mol/mol");
@@ -1304,7 +1305,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DP_KCLDBASE",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DP_KCLDBASE",
                                   MPI_FLOAT, 2, dimids, &DP_KCLDBASE);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DP_KCLDBASE, "units", 1, "1");
@@ -1317,7 +1318,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DP_MFUP_MAX",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DP_MFUP_MAX",
                                   MPI_FLOAT, 2, dimids, &DP_MFUP_MAX);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DP_MFUP_MAX, "units", 5, "kg/m2");
@@ -1331,7 +1332,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DP_WCLDBASE",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DP_WCLDBASE",
                                   MPI_FLOAT, 2, dimids, &DP_WCLDBASE);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DP_WCLDBASE, "units", 3, "m/s");
@@ -1345,7 +1346,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DSTSFMBL", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DSTSFMBL", MPI_FLOAT,
                                   2, dimids, &DSTSFMBL);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DSTSFMBL, "units", 7, "kg/m2/s");
@@ -1359,7 +1360,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DTCOND", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DTCOND", MPI_FLOAT, 3,
                                   dimids, &DTCOND);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, DTCOND, "mdims", MPI_INT, 1, &mdims);
@@ -1374,7 +1375,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DTENDTH", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DTENDTH", MPI_FLOAT, 2,
                                   dimids, &DTENDTH);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DTENDTH, "units", 4, "W/m2");
@@ -1388,7 +1389,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "DTENDTQ", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "DTENDTQ", MPI_FLOAT, 2,
                                   dimids, &DTENDTQ);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, DTENDTQ, "units", 7, "kg/m2/s");
@@ -1403,7 +1404,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "EXTINCT", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "EXTINCT", MPI_FLOAT, 3,
                                   dimids, &EXTINCT);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, EXTINCT, "mdims", MPI_INT, 1, &mdims);
@@ -1423,7 +1424,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FICE", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FICE", MPI_FLOAT, 3,
                                   dimids, &FICE);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, FICE, "mdims", MPI_INT, 1, &mdims);
@@ -1438,7 +1439,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLDS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FLDS", MPI_FLOAT, 2,
                                   dimids, &FLDS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FLDS, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1453,7 +1454,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLNS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FLNS", MPI_FLOAT, 2,
                                   dimids, &FLNS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FLNS, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1468,7 +1469,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLNSC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FLNSC", MPI_FLOAT, 2,
                                   dimids, &FLNSC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FLNSC, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1483,7 +1484,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLNT", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FLNT", MPI_FLOAT, 2,
                                   dimids, &FLNT);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FLNT, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1498,7 +1499,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLNTC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FLNTC", MPI_FLOAT, 2,
                                   dimids, &FLNTC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FLNTC, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1513,7 +1514,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLUT", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FLUT", MPI_FLOAT, 2,
                                   dimids, &FLUT);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FLUT, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1528,7 +1529,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLUTC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FLUTC", MPI_FLOAT, 2,
                                   dimids, &FLUTC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FLUTC, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1545,7 +1546,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FREQI", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FREQI", MPI_FLOAT, 3,
                                   dimids, &FREQI);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, FREQI, "mdims", MPI_INT, 1, &mdims);
@@ -1561,7 +1562,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FREQL", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FREQL", MPI_FLOAT, 3,
                                   dimids, &FREQL);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, FREQL, "mdims", MPI_INT, 1, &mdims);
@@ -1577,7 +1578,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FREQR", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FREQR", MPI_FLOAT, 3,
                                   dimids, &FREQR);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, FREQR, "mdims", MPI_INT, 1, &mdims);
@@ -1593,7 +1594,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FREQS", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FREQS", MPI_FLOAT, 3,
                                   dimids, &FREQS);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, FREQS, "mdims", MPI_INT, 1, &mdims);
@@ -1608,7 +1609,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSDS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FSDS", MPI_FLOAT, 2,
                                   dimids, &FSDS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FSDS, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1623,7 +1624,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSDSC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FSDSC", MPI_FLOAT, 2,
                                   dimids, &FSDSC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FSDSC, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1638,7 +1639,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FSNS", MPI_FLOAT, 2,
                                   dimids, &FSNS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FSNS, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1653,7 +1654,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNSC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FSNSC", MPI_FLOAT, 2,
                                   dimids, &FSNSC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FSNSC, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1668,7 +1669,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNT", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FSNT", MPI_FLOAT, 2,
                                   dimids, &FSNT);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FSNT, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1683,7 +1684,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNTC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FSNTC", MPI_FLOAT, 2,
                                   dimids, &FSNTC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FSNTC, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1698,7 +1699,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNTOA", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FSNTOA", MPI_FLOAT, 2,
                                   dimids, &FSNTOA);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FSNTOA, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1713,7 +1714,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSNTOAC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FSNTOAC", MPI_FLOAT, 2,
                                   dimids, &FSNTOAC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FSNTOAC, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1729,7 +1730,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSUTOA", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FSUTOA", MPI_FLOAT, 2,
                                   dimids, &FSUTOA);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FSUTOA, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1744,7 +1745,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FSUTOAC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FSUTOAC", MPI_FLOAT, 2,
                                   dimids, &FSUTOAC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FSUTOAC, "Sampling_Sequence", 8, "rad_lwsw");
@@ -1760,7 +1761,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "F_eff", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "F_eff", MPI_FLOAT, 2,
                                   dimids, &F_eff);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, F_eff, "units", 1, "1");
@@ -1774,7 +1775,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "H2O2_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "H2O2_SRF", MPI_FLOAT,
                                   2, dimids, &H2O2_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, H2O2_SRF, "units", 7, "mol/mol");
@@ -1787,7 +1788,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "H2SO4_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "H2SO4_SRF", MPI_FLOAT,
                                   2, dimids, &H2SO4_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, H2SO4_SRF, "units", 7, "mol/mol");
@@ -1800,7 +1801,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "H2SO4_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "H2SO4_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &H2SO4_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, H2SO4_sfgaex1, "units", 7, "kg/m2/s");
@@ -1814,7 +1815,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ICEFRAC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ICEFRAC", MPI_FLOAT, 2,
                                   dimids, &ICEFRAC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ICEFRAC, "units", 8, "fraction");
@@ -1828,7 +1829,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ICIMR", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ICIMR", MPI_FLOAT, 3,
                                   dimids, &ICIMR);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, ICIMR, "mdims", MPI_INT, 1, &mdims);
@@ -1844,7 +1845,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ICWMR", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ICWMR", MPI_FLOAT, 3,
                                   dimids, &ICWMR);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, ICWMR, "mdims", MPI_INT, 1, &mdims);
@@ -1860,7 +1861,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "IWC", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "IWC", MPI_FLOAT, 3,
                                   dimids, &IWC);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, IWC, "mdims", MPI_INT, 1, &mdims);
@@ -1875,7 +1876,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LANDFRAC", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LANDFRAC", MPI_FLOAT,
                                   2, dimids, &LANDFRAC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, LANDFRAC, "units", 8, "fraction");
@@ -1888,7 +1889,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LHFLX", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LHFLX", MPI_FLOAT, 2,
                                   dimids, &LHFLX);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, LHFLX, "units", 4, "W/m2");
@@ -1902,7 +1903,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_DO3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LINOZ_DO3", MPI_FLOAT,
                                   3, dimids, &LINOZ_DO3);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, LINOZ_DO3, "mdims", MPI_INT, 1, &mdims);
@@ -1919,7 +1920,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_DO3_PSC",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LINOZ_DO3_PSC",
                                   MPI_FLOAT, 3, dimids, &LINOZ_DO3_PSC);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, LINOZ_DO3_PSC, "mdims", MPI_INT, 1, &mdims);
@@ -1936,7 +1937,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_O3CLIM",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LINOZ_O3CLIM",
                                   MPI_FLOAT, 3, dimids, &LINOZ_O3CLIM);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, LINOZ_O3CLIM, "mdims", MPI_INT, 1, &mdims);
@@ -1952,7 +1953,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_O3COL",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LINOZ_O3COL",
                                   MPI_FLOAT, 3, dimids, &LINOZ_O3COL);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, LINOZ_O3COL, "mdims", MPI_INT, 1, &mdims);
@@ -1967,7 +1968,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_SFCSINK",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LINOZ_SFCSINK",
                                   MPI_FLOAT, 2, dimids, &LINOZ_SFCSINK);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, LINOZ_SFCSINK, "units", 8, "Tg/yr/m2");
@@ -1982,7 +1983,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_SSO3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LINOZ_SSO3", MPI_FLOAT,
                                   3, dimids, &LINOZ_SSO3);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, LINOZ_SSO3, "mdims", MPI_INT, 1, &mdims);
@@ -1997,7 +1998,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LINOZ_SZA", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LINOZ_SZA", MPI_FLOAT,
                                   2, dimids, &LINOZ_SZA);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, LINOZ_SZA, "units", 7, "degrees");
@@ -2010,7 +2011,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LND_MBL", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LND_MBL", MPI_FLOAT, 2,
                                   dimids, &LND_MBL);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, LND_MBL, "units", 4, "frac");
@@ -2023,7 +2024,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LWCF", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LWCF", MPI_FLOAT, 2,
                                   dimids, &LWCF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, LWCF, "Sampling_Sequence", 8, "rad_lwsw");
@@ -2039,7 +2040,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_bc", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "Mass_bc", MPI_FLOAT, 3,
                                   dimids, &Mass_bc);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, Mass_bc, "mdims", MPI_INT, 1, &mdims);
@@ -2056,7 +2057,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_dst", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "Mass_dst", MPI_FLOAT,
                                   3, dimids, &Mass_dst);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, Mass_dst, "mdims", MPI_INT, 1, &mdims);
@@ -2073,7 +2074,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_mom", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "Mass_mom", MPI_FLOAT,
                                   3, dimids, &Mass_mom);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, Mass_mom, "mdims", MPI_INT, 1, &mdims);
@@ -2091,7 +2092,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_ncl", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "Mass_ncl", MPI_FLOAT,
                                   3, dimids, &Mass_ncl);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, Mass_ncl, "mdims", MPI_INT, 1, &mdims);
@@ -2108,7 +2109,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_pom", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "Mass_pom", MPI_FLOAT,
                                   3, dimids, &Mass_pom);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, Mass_pom, "mdims", MPI_INT, 1, &mdims);
@@ -2125,7 +2126,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_so4", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "Mass_so4", MPI_FLOAT,
                                   3, dimids, &Mass_so4);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, Mass_so4, "mdims", MPI_INT, 1, &mdims);
@@ -2142,7 +2143,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Mass_soa", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "Mass_soa", MPI_FLOAT,
                                   3, dimids, &Mass_soa);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, Mass_soa, "mdims", MPI_INT, 1, &mdims);
@@ -2159,7 +2160,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "NUMICE", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "NUMICE", MPI_FLOAT, 3,
                                   dimids, &NUMICE);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, NUMICE, "mdims", MPI_INT, 1, &mdims);
@@ -2177,7 +2178,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "NUMLIQ", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "NUMLIQ", MPI_FLOAT, 3,
                                   dimids, &NUMLIQ);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, NUMLIQ, "mdims", MPI_INT, 1, &mdims);
@@ -2195,7 +2196,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "NUMRAI", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "NUMRAI", MPI_FLOAT, 3,
                                   dimids, &NUMRAI);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, NUMRAI, "mdims", MPI_INT, 1, &mdims);
@@ -2213,7 +2214,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "NUMSNO", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "NUMSNO", MPI_FLOAT, 3,
                                   dimids, &NUMSNO);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, NUMSNO, "mdims", MPI_INT, 1, &mdims);
@@ -2231,7 +2232,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "O3", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "O3", MPI_FLOAT, 3,
                                   dimids, &O3);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, O3, "mdims", MPI_INT, 1, &mdims);
@@ -2248,7 +2249,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "O3_SRF", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "O3_SRF", MPI_FLOAT, 2,
                                   dimids, &O3_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, O3_SRF, "units", 7, "mol/mol");
@@ -2261,7 +2262,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OCNFRAC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "OCNFRAC", MPI_FLOAT, 2,
                                   dimids, &OCNFRAC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, OCNFRAC, "units", 8, "fraction");
@@ -2275,7 +2276,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OMEGA", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "OMEGA", MPI_FLOAT, 3,
                                   dimids, &OMEGA);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, OMEGA, "mdims", MPI_INT, 1, &mdims);
@@ -2290,7 +2291,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OMEGA500", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "OMEGA500", MPI_FLOAT,
                                   2, dimids, &OMEGA500);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, OMEGA500, "units", 4, "Pa/s");
@@ -2305,7 +2306,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OMEGAT", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "OMEGAT", MPI_FLOAT, 3,
                                   dimids, &OMEGAT);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, OMEGAT, "mdims", MPI_INT, 1, &mdims);
@@ -2320,7 +2321,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PBLH", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "PBLH", MPI_FLOAT, 2,
                                   dimids, &PBLH);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, PBLH, "units", 1, "m");
@@ -2333,7 +2334,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PHIS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "PHIS", MPI_FLOAT, 2,
                                   dimids, &PHIS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, PHIS, "units", 5, "m2/s2");
@@ -2344,7 +2345,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PRECC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "PRECC", MPI_FLOAT, 2,
                                   dimids, &PRECC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, PRECC, "units", 3, "m/s");
@@ -2357,7 +2358,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PRECL", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "PRECL", MPI_FLOAT, 2,
                                   dimids, &PRECL);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, PRECL, "units", 3, "m/s");
@@ -2371,7 +2372,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PRECSC", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "PRECSC", MPI_FLOAT, 2,
                                   dimids, &PRECSC);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, PRECSC, "units", 3, "m/s");
@@ -2384,7 +2385,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PRECSL", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "PRECSL", MPI_FLOAT, 2,
                                   dimids, &PRECSL);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, PRECSL, "units", 3, "m/s");
@@ -2398,7 +2399,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "PS", MPI_FLOAT, 2,
                                   dimids, &PS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, PS, "units", 2, "Pa");
@@ -2411,7 +2412,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PSL", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "PSL", MPI_FLOAT, 2,
                                   dimids, &PSL);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, PSL, "units", 2, "Pa");
@@ -2425,7 +2426,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Q", MPI_FLOAT, 3,
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "Q", MPI_FLOAT, 3,
                                   dimids, &Q);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, Q, "mdims", MPI_INT, 1, &mdims);
@@ -2442,7 +2443,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "QFLX", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "QFLX", MPI_FLOAT, 2,
                                   dimids, &QFLX);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, QFLX, "units", 7, "kg/m2/s");
@@ -2455,7 +2456,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "QREFHT", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "QREFHT", MPI_FLOAT, 2,
                                   dimids, &QREFHT);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, QREFHT, "units", 5, "kg/kg");
@@ -2469,7 +2470,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "QRL", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "QRL", MPI_FLOAT, 3,
                                   dimids, &QRL);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, QRL, "mdims", MPI_INT, 1, &mdims);
@@ -2487,7 +2488,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "QRS", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "QRS", MPI_FLOAT, 3,
                                   dimids, &QRS);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, QRS, "mdims", MPI_INT, 1, &mdims);
@@ -2505,7 +2506,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "RAINQM", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "RAINQM", MPI_FLOAT, 3,
                                   dimids, &RAINQM);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, RAINQM, "mdims", MPI_INT, 1, &mdims);
@@ -2522,7 +2523,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "RAM1", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "RAM1", MPI_FLOAT, 2,
                                   dimids, &RAM1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, RAM1, "units", 4, "frac");
@@ -2536,7 +2537,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "RELHUM", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "RELHUM", MPI_FLOAT, 3,
                                   dimids, &RELHUM);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, RELHUM, "mdims", MPI_INT, 1, &mdims);
@@ -2549,10 +2550,10 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     CHECK_ERR
     varids[i++] = RELHUM;
 
-    /* 
+    /*
         dimids[0] = dim_time;
         dimids[1] = dim_ncol;
-        err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SCO", MPI_FLOAT, 2,
+        err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SCO", MPI_FLOAT, 2,
                                       dimids, &SCO);
         CHECK_ERR
         err = PUT_ATT_TEXT (ncid, SCO, "units", 3, "DU");
@@ -2568,7 +2569,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFDMS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFDMS", MPI_FLOAT, 2,
                                   dimids, &SFDMS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFDMS, "units", 7, "kg/m2/s");
@@ -2581,7 +2582,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFH2O2", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFH2O2", MPI_FLOAT, 2,
                                   dimids, &SFH2O2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFH2O2, "units", 7, "kg/m2/s");
@@ -2594,7 +2595,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFH2SO4", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFH2SO4", MPI_FLOAT, 2,
                                   dimids, &SFH2SO4);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFH2SO4, "units", 7, "kg/m2/s");
@@ -2607,7 +2608,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFO3", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFO3", MPI_FLOAT, 2,
                                   dimids, &SFO3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFO3, "units", 7, "kg/m2/s");
@@ -2620,7 +2621,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFSO2", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFSO2", MPI_FLOAT, 2,
                                   dimids, &SFSO2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFSO2, "units", 7, "kg/m2/s");
@@ -2633,7 +2634,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFSOAG", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFSOAG", MPI_FLOAT, 2,
                                   dimids, &SFSOAG);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFSOAG, "units", 7, "kg/m2/s");
@@ -2646,7 +2647,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFbc_a1", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFbc_a1", MPI_FLOAT, 2,
                                   dimids, &SFbc_a1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFbc_a1, "units", 7, "kg/m2/s");
@@ -2659,7 +2660,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFbc_a3", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFbc_a3", MPI_FLOAT, 2,
                                   dimids, &SFbc_a3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFbc_a3, "units", 7, "kg/m2/s");
@@ -2672,7 +2673,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFbc_a4", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFbc_a4", MPI_FLOAT, 2,
                                   dimids, &SFbc_a4);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFbc_a4, "units", 7, "kg/m2/s");
@@ -2685,7 +2686,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFdst_a1", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFdst_a1", MPI_FLOAT,
                                   2, dimids, &SFdst_a1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFdst_a1, "units", 7, "kg/m2/s");
@@ -2698,7 +2699,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFdst_a3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFdst_a3", MPI_FLOAT,
                                   2, dimids, &SFdst_a3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFdst_a3, "units", 7, "kg/m2/s");
@@ -2711,7 +2712,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFmom_a1", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFmom_a1", MPI_FLOAT,
                                   2, dimids, &SFmom_a1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFmom_a1, "units", 7, "kg/m2/s");
@@ -2724,7 +2725,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFmom_a2", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFmom_a2", MPI_FLOAT,
                                   2, dimids, &SFmom_a2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFmom_a2, "units", 7, "kg/m2/s");
@@ -2737,7 +2738,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFmom_a3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFmom_a3", MPI_FLOAT,
                                   2, dimids, &SFmom_a3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFmom_a3, "units", 7, "kg/m2/s");
@@ -2750,7 +2751,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFmom_a4", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFmom_a4", MPI_FLOAT,
                                   2, dimids, &SFmom_a4);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFmom_a4, "units", 7, "kg/m2/s");
@@ -2763,7 +2764,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFncl_a1", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFncl_a1", MPI_FLOAT,
                                   2, dimids, &SFncl_a1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFncl_a1, "units", 7, "kg/m2/s");
@@ -2776,7 +2777,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFncl_a2", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFncl_a2", MPI_FLOAT,
                                   2, dimids, &SFncl_a2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFncl_a2, "units", 7, "kg/m2/s");
@@ -2789,7 +2790,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFncl_a3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFncl_a3", MPI_FLOAT,
                                   2, dimids, &SFncl_a3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFncl_a3, "units", 7, "kg/m2/s");
@@ -2802,7 +2803,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFnum_a1", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFnum_a1", MPI_FLOAT,
                                   2, dimids, &SFnum_a1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFnum_a1, "units", 7, " 1/m2/s");
@@ -2815,7 +2816,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFnum_a2", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFnum_a2", MPI_FLOAT,
                                   2, dimids, &SFnum_a2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFnum_a2, "units", 7, " 1/m2/s");
@@ -2828,7 +2829,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFnum_a3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFnum_a3", MPI_FLOAT,
                                   2, dimids, &SFnum_a3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFnum_a3, "units", 7, " 1/m2/s");
@@ -2841,7 +2842,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFnum_a4", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFnum_a4", MPI_FLOAT,
                                   2, dimids, &SFnum_a4);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFnum_a4, "units", 7, " 1/m2/s");
@@ -2854,7 +2855,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFpom_a1", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFpom_a1", MPI_FLOAT,
                                   2, dimids, &SFpom_a1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFpom_a1, "units", 7, "kg/m2/s");
@@ -2867,7 +2868,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFpom_a3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFpom_a3", MPI_FLOAT,
                                   2, dimids, &SFpom_a3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFpom_a3, "units", 7, "kg/m2/s");
@@ -2880,7 +2881,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFpom_a4", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFpom_a4", MPI_FLOAT,
                                   2, dimids, &SFpom_a4);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFpom_a4, "units", 7, "kg/m2/s");
@@ -2893,7 +2894,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFso4_a1", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFso4_a1", MPI_FLOAT,
                                   2, dimids, &SFso4_a1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFso4_a1, "units", 7, "kg/m2/s");
@@ -2906,7 +2907,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFso4_a2", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFso4_a2", MPI_FLOAT,
                                   2, dimids, &SFso4_a2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFso4_a2, "units", 7, "kg/m2/s");
@@ -2919,7 +2920,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFso4_a3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFso4_a3", MPI_FLOAT,
                                   2, dimids, &SFso4_a3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFso4_a3, "units", 7, "kg/m2/s");
@@ -2932,7 +2933,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFsoa_a1", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFsoa_a1", MPI_FLOAT,
                                   2, dimids, &SFsoa_a1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFsoa_a1, "units", 7, "kg/m2/s");
@@ -2945,7 +2946,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFsoa_a2", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFsoa_a2", MPI_FLOAT,
                                   2, dimids, &SFsoa_a2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFsoa_a2, "units", 7, "kg/m2/s");
@@ -2958,7 +2959,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SFsoa_a3", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SFsoa_a3", MPI_FLOAT,
                                   2, dimids, &SFsoa_a3);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SFsoa_a3, "units", 7, "kg/m2/s");
@@ -2971,7 +2972,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SHFLX", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SHFLX", MPI_FLOAT, 2,
                                   dimids, &SHFLX);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SHFLX, "units", 4, "W/m2");
@@ -2984,7 +2985,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SH_KCLDBASE",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SH_KCLDBASE",
                                   MPI_FLOAT, 2, dimids, &SH_KCLDBASE);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SH_KCLDBASE, "units", 1, "1");
@@ -2997,7 +2998,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SH_MFUP_MAX",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SH_MFUP_MAX",
                                   MPI_FLOAT, 2, dimids, &SH_MFUP_MAX);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SH_MFUP_MAX, "units", 5, "kg/m2");
@@ -3011,7 +3012,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SH_WCLDBASE",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SH_WCLDBASE",
                                   MPI_FLOAT, 2, dimids, &SH_WCLDBASE);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SH_WCLDBASE, "units", 3, "m/s");
@@ -3025,7 +3026,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SNOWHICE", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SNOWHICE", MPI_FLOAT,
                                   2, dimids, &SNOWHICE);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SNOWHICE, "units", 1, "m");
@@ -3038,7 +3039,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SNOWHLND", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SNOWHLND", MPI_FLOAT,
                                   2, dimids, &SNOWHLND);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SNOWHLND, "units", 1, "m");
@@ -3052,7 +3053,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SNOWQM", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SNOWQM", MPI_FLOAT, 3,
                                   dimids, &SNOWQM);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, SNOWQM, "mdims", MPI_INT, 1, &mdims);
@@ -3070,7 +3071,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SO2", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SO2", MPI_FLOAT, 3,
                                   dimids, &SO2);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, SO2, "mdims", MPI_INT, 1, &mdims);
@@ -3087,7 +3088,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SO2_CLXF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SO2_CLXF", MPI_FLOAT,
                                   2, dimids, &SO2_CLXF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SO2_CLXF, "units", 11, "molec/cm2/s");
@@ -3101,7 +3102,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SO2_SRF", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SO2_SRF", MPI_FLOAT, 2,
                                   dimids, &SO2_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SO2_SRF, "units", 7, "mol/mol");
@@ -3114,7 +3115,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SOAG_CLXF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SOAG_CLXF", MPI_FLOAT,
                                   2, dimids, &SOAG_CLXF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SOAG_CLXF, "units", 11, "molec/cm2/s");
@@ -3128,7 +3129,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SOAG_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SOAG_SRF", MPI_FLOAT,
                                   2, dimids, &SOAG_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SOAG_SRF, "units", 7, "mol/mol");
@@ -3141,7 +3142,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SOAG_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SOAG_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &SOAG_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SOAG_sfgaex1, "units", 7, "kg/m2/s");
@@ -3155,7 +3156,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SOLIN", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SOLIN", MPI_FLOAT, 2,
                                   dimids, &SOLIN);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SOLIN, "Sampling_Sequence", 8, "rad_lwsw");
@@ -3170,7 +3171,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SSAVIS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SSAVIS", MPI_FLOAT, 2,
                                   dimids, &SSAVIS);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, SSAVIS, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -3185,7 +3186,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SSTSFMBL", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SSTSFMBL", MPI_FLOAT,
                                   2, dimids, &SSTSFMBL);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SSTSFMBL, "units", 7, "kg/m2/s");
@@ -3198,7 +3199,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SSTSFMBL_OM",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SSTSFMBL_OM",
                                   MPI_FLOAT, 2, dimids, &SSTSFMBL_OM);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SSTSFMBL_OM, "units", 7, "kg/m2/s");
@@ -3212,7 +3213,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SWCF", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SWCF", MPI_FLOAT, 2,
                                   dimids, &SWCF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SWCF, "Sampling_Sequence", 8, "rad_lwsw");
@@ -3228,7 +3229,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "T", MPI_FLOAT, 3,
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "T", MPI_FLOAT, 3,
                                   dimids, &T);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, T, "mdims", MPI_INT, 1, &mdims);
@@ -3243,7 +3244,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TAUGWX", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TAUGWX", MPI_FLOAT, 2,
                                   dimids, &TAUGWX);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TAUGWX, "units", 4, "N/m2");
@@ -3256,7 +3257,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TAUGWY", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TAUGWY", MPI_FLOAT, 2,
                                   dimids, &TAUGWY);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TAUGWY, "units", 4, "N/m2");
@@ -3269,7 +3270,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TAUX", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TAUX", MPI_FLOAT, 2,
                                   dimids, &TAUX);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TAUX, "units", 4, "N/m2");
@@ -3282,7 +3283,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TAUY", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TAUY", MPI_FLOAT, 2,
                                   dimids, &TAUY);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TAUY, "units", 4, "N/m2");
@@ -3296,7 +3297,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     /*
         dimids[0] = dim_time;
         dimids[1] = dim_ncol;
-        err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TCO", MPI_FLOAT, 2,
+        err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TCO", MPI_FLOAT, 2,
                                       dimids, &TCO);
         CHECK_ERR
         err = PUT_ATT_TEXT (ncid, TCO, "units", 2, "DU");
@@ -3311,7 +3312,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TGCLDCWP", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TGCLDCWP", MPI_FLOAT,
                                   2, dimids, &TGCLDCWP);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TGCLDCWP, "units", 5, "kg/m2");
@@ -3325,7 +3326,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TGCLDIWP", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TGCLDIWP", MPI_FLOAT,
                                   2, dimids, &TGCLDIWP);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TGCLDIWP, "units", 5, "kg/m2");
@@ -3338,7 +3339,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TGCLDLWP", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TGCLDLWP", MPI_FLOAT,
                                   2, dimids, &TGCLDLWP);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TGCLDLWP, "units", 5, "kg/m2");
@@ -3351,7 +3352,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TH7001000", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TH7001000", MPI_FLOAT,
                                   2, dimids, &TH7001000);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TH7001000, "units", 1, "K");
@@ -3364,7 +3365,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TMQ", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TMQ", MPI_FLOAT, 2,
                                   dimids, &TMQ);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TMQ, "units", 5, "kg/m2");
@@ -3378,7 +3379,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TREFHT", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TREFHT", MPI_FLOAT, 2,
                                   dimids, &TREFHT);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TREFHT, "units", 1, "K");
@@ -3391,7 +3392,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TROP_P", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TROP_P", MPI_FLOAT, 2,
                                   dimids, &TROP_P);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, TROP_P, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -3408,7 +3409,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TROP_T", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TROP_T", MPI_FLOAT, 2,
                                   dimids, &TROP_T);
     CHECK_ERR
     err = PUT_ATT_FLOAT (ncid, TROP_T, _FillValue, MPI_FLOAT, 1, &fillv);
@@ -3425,7 +3426,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TS", MPI_FLOAT, 2,
                                   dimids, &TS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TS, "units", 1, "K");
@@ -3438,7 +3439,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TSMN", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TSMN", MPI_FLOAT, 2,
                                   dimids, &TSMN);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TSMN, "units", 1, "K");
@@ -3452,7 +3453,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TSMX", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TSMX", MPI_FLOAT, 2,
                                   dimids, &TSMX);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TSMX, "units", 1, "K");
@@ -3466,7 +3467,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TUH", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TUH", MPI_FLOAT, 2,
                                   dimids, &TUH);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TUH, "units", 3, "W/m");
@@ -3479,7 +3480,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TUQ", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TUQ", MPI_FLOAT, 2,
                                   dimids, &TUQ);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TUQ, "units", 6, "kg/m/s");
@@ -3493,7 +3494,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TVH", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TVH", MPI_FLOAT, 2,
                                   dimids, &TVH);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TVH, "units", 3, "W/m");
@@ -3507,7 +3508,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TVQ", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TVQ", MPI_FLOAT, 2,
                                   dimids, &TVQ);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TVQ, "units", 6, "kg/m/s");
@@ -3522,7 +3523,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "U", MPI_FLOAT, 3,
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "U", MPI_FLOAT, 3,
                                   dimids, &U);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, U, "mdims", MPI_INT, 1, &mdims);
@@ -3537,7 +3538,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "U10", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "U10", MPI_FLOAT, 2,
                                   dimids, &U10);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, U10, "units", 3, "m/s");
@@ -3551,7 +3552,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "UU", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "UU", MPI_FLOAT, 3,
                                   dimids, &UU);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, UU, "mdims", MPI_INT, 1, &mdims);
@@ -3567,7 +3568,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "V", MPI_FLOAT, 3,
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "V", MPI_FLOAT, 3,
                                   dimids, &V);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, V, "mdims", MPI_INT, 1, &mdims);
@@ -3583,7 +3584,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "VQ", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "VQ", MPI_FLOAT, 3,
                                   dimids, &VQ);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, VQ, "mdims", MPI_INT, 1, &mdims);
@@ -3599,7 +3600,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "VT", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "VT", MPI_FLOAT, 3,
                                   dimids, &VT);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, VT, "mdims", MPI_INT, 1, &mdims);
@@ -3615,7 +3616,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "VU", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "VU", MPI_FLOAT, 3,
                                   dimids, &VU);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, VU, "mdims", MPI_INT, 1, &mdims);
@@ -3631,7 +3632,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "VV", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "VV", MPI_FLOAT, 3,
                                   dimids, &VV);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, VV, "mdims", MPI_INT, 1, &mdims);
@@ -3646,7 +3647,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "WD_H2O2", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "WD_H2O2", MPI_FLOAT, 2,
                                   dimids, &WD_H2O2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, WD_H2O2, "units", 4, "kg/s");
@@ -3659,7 +3660,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "WD_H2SO4", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "WD_H2SO4", MPI_FLOAT,
                                   2, dimids, &WD_H2SO4);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, WD_H2SO4, "units", 4, "kg/s");
@@ -3672,7 +3673,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "WD_SO2", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "WD_SO2", MPI_FLOAT, 2,
                                   dimids, &WD_SO2);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, WD_SO2, "units", 4, "kg/s");
@@ -3686,7 +3687,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "WSUB", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "WSUB", MPI_FLOAT, 3,
                                   dimids, &WSUB);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, WSUB, "mdims", MPI_INT, 1, &mdims);
@@ -3702,7 +3703,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Z3", MPI_FLOAT, 3,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "Z3", MPI_FLOAT, 3,
                                   dimids, &Z3);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, Z3, "mdims", MPI_INT, 1, &mdims);
@@ -3718,7 +3719,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "aero_water", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "aero_water", MPI_FLOAT,
                                   3, dimids, &aero_water);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, aero_water, "mdims", MPI_INT, 1, &mdims);
@@ -3734,7 +3735,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "airFV", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "airFV", MPI_FLOAT, 2,
                                   dimids, &airFV);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, airFV, "units", 4, "frac");
@@ -3747,7 +3748,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a1DDF", MPI_FLOAT,
                                   2, dimids, &bc_a1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a1DDF, "units", 7, "kg/m2/s");
@@ -3761,7 +3762,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a1SFWET", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a1SFWET", MPI_FLOAT,
                                   2, dimids, &bc_a1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a1SFWET, "units", 7, "kg/m2/s");
@@ -3774,7 +3775,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a1_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a1_SRF", MPI_FLOAT,
                                   2, dimids, &bc_a1_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a1_SRF, "units", 5, "kg/kg");
@@ -3787,7 +3788,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a1_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a1_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &bc_a1_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a1_sfgaex1, "units", 7, "kg/m2/s");
@@ -3801,7 +3802,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a3DDF", MPI_FLOAT,
                                   2, dimids, &bc_a3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a3DDF, "units", 7, "kg/m2/s");
@@ -3815,7 +3816,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a3SFWET", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a3SFWET", MPI_FLOAT,
                                   2, dimids, &bc_a3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a3SFWET, "units", 7, "kg/m2/s");
@@ -3828,7 +3829,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a3_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a3_SRF", MPI_FLOAT,
                                   2, dimids, &bc_a3_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a3_SRF, "units", 5, "kg/kg");
@@ -3841,7 +3842,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a4DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a4DDF", MPI_FLOAT,
                                   2, dimids, &bc_a4DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a4DDF, "units", 7, "kg/m2/s");
@@ -3855,7 +3856,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a4SFWET", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a4SFWET", MPI_FLOAT,
                                   2, dimids, &bc_a4SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a4SFWET, "units", 7, "kg/m2/s");
@@ -3868,7 +3869,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a4_CLXF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a4_CLXF", MPI_FLOAT,
                                   2, dimids, &bc_a4_CLXF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a4_CLXF, "units", 11, "molec/cm2/s");
@@ -3882,7 +3883,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a4_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a4_SRF", MPI_FLOAT,
                                   2, dimids, &bc_a4_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a4_SRF, "units", 5, "kg/kg");
@@ -3895,7 +3896,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_a4_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_a4_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &bc_a4_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_a4_sfgaex1, "units", 7, "kg/m2/s");
@@ -3909,7 +3910,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_c1DDF", MPI_FLOAT,
                                   2, dimids, &bc_c1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_c1DDF, "units", 7, "kg/m2/s");
@@ -3923,7 +3924,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c1SFWET", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_c1SFWET", MPI_FLOAT,
                                   2, dimids, &bc_c1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_c1SFWET, "units", 7, "kg/m2/s");
@@ -3936,7 +3937,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_c3DDF", MPI_FLOAT,
                                   2, dimids, &bc_c3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_c3DDF, "units", 7, "kg/m2/s");
@@ -3950,7 +3951,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c3SFWET", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_c3SFWET", MPI_FLOAT,
                                   2, dimids, &bc_c3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_c3SFWET, "units", 7, "kg/m2/s");
@@ -3963,7 +3964,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c4DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_c4DDF", MPI_FLOAT,
                                   2, dimids, &bc_c4DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_c4DDF, "units", 7, "kg/m2/s");
@@ -3977,7 +3978,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "bc_c4SFWET", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "bc_c4SFWET", MPI_FLOAT,
                                   2, dimids, &bc_c4SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, bc_c4SFWET, "units", 7, "kg/m2/s");
@@ -3990,7 +3991,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "chla", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "chla", MPI_FLOAT, 2,
                                   dimids, &chla);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, chla, "units", 6, "mg L-1");
@@ -4003,7 +4004,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_a1DDF", MPI_FLOAT,
                                   2, dimids, &dst_a1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_a1DDF, "units", 7, "kg/m2/s");
@@ -4017,7 +4018,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a1SF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_a1SF", MPI_FLOAT,
                                   2, dimids, &dst_a1SF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_a1SF, "units", 7, "kg/m2/s");
@@ -4030,7 +4031,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_a1SFWET",
                                   MPI_FLOAT, 2, dimids, &dst_a1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_a1SFWET, "units", 7, "kg/m2/s");
@@ -4043,7 +4044,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a1_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_a1_SRF", MPI_FLOAT,
                                   2, dimids, &dst_a1_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_a1_SRF, "units", 5, "kg/kg");
@@ -4056,7 +4057,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_a3DDF", MPI_FLOAT,
                                   2, dimids, &dst_a3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_a3DDF, "units", 7, "kg/m2/s");
@@ -4070,7 +4071,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a3SF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_a3SF", MPI_FLOAT,
                                   2, dimids, &dst_a3SF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_a3SF, "units", 7, "kg/m2/s");
@@ -4083,7 +4084,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_a3SFWET",
                                   MPI_FLOAT, 2, dimids, &dst_a3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_a3SFWET, "units", 7, "kg/m2/s");
@@ -4096,7 +4097,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_a3_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_a3_SRF", MPI_FLOAT,
                                   2, dimids, &dst_a3_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_a3_SRF, "units", 5, "kg/kg");
@@ -4109,7 +4110,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_c1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_c1DDF", MPI_FLOAT,
                                   2, dimids, &dst_c1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_c1DDF, "units", 7, "kg/m2/s");
@@ -4123,7 +4124,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_c1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_c1SFWET",
                                   MPI_FLOAT, 2, dimids, &dst_c1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_c1SFWET, "units", 7, "kg/m2/s");
@@ -4137,7 +4138,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_c3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_c3DDF", MPI_FLOAT,
                                   2, dimids, &dst_c3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_c3DDF, "units", 7, "kg/m2/s");
@@ -4151,7 +4152,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "dst_c3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "dst_c3SFWET",
                                   MPI_FLOAT, 2, dimids, &dst_c3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, dst_c3SFWET, "units", 7, "kg/m2/s");
@@ -4166,7 +4167,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hstobie_linoz",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "hstobie_linoz",
                                   MPI_FLOAT, 3, dimids, &hstobie_linoz);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, hstobie_linoz, "mdims", MPI_INT, 1, &mdims);
@@ -4179,7 +4180,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mlip", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mlip", MPI_FLOAT, 2,
                                   dimids, &mlip);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mlip, "units", 4, "uM C");
@@ -4192,7 +4193,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a1DDF", MPI_FLOAT,
                                   2, dimids, &mom_a1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a1DDF, "units", 7, "kg/m2/s");
@@ -4206,7 +4207,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a1SF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a1SF", MPI_FLOAT,
                                   2, dimids, &mom_a1SF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a1SF, "units", 7, "kg/m2/s");
@@ -4219,7 +4220,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a1SFWET",
                                   MPI_FLOAT, 2, dimids, &mom_a1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a1SFWET, "units", 7, "kg/m2/s");
@@ -4232,7 +4233,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a1_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a1_SRF", MPI_FLOAT,
                                   2, dimids, &mom_a1_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a1_SRF, "units", 5, "kg/kg");
@@ -4245,7 +4246,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a1_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a1_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &mom_a1_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a1_sfgaex1, "units", 7, "kg/m2/s");
@@ -4259,7 +4260,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a2DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a2DDF", MPI_FLOAT,
                                   2, dimids, &mom_a2DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a2DDF, "units", 7, "kg/m2/s");
@@ -4273,7 +4274,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a2SF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a2SF", MPI_FLOAT,
                                   2, dimids, &mom_a2SF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a2SF, "units", 7, "kg/m2/s");
@@ -4286,7 +4287,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a2SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a2SFWET",
                                   MPI_FLOAT, 2, dimids, &mom_a2SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a2SFWET, "units", 7, "kg/m2/s");
@@ -4299,7 +4300,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a2_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a2_SRF", MPI_FLOAT,
                                   2, dimids, &mom_a2_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a2_SRF, "units", 5, "kg/kg");
@@ -4312,7 +4313,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a3DDF", MPI_FLOAT,
                                   2, dimids, &mom_a3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a3DDF, "units", 7, "kg/m2/s");
@@ -4326,7 +4327,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a3SFWET",
                                   MPI_FLOAT, 2, dimids, &mom_a3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a3SFWET, "units", 7, "kg/m2/s");
@@ -4339,7 +4340,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a3_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a3_SRF", MPI_FLOAT,
                                   2, dimids, &mom_a3_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a3_SRF, "units", 5, "kg/kg");
@@ -4352,7 +4353,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a4DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a4DDF", MPI_FLOAT,
                                   2, dimids, &mom_a4DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a4DDF, "units", 7, "kg/m2/s");
@@ -4366,7 +4367,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a4SF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a4SF", MPI_FLOAT,
                                   2, dimids, &mom_a4SF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a4SF, "units", 7, "kg/m2/s");
@@ -4379,7 +4380,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a4SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a4SFWET",
                                   MPI_FLOAT, 2, dimids, &mom_a4SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a4SFWET, "units", 7, "kg/m2/s");
@@ -4392,7 +4393,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a4_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a4_SRF", MPI_FLOAT,
                                   2, dimids, &mom_a4_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a4_SRF, "units", 5, "kg/kg");
@@ -4405,7 +4406,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_a4_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_a4_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &mom_a4_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_a4_sfgaex1, "units", 7, "kg/m2/s");
@@ -4419,7 +4420,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_c1DDF", MPI_FLOAT,
                                   2, dimids, &mom_c1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_c1DDF, "units", 7, "kg/m2/s");
@@ -4433,7 +4434,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_c1SFWET",
                                   MPI_FLOAT, 2, dimids, &mom_c1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_c1SFWET, "units", 7, "kg/m2/s");
@@ -4447,7 +4448,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c2DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_c2DDF", MPI_FLOAT,
                                   2, dimids, &mom_c2DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_c2DDF, "units", 7, "kg/m2/s");
@@ -4461,7 +4462,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c2SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_c2SFWET",
                                   MPI_FLOAT, 2, dimids, &mom_c2SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_c2SFWET, "units", 7, "kg/m2/s");
@@ -4475,7 +4476,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_c3DDF", MPI_FLOAT,
                                   2, dimids, &mom_c3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_c3DDF, "units", 7, "kg/m2/s");
@@ -4489,7 +4490,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_c3SFWET",
                                   MPI_FLOAT, 2, dimids, &mom_c3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_c3SFWET, "units", 7, "kg/m2/s");
@@ -4503,7 +4504,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c4DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_c4DDF", MPI_FLOAT,
                                   2, dimids, &mom_c4DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_c4DDF, "units", 7, "kg/m2/s");
@@ -4517,7 +4518,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mom_c4SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mom_c4SFWET",
                                   MPI_FLOAT, 2, dimids, &mom_c4SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mom_c4SFWET, "units", 7, "kg/m2/s");
@@ -4531,7 +4532,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mpoly", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mpoly", MPI_FLOAT, 2,
                                   dimids, &mpoly);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mpoly, "units", 4, "uM C");
@@ -4544,7 +4545,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mprot", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mprot", MPI_FLOAT, 2,
                                   dimids, &mprot);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mprot, "units", 4, "uM C");
@@ -4557,7 +4558,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a1DDF", MPI_FLOAT,
                                   2, dimids, &ncl_a1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a1DDF, "units", 7, "kg/m2/s");
@@ -4571,7 +4572,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a1SF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a1SF", MPI_FLOAT,
                                   2, dimids, &ncl_a1SF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a1SF, "units", 7, "kg/m2/s");
@@ -4584,7 +4585,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a1SFWET",
                                   MPI_FLOAT, 2, dimids, &ncl_a1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a1SFWET, "units", 7, "kg/m2/s");
@@ -4597,7 +4598,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a1_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a1_SRF", MPI_FLOAT,
                                   2, dimids, &ncl_a1_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a1_SRF, "units", 5, "kg/kg");
@@ -4610,7 +4611,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a2DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a2DDF", MPI_FLOAT,
                                   2, dimids, &ncl_a2DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a2DDF, "units", 7, "kg/m2/s");
@@ -4624,7 +4625,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a2SF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a2SF", MPI_FLOAT,
                                   2, dimids, &ncl_a2SF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a2SF, "units", 7, "kg/m2/s");
@@ -4637,7 +4638,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a2SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a2SFWET",
                                   MPI_FLOAT, 2, dimids, &ncl_a2SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a2SFWET, "units", 7, "kg/m2/s");
@@ -4650,7 +4651,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a2_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a2_SRF", MPI_FLOAT,
                                   2, dimids, &ncl_a2_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a2_SRF, "units", 5, "kg/kg");
@@ -4663,7 +4664,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a3DDF", MPI_FLOAT,
                                   2, dimids, &ncl_a3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a3DDF, "units", 7, "kg/m2/s");
@@ -4677,7 +4678,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a3SF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a3SF", MPI_FLOAT,
                                   2, dimids, &ncl_a3SF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a3SF, "units", 7, "kg/m2/s");
@@ -4690,7 +4691,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a3SFWET",
                                   MPI_FLOAT, 2, dimids, &ncl_a3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a3SFWET, "units", 7, "kg/m2/s");
@@ -4703,7 +4704,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_a3_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_a3_SRF", MPI_FLOAT,
                                   2, dimids, &ncl_a3_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_a3_SRF, "units", 5, "kg/kg");
@@ -4716,7 +4717,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_c1DDF", MPI_FLOAT,
                                   2, dimids, &ncl_c1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_c1DDF, "units", 7, "kg/m2/s");
@@ -4730,7 +4731,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_c1SFWET",
                                   MPI_FLOAT, 2, dimids, &ncl_c1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_c1SFWET, "units", 7, "kg/m2/s");
@@ -4744,7 +4745,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c2DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_c2DDF", MPI_FLOAT,
                                   2, dimids, &ncl_c2DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_c2DDF, "units", 7, "kg/m2/s");
@@ -4758,7 +4759,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c2SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_c2SFWET",
                                   MPI_FLOAT, 2, dimids, &ncl_c2SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_c2SFWET, "units", 7, "kg/m2/s");
@@ -4772,7 +4773,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_c3DDF", MPI_FLOAT,
                                   2, dimids, &ncl_c3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_c3DDF, "units", 7, "kg/m2/s");
@@ -4786,7 +4787,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ncl_c3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ncl_c3SFWET",
                                   MPI_FLOAT, 2, dimids, &ncl_c3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ncl_c3SFWET, "units", 7, "kg/m2/s");
@@ -4800,7 +4801,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a1DDF", MPI_FLOAT,
                                   2, dimids, &num_a1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a1DDF, "units", 7, " 1/m2/s");
@@ -4814,7 +4815,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1SF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a1SF", MPI_FLOAT,
                                   2, dimids, &num_a1SF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a1SF, "units", 7, "kg/m2/s");
@@ -4827,7 +4828,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a1SFWET",
                                   MPI_FLOAT, 2, dimids, &num_a1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a1SFWET, "units", 7, " 1/m2/s");
@@ -4840,7 +4841,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1_CLXF",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a1_CLXF",
                                   MPI_FLOAT, 2, dimids, &num_a1_CLXF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a1_CLXF, "units", 11, "molec/cm2/s");
@@ -4854,7 +4855,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a1_SRF", MPI_FLOAT,
                                   2, dimids, &num_a1_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a1_SRF, "units", 5, " 1/kg");
@@ -4867,7 +4868,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a1_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a1_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &num_a1_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a1_sfgaex1, "units", 7, "kg/m2/s");
@@ -4881,7 +4882,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a2DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a2DDF", MPI_FLOAT,
                                   2, dimids, &num_a2DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a2DDF, "units", 7, " 1/m2/s");
@@ -4895,7 +4896,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a2SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a2SFWET",
                                   MPI_FLOAT, 2, dimids, &num_a2SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a2SFWET, "units", 7, " 1/m2/s");
@@ -4908,7 +4909,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a2_CLXF",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a2_CLXF",
                                   MPI_FLOAT, 2, dimids, &num_a2_CLXF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a2_CLXF, "units", 11, "molec/cm2/s");
@@ -4922,7 +4923,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a2_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a2_SRF", MPI_FLOAT,
                                   2, dimids, &num_a2_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a2_SRF, "units", 5, " 1/kg");
@@ -4935,7 +4936,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a3DDF", MPI_FLOAT,
                                   2, dimids, &num_a3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a3DDF, "units", 7, " 1/m2/s");
@@ -4949,7 +4950,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a3SF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a3SF", MPI_FLOAT,
                                   2, dimids, &num_a3SF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a3SF, "units", 7, "kg/m2/s");
@@ -4962,7 +4963,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a3SFWET",
                                   MPI_FLOAT, 2, dimids, &num_a3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a3SFWET, "units", 7, " 1/m2/s");
@@ -4975,7 +4976,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a3_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a3_SRF", MPI_FLOAT,
                                   2, dimids, &num_a3_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a3_SRF, "units", 5, " 1/kg");
@@ -4988,7 +4989,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a4DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a4DDF", MPI_FLOAT,
                                   2, dimids, &num_a4DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a4DDF, "units", 7, " 1/m2/s");
@@ -5002,7 +5003,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a4SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a4SFWET",
                                   MPI_FLOAT, 2, dimids, &num_a4SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a4SFWET, "units", 7, " 1/m2/s");
@@ -5015,7 +5016,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a4_CLXF",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a4_CLXF",
                                   MPI_FLOAT, 2, dimids, &num_a4_CLXF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a4_CLXF, "units", 11, "molec/cm2/s");
@@ -5029,7 +5030,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a4_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a4_SRF", MPI_FLOAT,
                                   2, dimids, &num_a4_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a4_SRF, "units", 5, " 1/kg");
@@ -5042,7 +5043,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_a4_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_a4_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &num_a4_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_a4_sfgaex1, "units", 7, "kg/m2/s");
@@ -5056,7 +5057,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_c1DDF", MPI_FLOAT,
                                   2, dimids, &num_c1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_c1DDF, "units", 7, " 1/m2/s");
@@ -5070,7 +5071,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_c1SFWET",
                                   MPI_FLOAT, 2, dimids, &num_c1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_c1SFWET, "units", 7, " 1/m2/s");
@@ -5084,7 +5085,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c2DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_c2DDF", MPI_FLOAT,
                                   2, dimids, &num_c2DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_c2DDF, "units", 7, " 1/m2/s");
@@ -5098,7 +5099,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c2SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_c2SFWET",
                                   MPI_FLOAT, 2, dimids, &num_c2SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_c2SFWET, "units", 7, " 1/m2/s");
@@ -5112,7 +5113,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_c3DDF", MPI_FLOAT,
                                   2, dimids, &num_c3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_c3DDF, "units", 7, " 1/m2/s");
@@ -5126,7 +5127,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_c3SFWET",
                                   MPI_FLOAT, 2, dimids, &num_c3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_c3SFWET, "units", 7, " 1/m2/s");
@@ -5140,7 +5141,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c4DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_c4DDF", MPI_FLOAT,
                                   2, dimids, &num_c4DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_c4DDF, "units", 7, " 1/m2/s");
@@ -5154,7 +5155,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "num_c4SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "num_c4SFWET",
                                   MPI_FLOAT, 2, dimids, &num_c4SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, num_c4SFWET, "units", 7, " 1/m2/s");
@@ -5168,7 +5169,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a1DDF", MPI_FLOAT,
                                   2, dimids, &pom_a1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a1DDF, "units", 7, "kg/m2/s");
@@ -5182,7 +5183,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a1SFWET",
                                   MPI_FLOAT, 2, dimids, &pom_a1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a1SFWET, "units", 7, "kg/m2/s");
@@ -5195,7 +5196,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a1_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a1_SRF", MPI_FLOAT,
                                   2, dimids, &pom_a1_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a1_SRF, "units", 5, "kg/kg");
@@ -5208,7 +5209,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a1_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a1_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &pom_a1_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a1_sfgaex1, "units", 7, "kg/m2/s");
@@ -5222,7 +5223,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a3DDF", MPI_FLOAT,
                                   2, dimids, &pom_a3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a3DDF, "units", 7, "kg/m2/s");
@@ -5236,7 +5237,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a3SFWET",
                                   MPI_FLOAT, 2, dimids, &pom_a3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a3SFWET, "units", 7, "kg/m2/s");
@@ -5249,7 +5250,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a3_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a3_SRF", MPI_FLOAT,
                                   2, dimids, &pom_a3_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a3_SRF, "units", 5, "kg/kg");
@@ -5262,7 +5263,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a4DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a4DDF", MPI_FLOAT,
                                   2, dimids, &pom_a4DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a4DDF, "units", 7, "kg/m2/s");
@@ -5276,7 +5277,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a4SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a4SFWET",
                                   MPI_FLOAT, 2, dimids, &pom_a4SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a4SFWET, "units", 7, "kg/m2/s");
@@ -5289,7 +5290,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a4_CLXF",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a4_CLXF",
                                   MPI_FLOAT, 2, dimids, &pom_a4_CLXF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a4_CLXF, "units", 11, "molec/cm2/s");
@@ -5303,7 +5304,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a4_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a4_SRF", MPI_FLOAT,
                                   2, dimids, &pom_a4_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a4_SRF, "units", 5, "kg/kg");
@@ -5316,7 +5317,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_a4_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_a4_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &pom_a4_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_a4_sfgaex1, "units", 7, "kg/m2/s");
@@ -5330,7 +5331,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_c1DDF", MPI_FLOAT,
                                   2, dimids, &pom_c1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_c1DDF, "units", 7, "kg/m2/s");
@@ -5344,7 +5345,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_c1SFWET",
                                   MPI_FLOAT, 2, dimids, &pom_c1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_c1SFWET, "units", 7, "kg/m2/s");
@@ -5358,7 +5359,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_c3DDF", MPI_FLOAT,
                                   2, dimids, &pom_c3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_c3DDF, "units", 7, "kg/m2/s");
@@ -5372,7 +5373,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_c3SFWET",
                                   MPI_FLOAT, 2, dimids, &pom_c3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_c3SFWET, "units", 7, "kg/m2/s");
@@ -5386,7 +5387,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c4DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_c4DDF", MPI_FLOAT,
                                   2, dimids, &pom_c4DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_c4DDF, "units", 7, "kg/m2/s");
@@ -5400,7 +5401,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "pom_c4SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "pom_c4SFWET",
                                   MPI_FLOAT, 2, dimids, &pom_c4SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, pom_c4SFWET, "units", 7, "kg/m2/s");
@@ -5414,7 +5415,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a1DDF", MPI_FLOAT,
                                   2, dimids, &so4_a1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a1DDF, "units", 7, "kg/m2/s");
@@ -5428,7 +5429,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a1SFWET",
                                   MPI_FLOAT, 2, dimids, &so4_a1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a1SFWET, "units", 7, "kg/m2/s");
@@ -5441,7 +5442,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a1_CLXF",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a1_CLXF",
                                   MPI_FLOAT, 2, dimids, &so4_a1_CLXF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a1_CLXF, "units", 11, "molec/cm2/s");
@@ -5455,7 +5456,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a1_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a1_SRF", MPI_FLOAT,
                                   2, dimids, &so4_a1_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a1_SRF, "units", 5, "kg/kg");
@@ -5468,7 +5469,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a1_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a1_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &so4_a1_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a1_sfgaex1, "units", 7, "kg/m2/s");
@@ -5482,7 +5483,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a2DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a2DDF", MPI_FLOAT,
                                   2, dimids, &so4_a2DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a2DDF, "units", 7, "kg/m2/s");
@@ -5496,7 +5497,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a2SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a2SFWET",
                                   MPI_FLOAT, 2, dimids, &so4_a2SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a2SFWET, "units", 7, "kg/m2/s");
@@ -5509,7 +5510,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a2_CLXF",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a2_CLXF",
                                   MPI_FLOAT, 2, dimids, &so4_a2_CLXF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a2_CLXF, "units", 11, "molec/cm2/s");
@@ -5523,7 +5524,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a2_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a2_SRF", MPI_FLOAT,
                                   2, dimids, &so4_a2_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a2_SRF, "units", 5, "kg/kg");
@@ -5536,7 +5537,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a2_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a2_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &so4_a2_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a2_sfgaex1, "units", 7, "kg/m2/s");
@@ -5550,7 +5551,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a3DDF", MPI_FLOAT,
                                   2, dimids, &so4_a3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a3DDF, "units", 7, "kg/m2/s");
@@ -5564,7 +5565,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a3SFWET",
                                   MPI_FLOAT, 2, dimids, &so4_a3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a3SFWET, "units", 7, "kg/m2/s");
@@ -5577,7 +5578,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a3_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a3_SRF", MPI_FLOAT,
                                   2, dimids, &so4_a3_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a3_SRF, "units", 5, "kg/kg");
@@ -5590,7 +5591,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_a3_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_a3_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &so4_a3_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_a3_sfgaex1, "units", 7, "kg/m2/s");
@@ -5604,7 +5605,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_c1DDF", MPI_FLOAT,
                                   2, dimids, &so4_c1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_c1DDF, "units", 7, "kg/m2/s");
@@ -5618,7 +5619,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_c1SFWET",
                                   MPI_FLOAT, 2, dimids, &so4_c1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_c1SFWET, "units", 7, "kg/m2/s");
@@ -5632,7 +5633,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c2DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_c2DDF", MPI_FLOAT,
                                   2, dimids, &so4_c2DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_c2DDF, "units", 7, "kg/m2/s");
@@ -5646,7 +5647,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c2SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_c2SFWET",
                                   MPI_FLOAT, 2, dimids, &so4_c2SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_c2SFWET, "units", 7, "kg/m2/s");
@@ -5660,7 +5661,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_c3DDF", MPI_FLOAT,
                                   2, dimids, &so4_c3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_c3DDF, "units", 7, "kg/m2/s");
@@ -5674,7 +5675,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "so4_c3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "so4_c3SFWET",
                                   MPI_FLOAT, 2, dimids, &so4_c3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, so4_c3SFWET, "units", 7, "kg/m2/s");
@@ -5688,7 +5689,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a1DDF", MPI_FLOAT,
                                   2, dimids, &soa_a1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a1DDF, "units", 7, "kg/m2/s");
@@ -5702,7 +5703,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a1SFWET",
                                   MPI_FLOAT, 2, dimids, &soa_a1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a1SFWET, "units", 7, "kg/m2/s");
@@ -5715,7 +5716,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a1_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a1_SRF", MPI_FLOAT,
                                   2, dimids, &soa_a1_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a1_SRF, "units", 5, "kg/kg");
@@ -5728,7 +5729,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a1_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a1_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &soa_a1_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a1_sfgaex1, "units", 7, "kg/m2/s");
@@ -5742,7 +5743,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a2DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a2DDF", MPI_FLOAT,
                                   2, dimids, &soa_a2DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a2DDF, "units", 7, "kg/m2/s");
@@ -5756,7 +5757,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a2SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a2SFWET",
                                   MPI_FLOAT, 2, dimids, &soa_a2SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a2SFWET, "units", 7, "kg/m2/s");
@@ -5769,7 +5770,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a2_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a2_SRF", MPI_FLOAT,
                                   2, dimids, &soa_a2_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a2_SRF, "units", 5, "kg/kg");
@@ -5782,7 +5783,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a2_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a2_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &soa_a2_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a2_sfgaex1, "units", 7, "kg/m2/s");
@@ -5796,7 +5797,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a3DDF", MPI_FLOAT,
                                   2, dimids, &soa_a3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a3DDF, "units", 7, "kg/m2/s");
@@ -5810,7 +5811,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a3SFWET",
                                   MPI_FLOAT, 2, dimids, &soa_a3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a3SFWET, "units", 7, "kg/m2/s");
@@ -5823,7 +5824,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a3_SRF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a3_SRF", MPI_FLOAT,
                                   2, dimids, &soa_a3_SRF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a3_SRF, "units", 5, "kg/kg");
@@ -5836,7 +5837,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_a3_sfgaex1",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_a3_sfgaex1",
                                   MPI_FLOAT, 2, dimids, &soa_a3_sfgaex1);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_a3_sfgaex1, "units", 7, "kg/m2/s");
@@ -5850,7 +5851,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c1DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_c1DDF", MPI_FLOAT,
                                   2, dimids, &soa_c1DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_c1DDF, "units", 7, "kg/m2/s");
@@ -5864,7 +5865,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c1SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_c1SFWET",
                                   MPI_FLOAT, 2, dimids, &soa_c1SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_c1SFWET, "units", 7, "kg/m2/s");
@@ -5878,7 +5879,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c2DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_c2DDF", MPI_FLOAT,
                                   2, dimids, &soa_c2DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_c2DDF, "units", 7, "kg/m2/s");
@@ -5892,7 +5893,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c2SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_c2SFWET",
                                   MPI_FLOAT, 2, dimids, &soa_c2SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_c2SFWET, "units", 7, "kg/m2/s");
@@ -5906,7 +5907,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c3DDF", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_c3DDF", MPI_FLOAT,
                                   2, dimids, &soa_c3DDF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_c3DDF, "units", 7, "kg/m2/s");
@@ -5920,7 +5921,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "soa_c3SFWET",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "soa_c3SFWET",
                                   MPI_FLOAT, 2, dimids, &soa_c3SFWET);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, soa_c3SFWET, "units", 7, "kg/m2/s");
@@ -5940,6 +5941,7 @@ err_out:
 
 /*----< def_F_case_h1_pio() >----------------------------------------------------*/
 int def_F_case_h1_pio (e3sm_io_driver &driver,
+                       e3sm_io_config &cfg,
                        e3sm_io_decom &decom,
                        int ncid,                 /* file ID */
                        const MPI_Offset dims[2], /* dimension sizes */
@@ -6035,7 +6037,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     i = 0;
     /* define variables */
     dimids[0] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lat", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "lat", MPI_DOUBLE, 1,
                                   dimids, &lat);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, lat, "long_name", 8, "latitude");
@@ -6045,7 +6047,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = lat;
 
     dimids[0] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lon", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "lon", MPI_DOUBLE, 1,
                                   dimids, &lon);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, lon, "long_name", 9, "longitude");
@@ -6055,7 +6057,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = lon;
 
     dimids[0] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "area", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "area", MPI_DOUBLE, 1,
                                   dimids, &area);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, area, "long_name", 14, "gll grid areas");
@@ -6063,7 +6065,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = area;
 
     dimids[0] = dim_lev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "lev", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "lev", MPI_DOUBLE, 1,
                                   dimids, &lev);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, lev, "long_name", 38, "hybrid level at midpoints (1000*(A+B))");
@@ -6080,7 +6082,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = lev;
 
     dimids[0] = dim_lev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hyam", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "hyam", MPI_DOUBLE, 1,
                                   dimids, &hyam);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, hyam, "long_name", 39, "hybrid A coefficient at layer midpoints");
@@ -6088,7 +6090,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = hyam;
 
     dimids[0] = dim_lev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hybm", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "hybm", MPI_DOUBLE, 1,
                                   dimids, &hybm);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, hybm, "long_name", 39, "hybrid B coefficient at layer midpoints");
@@ -6096,7 +6098,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = hybm;
 
     dimids[0] = dim_lev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "P0", MPI_DOUBLE, 0,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "P0", MPI_DOUBLE, 0,
                                   NULL, &P0);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, P0, "long_name", 18, "reference pressure");
@@ -6106,7 +6108,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = P0;
 
     dimids[0] = dim_ilev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ilev", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ilev", MPI_DOUBLE, 1,
                                   dimids, &ilev);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ilev, "long_name", 39, "hybrid level at interfaces (1000*(A+B))");
@@ -6123,7 +6125,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = ilev;
 
     dimids[0] = dim_ilev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hyai", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "hyai", MPI_DOUBLE, 1,
                                   dimids, &hyai);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, hyai, "long_name", 40, "hybrid A coefficient at layer interfaces");
@@ -6131,7 +6133,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = hyai;
 
     dimids[0] = dim_ilev;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "hybi", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "hybi", MPI_DOUBLE, 1,
                                   dimids, &hybi);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, hybi, "long_name", 40, "hybrid B coefficient at layer interfaces");
@@ -6139,7 +6141,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = hybi;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "time", MPI_DOUBLE, 1,
                                   dimids, &time);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, time, "long_name", 4, "time");
@@ -6153,7 +6155,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = time;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "date", MPI_INT, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "date", MPI_INT, 1,
                                   dimids, &date);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, date, "long_name", 23, "current date (YYYYMMDD)");
@@ -6161,7 +6163,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = date;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "datesec", MPI_INT, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "datesec", MPI_INT, 1,
                                   dimids, &datesec);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, datesec, "long_name", 31, "current seconds of current date");
@@ -6170,7 +6172,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_nbnd;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time_bnds", MPI_DOUBLE,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "time_bnds", MPI_DOUBLE,
                                   2, dimids, &time_bnds);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, time_bnds, "long_name", 23, "time interval endpoints");
@@ -6179,46 +6181,46 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_chars;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "date_written",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "date_written",
                                   MPI_CHAR, 2, dimids, &date_written);
     CHECK_ERR
     varids[i++] = date_written;
 
     dimids[0] = dim_time;
     dimids[1] = dim_chars;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "time_written",
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "time_written",
                                   MPI_CHAR, 2, dimids, &time_written);
     CHECK_ERR
     varids[i++] = time_written;
 
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ndbase", MPI_INT, 0,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ndbase", MPI_INT, 0,
                                   NULL, &ndbase);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ndbase, "long_name", 8, "base day");
     CHECK_ERR
     varids[i++] = ndbase;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nsbase", MPI_INT, 0,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "nsbase", MPI_INT, 0,
                                   NULL, &nsbase);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, nsbase, "long_name", 19, "seconds of base day");
     CHECK_ERR
     varids[i++] = nsbase;
 
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nbdate", MPI_INT, 0,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "nbdate", MPI_INT, 0,
                                   NULL, &nbdate);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, nbdate, "long_name", 20, "base date (YYYYMMDD)");
     CHECK_ERR
     varids[i++] = nbdate;
 
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nbsec", MPI_INT, 0,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "nbsec", MPI_INT, 0,
                                   NULL, &nbsec);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, nbsec, "long_name", 20, "seconds of base date");
     CHECK_ERR
     varids[i++] = nbsec;
 
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "mdt", MPI_INT, 0, NULL,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "mdt", MPI_INT, 0, NULL,
                                   &mdt);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, mdt, "long_name", 8, "timestep");
@@ -6228,7 +6230,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = mdt;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ndcur", MPI_INT, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ndcur", MPI_INT, 1,
                                   dimids, &ndcur);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ndcur, "long_name", 27, "current day (from base day)");
@@ -6236,7 +6238,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = ndcur;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nscur", MPI_INT, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "nscur", MPI_INT, 1,
                                   dimids, &nscur);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, nscur, "long_name", 30, "current seconds of current day");
@@ -6244,7 +6246,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = nscur;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "co2vmr", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "co2vmr", MPI_DOUBLE, 1,
                                   dimids, &co2vmr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, co2vmr, "long_name", 23, "co2 volume mixing ratio");
@@ -6252,7 +6254,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = co2vmr;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "ch4vmr", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "ch4vmr", MPI_DOUBLE, 1,
                                   dimids, &ch4vmr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, ch4vmr, "long_name", 23, "ch4 volume mixing ratio");
@@ -6260,7 +6262,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = ch4vmr;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "n2ovmr", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "n2ovmr", MPI_DOUBLE, 1,
                                   dimids, &n2ovmr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, n2ovmr, "long_name", 23, "n2o volume mixing ratio");
@@ -6268,7 +6270,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = n2ovmr;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "f11vmr", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "f11vmr", MPI_DOUBLE, 1,
                                   dimids, &f11vmr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, f11vmr, "long_name", 23, "f11 volume mixing ratio");
@@ -6276,7 +6278,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = f11vmr;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "f12vmr", MPI_DOUBLE, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "f12vmr", MPI_DOUBLE, 1,
                                   dimids, &f12vmr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, f12vmr, "long_name", 23, "f12 volume mixing ratio");
@@ -6284,7 +6286,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = f12vmr;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "sol_tsi", MPI_DOUBLE,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "sol_tsi", MPI_DOUBLE,
                                   1, dimids, &sol_tsi);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, sol_tsi, "long_name", 22, "total solar irradiance");
@@ -6294,7 +6296,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     varids[i++] = sol_tsi;
 
     dimids[0] = dim_time;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "nsteph", MPI_INT, 1,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "nsteph", MPI_INT, 1,
                                   dimids, &nsteph);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, nsteph, "long_name", 16, "current timestep");
@@ -6303,7 +6305,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDHGH", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLDHGH", MPI_FLOAT, 2,
                                   dimids, &CLDHGH);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, CLDHGH, "units", 8, "fraction");
@@ -6314,7 +6316,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDLOW", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLDLOW", MPI_FLOAT, 2,
                                   dimids, &CLDLOW);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, CLDLOW, "units", 8, "fraction");
@@ -6325,7 +6327,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "CLDMED", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "CLDMED", MPI_FLOAT, 2,
                                   dimids, &CLDMED);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, CLDMED, "units", 8, "fraction");
@@ -6336,7 +6338,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "FLNT", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "FLNT", MPI_FLOAT, 2,
                                   dimids, &FLNT);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, FLNT, "Sampling_Sequence", 8, "rad_lwsw");
@@ -6349,7 +6351,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "LWCF", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "LWCF", MPI_FLOAT, 2,
                                   dimids, &LWCF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, LWCF, "Sampling_Sequence", 8, "rad_lwsw");
@@ -6362,7 +6364,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OMEGA500", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "OMEGA500", MPI_FLOAT,
                                   2, dimids, &OMEGA500);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, OMEGA500, "units", 4, "Pa/s");
@@ -6374,7 +6376,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "OMEGA850", MPI_FLOAT,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "OMEGA850", MPI_FLOAT,
                                   2, dimids, &OMEGA850);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, OMEGA850, "units", 4, "Pa/s");
@@ -6386,7 +6388,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PRECT", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "PRECT", MPI_FLOAT, 2,
                                   dimids, &PRECT);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, PRECT, "units", 3, "m/s");
@@ -6398,7 +6400,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "PS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "PS", MPI_FLOAT, 2,
                                   dimids, &PS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, PS, "units", 2, "Pa");
@@ -6409,7 +6411,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "SWCF", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "SWCF", MPI_FLOAT, 2,
                                   dimids, &SWCF);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, SWCF, "Sampling_Sequence", 8, "rad_lwsw");
@@ -6422,7 +6424,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "T850", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "T850", MPI_FLOAT, 2,
                                   dimids, &T850);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, T850, "units", 1, "K");
@@ -6433,7 +6435,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TMQ", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TMQ", MPI_FLOAT, 2,
                                   dimids, &TMQ);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TMQ, "units", 5, "kg/m2");
@@ -6445,7 +6447,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "TS", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "TS", MPI_FLOAT, 2,
                                   dimids, &TS);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, TS, "units", 1, "K");
@@ -6457,7 +6459,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     dimids[0] = dim_time;
     dimids[1] = dim_lev;
     dimids[2] = dim_ncol;
-    err       = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "U", MPI_FLOAT, 3,
+    err       = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "U", MPI_FLOAT, 3,
                                   dimids, &U);
     CHECK_ERR
     err = PUT_ATT_INT (ncid, U, "mdims", MPI_INT, 1, &mdims);
@@ -6470,7 +6472,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "U250", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "U250", MPI_FLOAT, 2,
                                   dimids, &U250);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, U250, "units", 3, "m/s");
@@ -6481,7 +6483,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "U850", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "U850", MPI_FLOAT, 2,
                                   dimids, &U850);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, U850, "units", 3, "m/s");
@@ -6492,7 +6494,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "UBOT", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "UBOT", MPI_FLOAT, 2,
                                   dimids, &UBOT);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, UBOT, "units", 3, "m/s");
@@ -6503,7 +6505,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "V250", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "V250", MPI_FLOAT, 2,
                                   dimids, &V250);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, V250, "units", 3, "m/s");
@@ -6515,7 +6517,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "V850", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "V850", MPI_FLOAT, 2,
                                   dimids, &V850);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, V850, "units", 3, "m/s");
@@ -6527,7 +6529,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "VBOT", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "VBOT", MPI_FLOAT, 2,
                                   dimids, &VBOT);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, VBOT, "units", 3, "m/s");
@@ -6538,7 +6540,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     dimids[0] = dim_time;
     dimids[1] = dim_ncol;
-    err = e3sm_io_pio_define_var (driver, dnames, decom, decomids[i], ncid, "Z500", MPI_FLOAT, 2,
+    err = e3sm_io_pio_define_var (driver, cfg, dnames, decom, decomids[i], ncid, "Z500", MPI_FLOAT, 2,
                                   dimids, &Z500);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, Z500, "units", 1, "m");

--- a/src/cases/var_io_F_case_pio.cpp
+++ b/src/cases/var_io_F_case_pio.cpp
@@ -540,12 +540,12 @@ int run_varn_F_case_pio (e3sm_io_config &cfg,
     /* define dimensions, variables, and attributes */
     if (cfg.nvars == 414) {
         /* for h0 file */
-        err = def_F_case_h0_pio (driver, decom, ncid, decom.dims[2], cfg.nvars, decomids, varids,
+        err = def_F_case_h0_pio (driver, cfg, decom, ncid, decom.dims[2], cfg.nvars, decomids, varids,
                                  piovars);
         CHECK_ERR
     } else {
         /* for h1 file */
-        err = def_F_case_h1_pio (driver, decom, ncid, decom.dims[2], cfg.nvars, decomids, varids,
+        err = def_F_case_h1_pio (driver, cfg, decom, ncid, decom.dims[2], cfg.nvars, decomids, varids,
                                  piovars);
         CHECK_ERR
     }

--- a/src/cases/var_io_F_case_pio.cpp
+++ b/src/cases/var_io_F_case_pio.cpp
@@ -529,7 +529,12 @@ int run_varn_F_case_pio (e3sm_io_config &cfg,
     targetfname = std::string (cfg.targetdir) + '/' + outfile;
 
     /* create a new CDF-5 file for writing */
-    err = driver.create (targetfname, cfg.io_comm, cfg.info, &ncid);
+    if (cfg.filepernode) {
+        err = driver.create (targetfname + "." + std::to_string (cfg.node_id), cfg.node_comm,
+                             cfg.info, &ncid);
+    } else {
+        err = driver.create (targetfname, cfg.io_comm, cfg.info, &ncid);
+    }
     CHECK_ERR
 
     /* define dimensions, variables, and attributes */

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -65,6 +65,11 @@ typedef struct e3sm_io_config {
     MPI_Comm io_comm;
     MPI_Info info;
     int num_iotasks;
+    int num_node;
+    int node_id;
+    int node_rank;
+    int node_np;
+    MPI_Comm node_comm;
 
     char *targetdir;
     char *datadir;
@@ -74,6 +79,7 @@ typedef struct e3sm_io_config {
     int wr;
     int rd;
     int nvars;
+    int filepernode;
 
     e3sm_io_strate strate;
     e3sm_io_api api;


### PR DESCRIPTION
Add command line option (-l) for sub-filing
Create node-local communicator and calculate required information
Pass the config structure (includes sub-filing information) to F case subroutines
Create file with node-local communicator instead of io_comm.
Attach PIO attributes only on the first sub-file
