### PR TITLE
Make the F case blob strategy more consistent with E3SM Scorpio

### DIFF
--- a/src/cases/header_io_F_case_pio.cpp
+++ b/src/cases/header_io_F_case_pio.cpp
@@ -103,6 +103,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     char name[128];
 
     /* global attributes: */
+    /*
     iattr = 4;
     err   = e3sm_io_pio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR, "ne", MPI_INT, 1, &iattr);
     CHECK_ERR
@@ -134,10 +135,54 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "time_period_freq", 5, "day_5");
     CHECK_ERR
+    */
 
     // PIO attributes
     k   = 256;
     err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "/__pio__/fillmode", MPI_INT, 1, &k);
+    CHECK_ERR
+
+    // Sub-file 0 only attributes
+    // TODO: retrieve real attribute content
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/Conventions", 6, "CF-1.7");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/case", 33, "ADIOS_FC5AV1C-H01A_ne120_oRRS18v3");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/contact", 35, "e3sm-data-support@listserv.llnl.gov");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/git_version", 10, "025f820fce");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/history", 28, "created on 06/10/21 11:59:48");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/hostname", 8, "cori-knl");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/initial_file", 99, "/global/cfs/cdirs/e3sm/inputdata/atm/cam/inic/homme/cami_mam3_Linoz_0000-01-ne120np4_L72_c160318.nc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/institution", 660, "LLNL (Lawrence Livermore National Laboratory, Livermore, CA 94550, USA); ANL (Argonne National Laboratory, Argonne, IL 60439, USA); BNL (Brookhaven National Laboratory, Upton, NY 11973, USA); LANL (Los Alamos National Laboratory, Los Alamos, NM 87545, USA); LBNL (Lawrence Berkeley National Laboratory, Berkeley, CA 94720, USA); ORNL (Oak Ridge National Laboratory, Oak Ridge, TN 37831, USA); PNNL (Pacific Northwest National Laboratory, Richland, WA 99352, USA); SNL (Sandia National Laboratories, Albuquerque, NM 87185, USA). Mailing address: LLNL Climate Program, c/o David C. Bader, Principal Investigator, L-103, 7000 East Avenue, Livermore, CA 94550, USA");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/institution_id", 12, "E3SM-Project");
+    CHECK_ERR
+    k = 120;
+    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/ne", MPI_INT, 1, &k);
+    CHECK_ERR
+    k = 21600;
+    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/np", MPI_INT, 1, &k);
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/product", 12, "model-output");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/realm", 5, "atmos");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/source", 21, "E3SM Atmosphere Model");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/source_id", 10, "025f820fce");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/time_period_freq", 5, "day_5");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/title", 28, "EAM History file information");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/topography_file", 96, "/global/cfs/cdirs/e3sm/inputdata/atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/username", 4, "dqwu");
     CHECK_ERR
 
     /* define dimensions */

--- a/src/cases/header_io_F_case_pio.cpp
+++ b/src/cases/header_io_F_case_pio.cpp
@@ -137,7 +137,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     // PIO attributes
     k   = 256;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "/__e3sm_io__/fillmode", MPI_INT, 1, &k);
+    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "/__pio__/fillmode", MPI_INT, 1, &k);
     CHECK_ERR
 
     /* define dimensions */
@@ -158,7 +158,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     for (j = 0; j < 5; j++) {
         int piodecomid[] = {0, 1, 1, 1, 2};
 
-        sprintf (name, "/__e3sm_io__/decomp/%d", (j + 512));
+        sprintf (name, "/__pio__/decomp/%d", (j + 512));
         err = driver.def_local_var (ncid, name, MPI_LONG_LONG, 1, decom.raw_nreqs + piodecomid[j],
                                     piovars + j);
         CHECK_ERR
@@ -174,7 +174,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     }
 
     // TODO: only the first subfile contain nproc
-    err = driver.def_local_var (ncid, "/__e3sm_io__/info/nproc", MPI_INT, 0, NULL, piovars + (j++));
+    err = driver.def_local_var (ncid, "/__pio__/info/nproc", MPI_INT, 0, NULL, piovars + (j++));
     CHECK_ERR
 
     /* define variables */
@@ -5994,7 +5994,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     // PIO attributes
     k   = 256;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "/__e3sm_io__/fillmode", MPI_INT, 1, &k);
+    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "/__pio__/fillmode", MPI_INT, 1, &k);
     CHECK_ERR
 
     /* define dimensions */
