### PR TITLE
Fix bug on decomposition map init

### DIFF
--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -146,6 +146,11 @@ int main (int argc, char **argv) {
     cfg.two_buf        = 0;
     cfg.non_contig_buf = 0;
     cfg.io_stride      = 1;
+    for (i = 0; i < MAX_NUM_DECOMP; i++) {
+        decom.blocklens[i]   = NULL;
+        decom.disps[i]       = NULL;
+        decom.raw_offsets[i] = NULL;
+    }
 
     /* command-line arguments */
     while ((i = getopt (argc, argv, "vkr:s:o:i:dnmtRWf:ha:x:g:")) != EOF) switch (i) {
@@ -284,11 +289,6 @@ int main (int argc, char **argv) {
     if (cfg.datadir[0] != '\0') { PRINT_MSG (1, "Input folder name =%s\n", cfg.datadir); }
 
     /* read request information from decompositions 1, 2 and 3 */
-    for (i = 0; i < MAX_NUM_DECOMP; i++) {
-        decom.blocklens[i]   = NULL;
-        decom.disps[i]       = NULL;
-        decom.raw_offsets[i] = NULL;
-    }
     if (cfg.strate == blob) {
         err = read_decomp (cfg.verbose, cfg.io_comm, cfg.cfgpath, &(decom.num_decomp), decom.dims,
                            decom.contig_nreqs, decom.ndims, decom.disps, decom.blocklens,


### PR DESCRIPTION
If the program exit on error before deomposition map can be initialized
to NULL, the clean up routine will try to free it, causing segmentation
fault.
The fix move the initialization to the start of the program.
line options.