### PR TITLE
Count exact get/put size by the application

### DIFF
--- a/src/cases/var_io_F_case.cpp
+++ b/src/cases/var_io_F_case.cpp
@@ -447,7 +447,7 @@ int run_vard_F_case (e3sm_io_config &cfg,
     double pre_timing, open_timing, io_timing, close_timing;
     double timing, total_timing, max_timing;
     MPI_Aint *var_disps, *buf_disps;
-    MPI_Offset tmp, metadata_size, rec_size, put_size, total_size;
+    MPI_Offset tmp, metadata_size, rec_size, put_size, total_size, fsize;
     MPI_Offset offset_fix, offset_rec, var_offset, max_nreqs, total_nreqs;
     MPI_Datatype *var_types, type[4], *filetype_rec, filetype_dbl;
     MPI_Datatype buftype_rec, buftype_dbl;
@@ -737,6 +737,10 @@ int run_vard_F_case (e3sm_io_config &cfg,
     err = driver.inq_put_size (ncid, &total_size);
     CHECK_ERR
     put_size = total_size - metadata_size;
+    if (cfg.rank == 0){
+        err = driver.inq_file_size(targetfname, &fsize);
+        CHECK_ERR
+    }
     err      = driver.close (ncid);
     CHECK_ERR
     close_timing = MPI_Wtime () - close_timing;
@@ -791,6 +795,8 @@ int run_vard_F_case (e3sm_io_config &cfg,
 
     if (rank == 0) {
         printf ("History output file                = %s\n", outfile.c_str ());
+        printf ("Output file size                 = %.2f MiB = %.2f GiB\n",
+                (double)fsize / 1048576, (double)fsize / 1073741824);
         printf ("MAX heap memory allocated by PnetCDF internally is %.2f MiB\n",
                 (float)max_alloc / 1048576);
         printf ("Total number of variables          = %d\n", cfg.nvars);
@@ -981,7 +987,7 @@ int run_varn_F_case (e3sm_io_config &cfg,
     double *dbl_buf = NULL, *dbl_buf_ptr;
     double pre_timing, open_timing, post_timing, wait_timing, close_timing;
     double timing, total_timing, max_timing;
-    MPI_Offset tmp, metadata_size, put_size, total_size, max_nreqs, total_nreqs;
+    MPI_Offset tmp, metadata_size, put_size, total_size, fsize, max_nreqs, total_nreqs;
     MPI_Offset **starts_D2 = NULL, **counts_D2 = NULL;
     MPI_Offset **starts_D3 = NULL, **counts_D3 = NULL;
     MPI_Info info_used = MPI_INFO_NULL;
@@ -1314,6 +1320,10 @@ int run_varn_F_case (e3sm_io_config &cfg,
     err = driver.inq_put_size (ncid, &total_size);
     CHECK_ERR
     put_size = total_size - metadata_size;
+    if (cfg.rank == 0){
+        err = driver.inq_file_size(targetfname, &fsize);
+        CHECK_ERR
+    }
     err      = driver.close (ncid);
     CHECK_ERR
     close_timing += MPI_Wtime () - timing;
@@ -1369,6 +1379,8 @@ int run_varn_F_case (e3sm_io_config &cfg,
         int nvars_noD = cfg.nvars;
         for (i = 0; i < 3; i++) nvars_noD -= nvars_D[i];
         printf ("History output file                = %s\n", outfile.c_str ());
+        printf ("Output file size                 = %.2f MiB = %.2f GiB\n",
+                (double)fsize / 1048576, (double)fsize / 1073741824);
         printf ("No. variables use no decomposition = %3d\n", nvars_noD);
         printf ("No. variables use decomposition D1 = %3d\n", nvars_D[0]);
         printf ("No. variables use decomposition D2 = %3d\n", nvars_D[1]);
@@ -1430,7 +1442,7 @@ int run_varn_F_case_rd (e3sm_io_config &cfg,
     double *dbl_buf, *dbl_buf_ptr;
     double pre_timing, open_timing, post_timing, wait_timing, close_timing;
     double timing, total_timing, max_timing;
-    MPI_Offset tmp, metadata_size, put_size, total_size, max_nreqs, total_nreqs;
+    MPI_Offset tmp, metadata_size, put_size, total_size, fsize, max_nreqs, total_nreqs;
     MPI_Offset **starts_D2 = NULL, **counts_D2 = NULL;
     MPI_Offset **starts_D3 = NULL, **counts_D3 = NULL;
     MPI_Comm comm      = cfg.io_comm;
@@ -1754,6 +1766,10 @@ int run_varn_F_case_rd (e3sm_io_config &cfg,
     err = driver.inq_get_size (ncid, &total_size);
     CHECK_ERR
     put_size = total_size - metadata_size;
+    if (cfg.rank == 0){
+        err = driver.inq_file_size(targetfname, &fsize);
+        CHECK_ERR
+    }
     err      = driver.close (ncid);
     CHECK_ERR
     close_timing += MPI_Wtime () - timing;
@@ -1806,6 +1822,8 @@ int run_varn_F_case_rd (e3sm_io_config &cfg,
     MPI_Reduce (&m_alloc, &max_alloc, 1, MPI_OFFSET, MPI_MAX, 0, comm);
     if (rank == 0) {
         printf ("History output file                = %s\n", outfile.c_str ());
+        printf ("Input file size                 = %.2f MiB = %.2f GiB\n",
+                (double)fsize / 1048576, (double)fsize / 1073741824);
         printf ("MAX heap memory allocated by PnetCDF internally is %.2f MiB\n",
                 (float)max_alloc / 1048576);
         printf ("Total number of variables          = %d\n", cfg.nvars);

--- a/src/cases/var_io_G_case.cpp
+++ b/src/cases/var_io_G_case.cpp
@@ -210,7 +210,7 @@ int run_varn_G_case (e3sm_io_config &cfg,
     double *D1_fix_dbl_buf;
     double pre_timing, open_timing, post_timing, wait_timing, close_timing;
     double timing, total_timing, max_timing;
-    MPI_Offset tmp, metadata_size, put_size, total_size, total_nreqs, max_nreqs;
+    MPI_Offset tmp, metadata_size, put_size, total_size, fsize, total_nreqs, max_nreqs;
     MPI_Offset **fix_starts_D1, **fix_counts_D1;
     MPI_Offset **fix_starts_D2, **fix_counts_D2;
     MPI_Offset **fix_starts_D3, **fix_counts_D3;
@@ -686,6 +686,10 @@ int run_varn_G_case (e3sm_io_config &cfg,
     err = driver.inq_put_size (ncid, &total_size);
     CHECK_ERR
     put_size = total_size - metadata_size;
+    if (cfg.rank == 0){
+        err = driver.inq_file_size(outfname, &fsize);
+        CHECK_ERR
+    }
 
     err = driver.close (ncid);
     CHECK_ERR
@@ -782,6 +786,8 @@ int run_varn_G_case (e3sm_io_config &cfg,
         int nvars_noD = cfg.nvars;
         for (i = 0; i < 6; i++) nvars_noD -= nvars_D[i];
         printf ("History output file                = %s\n", outfile.c_str ());
+        printf ("Output file size                 = %.2f MiB = %.2f GiB\n",
+                (double)fsize / 1048576, (double)fsize / 1073741824);
         printf ("No. variables use no decomposition = %3d\n", nvars_noD);
         printf ("No. variables use decomposition D1 = %3d\n", nvars_D[0]);
         printf ("No. variables use decomposition D2 = %3d\n", nvars_D[1]);
@@ -844,7 +850,7 @@ int run_varn_G_case_rd (e3sm_io_config &cfg,
     double *D1_fix_dbl_buf;
     double pre_timing, open_timing, post_timing, wait_timing, close_timing;
     double timing, total_timing, max_timing;
-    MPI_Offset tmp, metadata_size, get_size, total_size, total_nreqs, max_nreqs;
+    MPI_Offset tmp, metadata_size, get_size, total_size, fsize, total_nreqs, max_nreqs;
     MPI_Offset **fix_starts_D1, **fix_counts_D1;
     MPI_Offset **fix_starts_D2, **fix_counts_D2;
     MPI_Offset **fix_starts_D3, **fix_counts_D3;
@@ -1276,6 +1282,10 @@ int run_varn_G_case_rd (e3sm_io_config &cfg,
     err = driver.inq_get_size (ncid, &total_size);
     CHECK_ERR
     get_size = total_size - metadata_size;
+    if (cfg.rank == 0){
+        err = driver.inq_file_size(outfname, &fsize);
+        CHECK_ERR
+    }
 
     err = driver.close (ncid);
     CHECK_ERR
@@ -1368,6 +1378,8 @@ int run_varn_G_case_rd (e3sm_io_config &cfg,
     MPI_Reduce (&m_alloc, &max_alloc, 1, MPI_OFFSET, MPI_MAX, 0, comm);
     if (rank == 0) {
         printf ("History output file                = %s\n", outfile.c_str ());
+        printf ("Input file size                 = %.2f MiB = %.2f GiB\n",
+                (double)fsize / 1048576, (double)fsize / 1073741824);
         printf ("MAX heap memory allocated by PnetCDF internally is %.2f MiB\n",
                 (float)max_alloc / 1048576);
         printf ("Total number of variables          = %d\n", cfg.nvars);

--- a/src/drivers/e3sm_io_driver.hpp
+++ b/src/drivers/e3sm_io_driver.hpp
@@ -14,10 +14,11 @@ class e3sm_io_driver {
 
    public:
     e3sm_io_driver (e3sm_io_config *cfg) : cfg (cfg) {};
-    virtual ~e3sm_io_driver (){   };
+    virtual ~e3sm_io_driver () {};
     virtual int create (std::string path, MPI_Comm comm, MPI_Info info, int *fid) = 0;
     virtual int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid)   = 0;
     virtual int close (int fid)                                                   = 0;
+    virtual int inq_file_size (std::string path, MPI_Offset *size)                = 0;
     virtual int inq_file_info (int fid, MPI_Info *info)                           = 0;
     virtual int inq_put_size (int fid, MPI_Offset *size)                          = 0;
     virtual int inq_get_size (int fid, MPI_Offset *size)                          = 0;

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -49,9 +49,11 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
         std::vector<adios2_variable *> dids;
         std::vector<int> ndims;
         std::vector<size_t> dsizes;
-        std::vector<adios2_variable*> ddids;
+        std::vector<adios2_variable *> ddids;
         MPI_Offset recsize = 0;
         adios2_operator *op;
+        MPI_Offset putsize = 0;
+        MPI_Offset getsize = 0;
     } adios2_file;
     std::vector<adios2_file *> files;
     double tsel, twrite, tread, text;

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -65,6 +65,7 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
     int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
     int close (int fid);
     int inq_file_info (int fid, MPI_Info *info);
+    int inq_file_size (std::string path, MPI_Offset *size);
     int inq_put_size (int fid, MPI_Offset *size);
     int inq_get_size (int fid, MPI_Offset *size);
     int inq_malloc_size (MPI_Offset *size);

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -240,6 +240,19 @@ err_out:;
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5)
     return nerrs;
 }
+int e3sm_io_driver_hdf5::inq_file_size (std::string path, MPI_Offset *size) {
+    int nerrs = 0;
+    int err;
+    struct stat file_stat;
+
+    err = stat (path.c_str (), &file_stat);
+    CHECK_ERR
+
+    *size = (MPI_Offset) (file_stat.st_size);
+
+err_out:;
+    return nerrs;
+}
 int e3sm_io_driver_hdf5::inq_put_size (int fid, MPI_Offset *size) {
     int nerrs = 0;
     herr_t herr;

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -84,6 +84,7 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
     int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
     int close (int fid);
     int inq_file_info (int fid, MPI_Info *info);
+    int inq_file_size (std::string path, MPI_Offset *size);
     int inq_put_size (int fid, MPI_Offset *size);
     int inq_get_size (int fid, MPI_Offset *size);
     int inq_malloc_size (MPI_Offset *size);

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -32,6 +32,9 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
         std::vector<hid_t> dids;
         std::vector<hsize_t> dsizes;
         MPI_Offset recsize = 0;
+        MPI_Offset putsize = 0;
+        MPI_Offset getsize = 0;
+
 #ifndef HDF5_HAVE_DWRITE_MULTI
         typedef struct H5D_rw_multi_t {
             hid_t dset_id;       /* dataset ID */

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -10,6 +10,8 @@
 #include <config.h>
 #endif
 //
+#include <sys/stat.h>
+//
 #include <pnetcdf.h>
 //
 #include <e3sm_io.h>
@@ -91,6 +93,20 @@ int e3sm_io_driver_pnc::inq_file_info (int fid, MPI_Info *info) {
 
     err = ncmpi_inq_file_info (fid, info);
     CHECK_NCERR
+
+err_out:;
+    return nerrs;
+}
+
+int e3sm_io_driver_pnc::inq_file_size (std::string path, MPI_Offset *size) {
+    int nerrs = 0;
+    int err;
+    struct stat file_stat;
+
+    err = stat (path.c_str (), &file_stat);
+    CHECK_ERR
+
+    *size = (MPI_Offset) (file_stat.st_size);
 
 err_out:;
     return nerrs;

--- a/src/drivers/e3sm_io_driver_pnc.hpp
+++ b/src/drivers/e3sm_io_driver_pnc.hpp
@@ -48,6 +48,7 @@ class e3sm_io_driver_pnc : public e3sm_io_driver {
     int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
     int close (int fid);
     int inq_file_info (int fid, MPI_Info *info);
+    int inq_file_size (std::string path, MPI_Offset *size);
     int inq_put_size (int fid, MPI_Offset *size);
     int inq_get_size (int fid, MPI_Offset *size);
     int inq_malloc_size (MPI_Offset *size);


### PR DESCRIPTION
Stop using file size as get/put size in ADIOS2 and HDF5.
Count get/put size one very variable/attribute I/O in HDF5 and ADIOS2 driver.
Report file size alongside get/put size in each test cases.