@@ -6015,7 +6015,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     for (j = 0; j < 5; j++) {
         int piodecomid[] = {0, 1, 1, 1, 2};
         k                = 6;
-        sprintf (name, "/__e3sm_io__/decomp/%d", (j + 512));
+        sprintf (name, "/__pio__/decomp/%d", (j + 512));
         err = driver.def_local_var (ncid, name, MPI_LONG_LONG, 1, decom.raw_nreqs + piodecomid[j],
                                     piovars + j);
         CHECK_ERR
@@ -6029,7 +6029,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
     }
 
     // TODO: only the first subfile contain nproc
-    err = driver.def_local_var (ncid, "/__e3sm_io__/info/nproc", MPI_INT, 0, NULL, piovars + (j++));
+    err = driver.def_local_var (ncid, "/__pio__/info/nproc", MPI_INT, 0, NULL, piovars + (j++));
     CHECK_ERR
 
     i = 0;

--- a/src/cases/var_io_F_case_pio.cpp
+++ b/src/cases/var_io_F_case_pio.cpp
@@ -560,10 +560,12 @@ int run_varn_F_case_pio (e3sm_io_config &cfg,
     timing = MPI_Wtime ();
 
     // Write pio scalar vars (one time)
-    // TODO: only the first subfile contain nproc
-    // nproc
-    err = driver.put_varl (ncid, piovars[5], MPI_LONG_LONG, &(cfg.np), nb);
-    CHECK_ERR
+    
+    // Nproc only written by rank 0
+    if (cfg.rank == 0) {
+        err = driver.put_varl (ncid, piovars[5], MPI_LONG_LONG, &(cfg.np), nb);
+        CHECK_ERR
+    }
 
     i           = 0;
     dbl_buf_ptr = dbl_buf;

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -363,7 +363,7 @@ int e3sm_io_driver_adios2::def_dim (int fid, std::string name, MPI_Offset size, 
     adios2_file *fp = this->files[fid];
     adios2_variable *dp;
 
-    dp = adios2_define_variable (fp->iop, ("/__pio__/dim/" + name).c_str (), adios2_type_int64_t, 0,
+    dp = adios2_define_variable (fp->iop, ("/__pio__/dim/" + name).c_str (), adios2_type_uint64_t, 0,
                                  NULL, NULL, NULL, adios2_constant_dims_true);
     CHECK_APTR (dp)
 

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -357,7 +357,7 @@ int e3sm_io_driver_adios2::def_dim (int fid, std::string name, MPI_Offset size, 
     adios2_variable *dp;
 
     dp =
-        adios2_define_variable (fp->iop, ("/__e3sm_io__/dim/" + name).c_str (), adios2_type_int64_t,
+        adios2_define_variable (fp->iop, ("/__pio__/dim/" + name).c_str (), adios2_type_int64_t,
                                 0, NULL, NULL, NULL, adios2_constant_dims_true);
     CHECK_APTR (dp)
 
@@ -374,7 +374,7 @@ int e3sm_io_driver_adios2::inq_dim (int fid, std::string name, int *dimid) {
     MPI_Offset size;
     adios2_variable *dp;
 
-    dp = adios2_inquire_variable (fp->iop, ("/__e3sm_io__/dim/" + name).c_str ());
+    dp = adios2_inquire_variable (fp->iop, ("/__pio__/dim/" + name).c_str ());
 
     // Read must happen in data mode
     if (fp->ep == NULL) {

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -30,7 +30,7 @@ inline adios2_type mpi_type_to_adios2_type (MPI_Datatype mpitype) {
         case MPI_LONG_LONG:
             return adios2_type_int64_t;
         case MPI_CHAR:
-            return adios2_type_uint8_t;
+            return adios2_type_string;
         default:
             printf ("Error at line %d in %s: Unknown type %d\n", __LINE__, __FILE__, mpitype);
             DEBUG_ABORT


### PR DESCRIPTION
Prefix global attributes name with "pio_global"
Add new attributes: "contact", "git_version", "history", "institution", "institution_id", "product", "realm", "source_id"

Use uint64 isntead of int64 for dimension variables in adios2 driver

Implement put_xxx_text with adios2_type_string instead of adios2_type_uint8 (char) array
    
Replace __e3sm_io__ prefix for scorpio data objects with __pio__:
  
Variable Nproc should only be written by rank 0.
