### PR TITLE
Restore previously removed subfiling support:

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ sharing Decomposition 4, 2 sharing Decomposition 5, and 4 sharing Decomposition
        [-f num] File number to run in F case (-1 (both) (default), 0, 1)
        [-r num] Number of records (default 1)
        [-s num] Stride between IO tasks (default 1)
+       [-g num] Number of IO groups (subfiles) (default 1)
        [-o output_dir] Output directory name (default ./)
        [-i target_dir] Path to directory containing the input files
               pnetcdf:     PnetCDF library

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -112,7 +112,9 @@ int e3sm_io_driver_adios2::create (std::string path, MPI_Comm comm, MPI_Info inf
     CHECK_APTR (fp->iop)
     aerr = adios2_set_engine (fp->iop, "BP3");
     CHECK_AERR
-    aerr = adios2_set_parameter (fp->iop, "substreams", "1");
+
+    sprintf (ng, "%d", cfg->num_group);
+    aerr = adios2_set_parameter (fp->iop, "substreams", ng);
     CHECK_AERR
     aerr = adios2_set_parameter (fp->iop, "CollectiveMetadata", "OFF");
     CHECK_AERR

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -89,6 +89,8 @@ e3sm_io_driver_hdf5::e3sm_io_driver_hdf5 (e3sm_io_config *cfg) : e3sm_io_driver 
         throw "Fitler requries chunking in HDF5";
     }
 
+    if (cfg->num_group != 1) { throw "Subfiling not supported by HDF5 driver"; }
+
     /*
     env = getenv ("E3SM_IO_HDF5_ENABLE_LOGVOL");
     if (env) {

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -46,6 +46,12 @@ int e3sm_io_driver_pnc::create (std::string path, MPI_Comm comm, MPI_Info info, 
         MPI_Info_set (info, "nc_zip_comm_unit", "chunk");
     }
 
+    if (cfg->num_group > 1) {
+        char ng[32];
+        sprintf (ng, "%d", cfg->num_group);
+        MPI_Info_set (info, "nc_num_subfiles", ng);
+    }
+
     err = ncmpi_create (comm, path.c_str (), NC_CLOBBER | NC_64BIT_DATA, info, fid);
     CHECK_NCERR
 

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -88,6 +88,7 @@ static void usage (char *argv0) {
         "       [-f num] File number to run in F case (-1 (both) (default), 0, 1)\n"
         "       [-r num] Number of records (default 1)\n"
         "       [-s num] Stride between IO tasks (default 1)\n"
+        "       [-g num] Number of IO groups (subfiles) (default 1)\n"
         "       [-o output_dir] Output directory name (default ./)\n"
         "       [-i target_dir] Path to directory containing the input files\n"
         "       [-a api] Underlying API to test (pnetcdf (default), hdf5_ra, hdf5_log, hdf5_mv, "
@@ -126,6 +127,7 @@ int main (int argc, char **argv) {
     cfg.io_comm        = MPI_COMM_WORLD;
     cfg.info           = MPI_INFO_NULL;
     cfg.num_iotasks    = cfg.np;
+    cfg.num_group      = 1;
     cfg.targetdir      = targetdir;
     cfg.datadir        = datadir;
     cfg.cfgpath        = cfgpath;
@@ -146,7 +148,7 @@ int main (int argc, char **argv) {
     cfg.io_stride      = 1;
 
     /* command-line arguments */
-    while ((i = getopt (argc, argv, "vkr:s:o:i:dnmtRWf:ha:x:")) != EOF) switch (i) {
+    while ((i = getopt (argc, argv, "vkr:s:o:i:dnmtRWf:ha:x:g:")) != EOF) switch (i) {
             case 'v':
                 cfg.verbose = 1;
                 break;
@@ -211,6 +213,7 @@ int main (int argc, char **argv) {
                     RET_ERR ("Unknown I/O strategy")
                 }
                 break;
+
             case 'o':
                 strncpy (cfg.targetdir, optarg, E3SM_IO_MAX_PATH);
                 break;
@@ -237,6 +240,9 @@ int main (int argc, char **argv) {
                 break;
             case 'f':
                 cfg.hx = atoi (optarg);
+                break;
+            case 'g':
+                cfg.num_group = atoi (optarg);
                 break;
             case 'c':
                 cfg.chunksize = atoll (optarg);

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -64,6 +64,7 @@ typedef struct e3sm_io_config {
     MPI_Comm io_comm;
     MPI_Info info;
     int num_iotasks;
+    int num_group;
 
     char *targetdir;
     char *datadir;


### PR DESCRIPTION
Add command line option (-g) to set number of subfiles.
Set the corresponding subfiling property if the underlying API supports it.
It is not supported by HDF5 driver.