### PR TITLE
Only rank 0 writes to pio attributes

### DIFF
--- a/src/cases/e3sm_io_case_pio.hpp
+++ b/src/cases/e3sm_io_case_pio.hpp
@@ -99,7 +99,7 @@ inline int e3sm_io_pio_define_var (e3sm_io_driver &driver,
             // CHECK_ERR
 
             ibuf = var->decomp_id + 512;
-            err  = driver.put_att (fid, var->data, "__e3sm_io__/decomp", MPI_INT, 1, &ibuf, coll);
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/decomp", MPI_INT, 1, &ibuf, master);
             CHECK_ERR
 
             cbufp = cbuf;
@@ -110,18 +110,18 @@ inline int e3sm_io_pio_define_var (e3sm_io_driver &driver,
                 cbufp += ret;
             }
             err =
-                driver.put_att (fid, var->data, "__e3sm_io__/dims", MPI_CHAR, strlen (cbuf), cbuf, coll);
+                driver.put_att (fid, var->data, "__e3sm_io__/dims", MPI_CHAR, strlen (cbuf), cbuf, master);
             CHECK_ERR
 
             err =
-                driver.put_att (fid, var->data, "__e3sm_io__/ncop", MPI_CHAR, 7, (void *)"darray", coll);
+                driver.put_att (fid, var->data, "__e3sm_io__/ncop", MPI_CHAR, 7, (void *)"darray", master);
             CHECK_ERR
 
             ibuf = 5;
-            err  = driver.put_att (fid, var->data, "__e3sm_io__/nctype", MPI_INT, 1, &ibuf, coll);
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/nctype", MPI_INT, 1, &ibuf, master);
             CHECK_ERR
 
-            err = driver.put_att (fid, var->data, "__e3sm_io__/ndims", MPI_INT, 1, &ndim, coll);
+            err = driver.put_att (fid, var->data, "__e3sm_io__/ndims", MPI_INT, 1, &ndim, master);
             CHECK_ERR
         }
     } else {
@@ -144,7 +144,7 @@ inline int e3sm_io_pio_define_var (e3sm_io_driver &driver,
         // Attributes for non-constant small vars
         if (ndim > 0) {
             ibuf = (int)mpi_type_to_adios2_type (type);
-            err  = driver.put_att (fid, var->data, "__e3sm_io__/adiostype", MPI_INT, 1, &ibuf, coll);
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/adiostype", MPI_INT, 1, &ibuf, master);
             CHECK_ERR
 
             cbufp = cbuf;
@@ -155,18 +155,18 @@ inline int e3sm_io_pio_define_var (e3sm_io_driver &driver,
                 cbufp += ret;
             }
             err =
-                driver.put_att (fid, var->data, "__e3sm_io__/dims", MPI_CHAR, strlen (cbuf), cbuf, coll);
+                driver.put_att (fid, var->data, "__e3sm_io__/dims", MPI_CHAR, strlen (cbuf), cbuf, master);
             CHECK_ERR
 
             err =
-                driver.put_att (fid, var->data, "__e3sm_io__/ncop", MPI_CHAR, 7, (void *)"put_var", coll);
+                driver.put_att (fid, var->data, "__e3sm_io__/ncop", MPI_CHAR, 7, (void *)"put_var", master);
             CHECK_ERR
 
             ibuf = (int)mpitype2nctype (type);
-            err  = driver.put_att (fid, var->data, "__e3sm_io__/nctype", MPI_INT, 1, &ibuf, coll);
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/nctype", MPI_INT, 1, &ibuf, master);
             CHECK_ERR
 
-            err = driver.put_att (fid, var->data, "__e3sm_io__/ndims", MPI_INT, 1, &ndim, coll);
+            err = driver.put_att (fid, var->data, "__e3sm_io__/ndims", MPI_INT, 1, &ndim, master);
             CHECK_ERR
         }
 

--- a/src/cases/e3sm_io_case_pio.hpp
+++ b/src/cases/e3sm_io_case_pio.hpp
@@ -99,7 +99,7 @@ inline int e3sm_io_pio_define_var (e3sm_io_driver &driver,
             // CHECK_ERR
 
             ibuf = var->decomp_id + 512;
-            err  = driver.put_att (fid, var->data, "__e3sm_io__/decomp", MPI_INT, 1, &ibuf);
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/decomp", MPI_INT, 1, &ibuf, coll);
             CHECK_ERR
 
             cbufp = cbuf;
@@ -110,18 +110,18 @@ inline int e3sm_io_pio_define_var (e3sm_io_driver &driver,
                 cbufp += ret;
             }
             err =
-                driver.put_att (fid, var->data, "__e3sm_io__/dims", MPI_CHAR, strlen (cbuf), cbuf);
+                driver.put_att (fid, var->data, "__e3sm_io__/dims", MPI_CHAR, strlen (cbuf), cbuf, coll);
             CHECK_ERR
 
             err =
-                driver.put_att (fid, var->data, "__e3sm_io__/ncop", MPI_CHAR, 7, (void *)"darray");
+                driver.put_att (fid, var->data, "__e3sm_io__/ncop", MPI_CHAR, 7, (void *)"darray", coll);
             CHECK_ERR
 
             ibuf = 5;
-            err  = driver.put_att (fid, var->data, "__e3sm_io__/nctype", MPI_INT, 1, &ibuf);
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/nctype", MPI_INT, 1, &ibuf, coll);
             CHECK_ERR
 
-            err = driver.put_att (fid, var->data, "__e3sm_io__/ndims", MPI_INT, 1, &ndim);
+            err = driver.put_att (fid, var->data, "__e3sm_io__/ndims", MPI_INT, 1, &ndim, coll);
             CHECK_ERR
         }
     } else {
@@ -144,7 +144,7 @@ inline int e3sm_io_pio_define_var (e3sm_io_driver &driver,
         // Attributes for non-constant small vars
         if (ndim > 0) {
             ibuf = (int)mpi_type_to_adios2_type (type);
-            err  = driver.put_att (fid, var->data, "__e3sm_io__/adiostype", MPI_INT, 1, &ibuf);
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/adiostype", MPI_INT, 1, &ibuf, coll);
             CHECK_ERR
 
             cbufp = cbuf;
@@ -155,18 +155,18 @@ inline int e3sm_io_pio_define_var (e3sm_io_driver &driver,
                 cbufp += ret;
             }
             err =
-                driver.put_att (fid, var->data, "__e3sm_io__/dims", MPI_CHAR, strlen (cbuf), cbuf);
+                driver.put_att (fid, var->data, "__e3sm_io__/dims", MPI_CHAR, strlen (cbuf), cbuf, coll);
             CHECK_ERR
 
             err =
-                driver.put_att (fid, var->data, "__e3sm_io__/ncop", MPI_CHAR, 7, (void *)"put_var");
+                driver.put_att (fid, var->data, "__e3sm_io__/ncop", MPI_CHAR, 7, (void *)"put_var", coll);
             CHECK_ERR
 
             ibuf = (int)mpitype2nctype (type);
-            err  = driver.put_att (fid, var->data, "__e3sm_io__/nctype", MPI_INT, 1, &ibuf);
+            err  = driver.put_att (fid, var->data, "__e3sm_io__/nctype", MPI_INT, 1, &ibuf, coll);
             CHECK_ERR
 
-            err = driver.put_att (fid, var->data, "__e3sm_io__/ndims", MPI_INT, 1, &ndim);
+            err = driver.put_att (fid, var->data, "__e3sm_io__/ndims", MPI_INT, 1, &ndim, coll);
             CHECK_ERR
         }
 
@@ -216,7 +216,7 @@ inline int e3sm_io_pio_put_att (e3sm_io_driver &driver,
                                 MPI_Datatype type,
                                 MPI_Offset size,
                                 void *buf) {
-    return driver.put_att (fid, vid, name, type, size, buf);
+    return driver.put_att (fid, vid, name, type, size, buf, coll);
 }
 
 inline int e3sm_io_pio_put_att (e3sm_io_driver &driver,
@@ -226,5 +226,5 @@ inline int e3sm_io_pio_put_att (e3sm_io_driver &driver,
                                 MPI_Datatype type,
                                 MPI_Offset size,
                                 void *buf) {
-    return driver.put_att (fid, var.data, name, type, size, buf);
+    return driver.put_att (fid, var.data, name, type, size, buf, coll);
 }

--- a/src/cases/header_io_F_case.cpp
+++ b/src/cases/header_io_F_case.cpp
@@ -18,9 +18,10 @@
 #include <e3sm_io_driver.hpp>
 #include <e3sm_io_err.h>
 
-#define PUT_ATT_TEXT(F, D, N, S, B)     driver.put_att (F, D, N, MPI_CHAR, S, (void *)B);
-#define PUT_ATT_FLOAT(F, D, N, T, S, B) driver.put_att (F, D, N, MPI_FLOAT, S, (float *)B);
-#define PUT_ATT_INT(F, D, N, T, S, B)   driver.put_att (F, D, N, MPI_FLOAT, S, (int *)B);
+#define PUT_ATT_TEXT(F, D, N, S, B)     driver.put_att (F, D, N, MPI_CHAR, S, (void *)B, coll);
+#define PUT_ATT_FLOAT(F, D, N, T, S, B) driver.put_att (F, D, N, MPI_FLOAT, S, (float *)B, coll);
+#define PUT_ATT_INT(F, D, N, T, S, B)   driver.put_att (F, D, N, MPI_FLOAT, S, (int *)B, coll);
+#define PUT_ATT(F, D, N, T, S, B)   driver.put_att (F, D, N, T, S, B, coll);
 
 #define GET_ATT_TEXT(F, D, N, S, B)     driver.get_att (F, D, N, (void *)attbuf);
 #define GET_ATT_FLOAT(F, D, N, T, S, B) driver.get_att (F, D, N, (float *)attbuf);
@@ -92,9 +93,9 @@ int def_F_case_h0 (e3sm_io_driver &driver,
 
     /* global attributes: */
     iattr = 4;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "ne", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "ne", MPI_INT, 1, &iattr);
     CHECK_ERR
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "np", MPI_INT, 1, &iattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "np", MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "Conventions", 6, "CF-1.0");
     CHECK_ERR
@@ -10899,9 +10900,9 @@ int def_F_case_h1 (e3sm_io_driver &driver,
 
     /* global attributes: */
     iattr = 4;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "ne", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "ne", MPI_INT, 1, &iattr);
     CHECK_ERR
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "np", MPI_INT, 1, &iattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "np", MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "Conventions", 6, "CF-1.0");
     CHECK_ERR

--- a/src/cases/header_io_F_case_pio.cpp
+++ b/src/cases/header_io_F_case_pio.cpp
@@ -28,6 +28,7 @@
 #define PUT_ATT_FLOAT(F, D, N, T, S, B) \
     e3sm_io_pio_put_att (driver, F, D, N, MPI_FLOAT, S, (float *)B);
 #define PUT_ATT_INT(F, D, N, T, S, B) e3sm_io_pio_put_att (driver, F, D, N, MPI_FLOAT, S, (int *)B);
+#define PUT_ATT(F, D, N, T, S, B) e3sm_io_pio_put_att (driver, F, D, N, T, S, (int *)B);
 
 #define GET_ATT_TEXT(F, D, N, S, B)     driver.get_att (F, D, N, (void *)attbuf);
 #define GET_ATT_FLOAT(F, D, N, T, S, B) driver.get_att (F, D, N, (float *)attbuf);
@@ -139,7 +140,7 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
 
     // PIO attributes
     k   = 256;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "/__pio__/fillmode", MPI_INT, 1, &k);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "/__pio__/fillmode", MPI_INT, 1, &k);
     CHECK_ERR
 
     // Sub-file 0 only attributes
@@ -163,10 +164,10 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/institution_id", 12, "E3SM-Project");
     CHECK_ERR
     k = 120;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/ne", MPI_INT, 1, &k);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/ne", MPI_INT, 1, &k);
     CHECK_ERR
     k = 21600;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/np", MPI_INT, 1, &k);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/np", MPI_INT, 1, &k);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/product", 12, "model-output");
     CHECK_ERR
@@ -207,14 +208,14 @@ int def_F_case_h0_pio (e3sm_io_driver &driver,
         err = driver.def_local_var (ncid, name, MPI_LONG_LONG, 1, decom.raw_nreqs + piodecomid[j],
                                     piovars + j);
         CHECK_ERR
-        err = driver.put_att (ncid, piovars[j], "dimlen", MPI_INT, decom.ndims[piodecomid[j]],
+        err = PUT_ATT (ncid, piovars[j], "dimlen", MPI_INT, decom.ndims[piodecomid[j]],
                               decom.dims + piodecomid[j]);
         CHECK_ERR
-        err = driver.put_att (ncid, piovars[j], "ndims", MPI_INT, 1, decom.ndims + piodecomid[j]);
+        err = PUT_ATT (ncid, piovars[j], "ndims", MPI_INT, 1, decom.ndims + piodecomid[j]);
         CHECK_ERR
 
         k   = 6;
-        err = driver.put_att (ncid, piovars[j], "piotype", MPI_INT, 1, &k);
+        err = PUT_ATT (ncid, piovars[j], "piotype", MPI_INT, 1, &k);
         CHECK_ERR
     }
 
@@ -6039,7 +6040,7 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
 
     // PIO attributes
     k   = 256;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "/__pio__/fillmode", MPI_INT, 1, &k);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "/__pio__/fillmode", MPI_INT, 1, &k);
     CHECK_ERR
 
     /* define dimensions */
@@ -6064,12 +6065,12 @@ int def_F_case_h1_pio (e3sm_io_driver &driver,
         err = driver.def_local_var (ncid, name, MPI_LONG_LONG, 1, decom.raw_nreqs + piodecomid[j],
                                     piovars + j);
         CHECK_ERR
-        err = driver.put_att (ncid, piovars[j], "dimlen", MPI_INT, decom.ndims[piodecomid[j]],
+        err = PUT_ATT (ncid, piovars[j], "dimlen", MPI_INT, decom.ndims[piodecomid[j]],
                               decom.dims + piodecomid[j]);
         CHECK_ERR
-        err = driver.put_att (ncid, piovars[j], "ndims", MPI_INT, 1, decom.ndims + piodecomid[j]);
+        err = PUT_ATT (ncid, piovars[j], "ndims", MPI_INT, 1, decom.ndims + piodecomid[j]);
         CHECK_ERR
-        err = driver.put_att (ncid, piovars[j], "piotype", MPI_INT, 1, &k);
+        err = PUT_ATT (ncid, piovars[j], "piotype", MPI_INT, 1, &k);
         CHECK_ERR
     }
 

--- a/src/cases/header_io_G_case.cpp
+++ b/src/cases/header_io_G_case.cpp
@@ -18,9 +18,10 @@
 #include <e3sm_io_driver.hpp>
 #include <e3sm_io_err.h>
 
-#define PUT_ATT_TEXT(F, D, N, S, B)     driver.put_att (F, D, N, MPI_CHAR, S, (void *)B);
-#define PUT_ATT_FLOAT(F, D, N, T, S, B) driver.put_att (F, D, N, MPI_FLOAT, S, (float *)B);
-#define PUT_ATT_INT(F, D, N, T, S, B)   driver.put_att (F, D, N, MPI_FLOAT, S, (int *)B);
+#define PUT_ATT_TEXT(F, D, N, S, B)     driver.put_att (F, D, N, MPI_CHAR, S, (void *)B, coll);
+#define PUT_ATT_FLOAT(F, D, N, T, S, B) driver.put_att (F, D, N, MPI_FLOAT, S, (float *)B, coll);
+#define PUT_ATT_INT(F, D, N, T, S, B)   driver.put_att (F, D, N, MPI_FLOAT, S, (int *)B, coll);
+#define PUT_ATT(F, D, N, T, S, B)   driver.put_att (F, D, N, T, S, B, coll);
 
 #define GET_ATT_TEXT(F, D, N, S, B)     driver.get_att (F, D, N, (void *)attbuf);
 #define GET_ATT_FLOAT(F, D, N, T, S, B) driver.get_att (F, D, N, (float *)attbuf);
@@ -39,7 +40,7 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "on_a_sphere", 3, "YES");
     CHECK_ERR
     dattr = 6371229.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "sphere_radius", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "sphere_radius", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "model_name", 4, "mpas");
     CHECK_ERR
@@ -77,20 +78,20 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_write_output_on_startup", 2, "NO");
     CHECK_ERR
     iattr = 0;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_pio_num_iotasks", MPI_INT, 1, &iattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_pio_num_iotasks", MPI_INT, 1, &iattr);
     CHECK_ERR
     iattr = 1;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_pio_stride", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_pio_stride", MPI_INT, 1, &iattr);
     CHECK_ERR
     iattr = 3;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_num_halos", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_num_halos", MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_block_decomp_file_prefix", 89,
                         "/project/projectdirs/acme/inputdata/ocn/mpas-o/oRRS18to6v3/"
                         "mpas-o.graph.info.170111.part.");
     CHECK_ERR
     iattr = 0;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_number_of_blocks", MPI_INT, 1, &iattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_number_of_blocks", MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_explicit_proc_decomp", 2, "NO");
     CHECK_ERR
@@ -98,7 +99,7 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "graph.info.part.");
     CHECK_ERR
     iattr = -1;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_vert_levels", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_vert_levels", MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_init_configuration", 4, "none");
     CHECK_ERR
@@ -111,15 +112,15 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_vertical_grid", 7, "uniform");
     CHECK_ERR
     dattr = 1.077;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_1dCVTgenerator_stretch1", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_1dCVTgenerator_stretch1", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 1.0275;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_1dCVTgenerator_stretch2", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_1dCVTgenerator_stretch2", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 1.2;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_1dCVTgenerator_dzSeed", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_1dCVTgenerator_dzSeed", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iterative_init_variable", 15,
@@ -135,10 +136,10 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_min_max_thickness", 2, "NO");
     CHECK_ERR
     dattr = 1.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_min_thickness", MPI_DOUBLE, 1, &dattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_min_thickness", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 6.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_max_thickness_factor", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_max_thickness_factor", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_dzdk_positive", 2, "NO");
@@ -146,19 +147,19 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_freq_filtered_thickness", 2, "NO");
     CHECK_ERR
     dattr = 5.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_thickness_filter_timescale",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_thickness_filter_timescale",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_highFreqThick_restore", 2, "NO");
     CHECK_ERR
     dattr = 30.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_highFreqThick_restore_time",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_highFreqThick_restore_time",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_highFreqThick_del2", 2, "NO");
     CHECK_ERR
     dattr = 100.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_highFreqThick_del2", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_highFreqThick_del2", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_alter_ICs_for_pbcs", 2, "NO");
@@ -166,17 +167,17 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_pbc_alteration_type", 9, "full_cell");
     CHECK_ERR
     dattr = 0.1;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_min_pbc_fraction", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_min_pbc_fraction", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_hmix_scaleWithMesh", 3, "YES");
     CHECK_ERR
     dattr = -1.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_maxMeshDensity", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_maxMeshDensity", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_apvm_scale_factor", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_apvm_scale_factor", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_mom_del2", 2, "NO");
@@ -184,37 +185,37 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_tracer_del2", 2, "NO");
     CHECK_ERR
     dattr = 10.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_mom_del2", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_mom_del2", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 10.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_tracer_del2", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_tracer_del2", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_mom_del4", 3, "YES");
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_tracer_del4", 2, "NO");
     CHECK_ERR
     dattr = 3200000000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_mom_del4", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_mom_del4", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_mom_del4_div_factor", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_mom_del4_div_factor", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_tracer_del4", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_tracer_del4", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_Leith_del2", 2, "NO");
     CHECK_ERR
     dattr = 1.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_Leith_parameter", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_Leith_parameter", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 15000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_Leith_dx", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_Leith_dx", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 2500.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_Leith_visc2_max", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_Leith_visc2_max", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_standardGM", 2, "NO");
     CHECK_ERR
@@ -222,109 +223,109 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
         PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_Redi_surface_layer_tapering", 2, "NO");
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_Redi_surface_layer_tapering_extent",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_Redi_surface_layer_tapering_extent",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err =
         PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_Redi_bottom_layer_tapering", 2, "NO");
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_Redi_bottom_layer_tapering_depth",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_Redi_bottom_layer_tapering_depth",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_GM_Bolus_kappa_function", 8, "constant");
     CHECK_ERR
     dattr = 1800.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_standardGM_tracer_kappa", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_standardGM_tracer_kappa", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_GM_Bolus_kappa_min", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_GM_Bolus_kappa_min", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 600.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_GM_Bolus_kappa_max", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_GM_Bolus_kappa_max", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 20000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_GM_Bolus_cell_size_min", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_GM_Bolus_cell_size_min", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 30000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_GM_Bolus_cell_size_max", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_GM_Bolus_cell_size_max", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_Redi_kappa", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_Redi_kappa", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.3;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_gravWaveSpeed_trunc", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_gravWaveSpeed_trunc", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.01;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_max_relative_slope", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_max_relative_slope", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_mom_del2_tensor", 2, "NO");
     CHECK_ERR
     dattr = 10.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_mom_del2_tensor", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_mom_del2_tensor", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_mom_del4_tensor", 2, "NO");
     CHECK_ERR
     dattr = 50000000000000.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_mom_del4_tensor", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_mom_del4_tensor", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_Rayleigh_friction", 2, "NO");
     CHECK_ERR
     dattr = 0.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_Rayleigh_damping_coeff", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_Rayleigh_damping_coeff", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_Rayleigh_bottom_friction", 2, "NO");
     CHECK_ERR
     dattr = 0.0001;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_Rayleigh_bottom_damping_coeff",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_Rayleigh_bottom_damping_coeff",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_cvmix", 3, "YES");
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_prandtl_number", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_prandtl_number", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_cvmix_background", 3, "YES");
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_background_diffusion",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_background_diffusion",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.0001;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_background_viscosity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_background_viscosity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_cvmix_convection", 3, "YES");
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_convective_diffusion",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_convective_diffusion",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_convective_viscosity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_convective_viscosity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_convective_basedOnBVF", 3, "YES");
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_convective_triggerBVF",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_convective_triggerBVF",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_cvmix_shear", 3, "YES");
     CHECK_ERR
     iattr = 2;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_num_ri_smooth_loops", MPI_INT, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_num_ri_smooth_loops", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_use_BLD_smoothing", 3, "YES");
@@ -332,27 +333,27 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_mixing_scheme", 3, "KPP");
     CHECK_ERR
     dattr = 0.005;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_PP_nu_zero", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_PP_nu_zero", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 5.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_PP_alpha", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_PP_alpha", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 2.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_PP_exp", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_PP_exp", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.005;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_KPP_nu_zero", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_KPP_nu_zero", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 0.7;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_KPP_Ri_zero", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_KPP_Ri_zero", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 3.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_KPP_exp", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_shear_KPP_exp", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_cvmix_tidal_mixing", 2, "NO");
@@ -365,11 +366,11 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
         PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_cvmix_fixed_boundary_layer", 2, "NO");
     CHECK_ERR
     dattr = 30.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_kpp_boundary_layer_depth",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_kpp_boundary_layer_depth",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.25;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_cvmix_kpp_criticalBulkRichardsonNumber", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_kpp_matching", 12, "SimpleShapes");
@@ -382,19 +383,19 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "quadratic");
     CHECK_ERR
     dattr = 0.1;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_kpp_surface_layer_extent",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_kpp_surface_layer_extent",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 5.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_kpp_surface_layer_averaging",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_kpp_surface_layer_averaging",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 10.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "configure_cvmix_kpp_minimum_OBL_under_sea_ice", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 100.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_kpp_stop_OBL_search", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_kpp_stop_OBL_search", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_kpp_use_enhanced_diff", 3, "YES");
@@ -407,10 +408,10 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_const_diff", 2, "NO");
     CHECK_ERR
     dattr = 0.0001;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_vert_visc", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_vert_visc", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_vert_diff", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_vert_diff", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_rich_visc", 2, "NO");
     CHECK_ERR
@@ -418,59 +419,59 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     CHECK_ERR
     dattr = 0.0001;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_bkrd_vert_visc", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_bkrd_vert_visc", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.e-05;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_bkrd_vert_diff", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_bkrd_vert_diff", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.005;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rich_mix", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rich_mix", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_convective_visc", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_convective_visc", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_convective_diff", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_convective_diff", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_tanh_visc", 2, "NO");
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_tanh_diff", 2, "NO");
     CHECK_ERR
     dattr = 0.25;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_max_visc_tanh", MPI_DOUBLE, 1, &dattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_max_visc_tanh", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.0001;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_min_visc_tanh", MPI_DOUBLE, 1, &dattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_min_visc_tanh", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.025;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_max_diff_tanh", MPI_DOUBLE, 1, &dattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_max_diff_tanh", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.e-05;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_min_diff_tanh", MPI_DOUBLE, 1, &dattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_min_diff_tanh", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -100.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_zMid_tanh", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_zMid_tanh", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 100.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_zWidth_tanh", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_zWidth_tanh", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_bulk_wind_stress", 3, "YES");
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_bulk_thickness_flux", 3, "YES");
     CHECK_ERR
     dattr = 0.001;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_flux_attenuation_coefficient",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_flux_attenuation_coefficient",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 10.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_flux_attenuation_coefficient_runoff",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_flux_attenuation_coefficient_runoff",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 86400.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ssh_grad_relax_timescale", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ssh_grad_relax_timescale", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_remove_AIS_coupler_runoff", 2, "NO");
@@ -479,10 +480,10 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     CHECK_ERR
     iattr = 3;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_jerlov_water_type", MPI_INT, 1, &iattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_jerlov_water_type", MPI_INT, 1, &iattr);
     CHECK_ERR
     dattr = 1.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_surface_buoyancy_depth", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_surface_buoyancy_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_frazil_ice_formation", 3, "YES");
@@ -492,35 +493,35 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_under_land_ice", 3, "YES");
     CHECK_ERR
     dattr = 333700.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_heat_of_fusion", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_heat_of_fusion", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 1000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_ice_density", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_ice_density", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.1;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_fractional_thickness_limit",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_fractional_thickness_limit",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 3996.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_specific_heat_sea_water", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_specific_heat_sea_water", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 100.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_maximum_depth", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_maximum_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 4.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_sea_ice_reference_salinity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_sea_ice_reference_salinity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_land_ice_reference_salinity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_land_ice_reference_salinity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_maximum_freezing_temperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_maximum_freezing_temperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_frazil_use_surface_pressure", 2, "NO");
@@ -535,188 +536,188 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         2, "NO");
     CHECK_ERR
     dattr = 10.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_attenuation_coefficient",
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_attenuation_coefficient",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 10.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_boundaryLayerThickness",
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_boundaryLayerThickness",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                         "config_land_ice_flux_boundaryLayerNeighborWeight", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 2009.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_cp_ice", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_cp_ice", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 918.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_rho_ice", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_rho_ice", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.0025;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_topDragCoeff",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_topDragCoeff",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.0001;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_ISOMIP_gammaT",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_ISOMIP_gammaT",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_rms_tidal_velocity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_land_ice_flux_rms_tidal_velocity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.011;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_land_ice_flux_jenkins_heat_transfer_coefficient", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.00031;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_land_ice_flux_jenkins_salt_transfer_coefficient", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_vert_tracer_adv", 7, "stencil");
     CHECK_ERR
     iattr = 3;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_vert_tracer_adv_order", MPI_INT, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_vert_tracer_adv_order", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     iattr = 3;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_horiz_tracer_adv_order", MPI_INT, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_horiz_tracer_adv_order", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     dattr = 0.25;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_coef_3rd_order", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_coef_3rd_order", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_monotonic", 3, "YES");
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_implicit_bottom_drag", 3, "YES");
     CHECK_ERR
     dattr = 0.001;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_implicit_bottom_drag_coeff",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_implicit_bottom_drag_coeff",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_explicit_bottom_drag", 2, "NO");
     CHECK_ERR
     dattr = 0.001;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_explicit_bottom_drag_coeff",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_explicit_bottom_drag_coeff",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1026.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_density0", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_density0", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_pressure_gradient_type", 16,
                         "Jacobian_from_TS");
     CHECK_ERR
     dattr = 0.5;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_common_level_weight", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_common_level_weight", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_type", 2, "jm");
     CHECK_ERR
     dattr = -1.8;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_open_ocean_freezing_temperature_coeff_0", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_open_ocean_freezing_temperature_coeff_S", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_open_ocean_freezing_temperature_coeff_p", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_open_ocean_freezing_temperature_coeff_pS", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_open_ocean_freezing_temperature_reference_pressure", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 0.0622;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_land_ice_cavity_freezing_temperature_coeff_0", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -0.0563;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_land_ice_cavity_freezing_temperature_coeff_S", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -7.43e-08;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_land_ice_cavity_freezing_temperature_coeff_p", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -1.74e-10;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_land_ice_cavity_freezing_temperature_coeff_pS", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_land_ice_cavity_freezing_temperature_reference_pressure",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.2;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_linear_alpha", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_linear_alpha", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.8;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_linear_beta", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_linear_beta", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 5.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_linear_Tref", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_linear_Tref", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 35.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_linear_Sref", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_linear_Sref", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_linear_densityref", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_eos_linear_densityref", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     iattr = 2;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_n_ts_iter", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_n_ts_iter", MPI_INT, 1, &iattr);
     CHECK_ERR
     iattr = 1;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_n_bcl_iter_beg", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_n_bcl_iter_beg", MPI_INT, 1, &iattr);
     CHECK_ERR
     iattr = 2;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_n_bcl_iter_mid", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_n_bcl_iter_mid", MPI_INT, 1, &iattr);
     CHECK_ERR
     iattr = 2;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_n_bcl_iter_end", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_n_bcl_iter_end", MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_btr_dt", 13, "0000_00:00:12");
     CHECK_ERR
     iattr = 2;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_n_btr_cor_iter", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_n_btr_cor_iter", MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_vel_correction", 3, "YES");
     CHECK_ERR
     iattr = 2;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_btr_subcycle_loop_factor", MPI_INT, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_btr_subcycle_loop_factor", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     dattr = 0.5;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_btr_gam1_velWt1", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_btr_gam1_velWt1", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_btr_gam2_SSHWt1", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_btr_gam2_SSHWt1", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_btr_gam3_velWt2", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_btr_gam3_velWt2", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_btr_solve_SSH2", 2, "NO");
     CHECK_ERR
@@ -794,214 +795,214 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_rx1_constraint", 2, "NO");
     CHECK_ERR
     iattr = 20;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_outer_iter_count", MPI_INT, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_outer_iter_count", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     iattr = 10;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_inner_iter_count", MPI_INT, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_inner_iter_count", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     dattr = 0.1;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_init_inner_weight", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_init_inner_weight", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 5.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_max", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_max", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_horiz_smooth_weight", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_horiz_smooth_weight", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 1.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_vert_smooth_weight", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_vert_smooth_weight", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.1;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_slope_weight", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_slope_weight", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_zstar_weight", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_zstar_weight", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     iattr = 20;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_horiz_smooth_open_ocean_cells",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_horiz_smooth_open_ocean_cells",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     iattr = 3;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_min_levels", MPI_INT, 1, &iattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_min_levels", MPI_INT, 1, &iattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_min_layer_thickness", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_rx1_min_layer_thickness", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     iattr = 20;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_vert_levels",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_vert_levels",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_use_distances", 2,
                         "NO");
     CHECK_ERR
     dattr = 13.1000003814697;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_baroclinic_channel_surface_temperature", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 10.1000003814697;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_bottom_temperature",
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_bottom_temperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.20000004768372;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                         "config_baroclinic_channel_temperature_difference", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.0799999982118607;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_baroclinic_channel_gradient_width_frac", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 40000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_baroclinic_channel_gradient_width_dist", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_bottom_depth",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_bottom_depth",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 35.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_salinity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_salinity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -0.000119999996968545;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_coriolis_parameter",
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_baroclinic_channel_coriolis_parameter",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 20;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_vert_levels", MPI_INT, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_vert_levels", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     dattr = 20.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_bottom_depth",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_bottom_depth",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 5.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_cold_temperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_cold_temperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 30.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_warm_temperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_warm_temperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_direction", 1, "y");
     CHECK_ERR
     dattr = 35.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_salinity", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_salinity", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_layer_type", 7, "z-level");
     CHECK_ERR
     dattr = 0.00999999977648258;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_isopycnal_min_thickness",
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_lock_exchange_isopycnal_min_thickness",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 20;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_vert_levels", MPI_INT,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_vert_levels", MPI_INT,
                           1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_use_distances", 2, "NO");
     CHECK_ERR
     dattr = 20.1000003814697;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_surface_temperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_surface_temperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 10.1000003814697;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_bottom_temperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_bottom_temperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 2.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_temperature_difference",
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_temperature_difference",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.330000013113022;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_amplitude_width_frac",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_amplitude_width_frac",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 50000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_amplitude_width_dist",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_amplitude_width_dist",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_bottom_depth",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_bottom_depth",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 35.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_salinity", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_salinity", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     err =
         PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_layer_type", 7, "z-level");
     CHECK_ERR
     dattr = 125.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_isopycnal_displacement",
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_internal_waves_isopycnal_displacement",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 100;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_vert_levels", MPI_INT, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_vert_levels", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_use_distances", 2, "NO");
     CHECK_ERR
     dattr = 2000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_bottom_depth", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_bottom_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_ridge_depth", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_ridge_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 10.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_plug_temperature", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_plug_temperature", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 20.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_domain_temperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_domain_temperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 35.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_salinity", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_salinity", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.100000001490116;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_plug_width_frac", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_plug_width_frac", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 0.200000002980232;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_slope_center_frac",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_slope_center_frac",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.0500000007450581;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_slope_width_frac", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_slope_width_frac", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 20000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_plug_width_dist", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_plug_width_dist", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 40000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_slope_center_dist",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_slope_center_dist",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 7000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_slope_width_dist", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_slope_width_dist", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_layer_type", 7, "z-level");
     CHECK_ERR
     dattr = 0.00999999977648258;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_isopycnal_min_thickness",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_overflow_isopycnal_min_thickness",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 15.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_minimum_depth",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_minimum_depth",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_depth_file", 4, "none");
@@ -1011,7 +1012,7 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_depth_varname", 4, "none");
     CHECK_ERR
     dattr = 1.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_depth_conversion_factor",
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_depth_conversion_factor",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err =
@@ -1029,12 +1030,12 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "none");
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_global_ocean_tracer_depth_conversion_factor", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     iattr = -1;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_tracer_vert_levels",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_tracer_vert_levels",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_temperature_varname", 4,
@@ -1059,7 +1060,7 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "bilinear_interpolation");
     CHECK_ERR
     iattr = 0;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_smooth_TS_iterations",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_smooth_TS_iterations",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_swData_file", 4, "none");
@@ -1092,11 +1093,11 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
         PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_clearSky_varname", 4, "none");
     CHECK_ERR
     dattr = 4.99999987368938e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_piston_velocity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_piston_velocity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_interior_restore_rate",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_interior_restore_rate",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err =
@@ -1172,7 +1173,7 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "config_global_ocean_use_constant_land_ice_cavity_temperature", 2, "NO");
     CHECK_ERR
     dattr = -1.79999995231628;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_global_ocean_constant_land_ice_cavity_temperature", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
@@ -1208,7 +1209,7 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     CHECK_ERR
     dattr = 1.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                         "config_global_ocean_windstress_conversion_factor", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_ecosys_file", 7, "unknown");
@@ -1226,12 +1227,12 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "none");
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_global_ocean_ecosys_depth_conversion_factor", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     iattr = -1;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_ecosys_vert_levels",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_ecosys_vert_levels",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_ecosys_lat_varname", 4,
@@ -1253,658 +1254,658 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "config_global_ocean_ecosys_forcing_time_dimname", 4, "none");
     CHECK_ERR
     iattr = 0;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_smooth_ecosys_iterations",
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_global_ocean_smooth_ecosys_iterations",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     iattr = 100;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_vert_levels", MPI_INT, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_vert_levels", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     dattr = 15.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_surface_temperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_surface_temperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 35.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_surface_salinity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_surface_salinity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 15.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                         "config_cvmix_WSwSBF_surface_restoring_temperature", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 35.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_cvmix_WSwSBF_surface_restoring_salinity", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 3.99999998990097e-06;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_cvmix_WSwSBF_temperature_piston_velocity", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 3.99999998990097e-06;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_salinity_piston_velocity",
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_salinity_piston_velocity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_sensible_heat_flux",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_sensible_heat_flux",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_latent_heat_flux",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_latent_heat_flux",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_shortwave_heat_flux",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_shortwave_heat_flux",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_rain_flux", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_rain_flux", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_evaporation_flux",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_evaporation_flux",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 9.99999997475243e-07;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_cvmix_WSwSBF_interior_temperature_restoring_rate", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 9.99999997475243e-07;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_cvmix_WSwSBF_interior_salinity_restoring_rate", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.00999999977648258;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_temperature_gradient",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_temperature_gradient",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_salinity_gradient",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_salinity_gradient",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_cvmix_WSwSBF_temperature_gradient_mixed_layer", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                         "config_cvmix_WSwSBF_salinity_gradient_mixed_layer", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                         "config_cvmix_WSwSBF_mixed_layer_depth_temperature", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_cvmix_WSwSBF_mixed_layer_depth_salinity", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_cvmix_WSwSBF_mixed_layer_temperature_change", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_cvmix_WSwSBF_mixed_layer_salinity_change", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err =
         PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_vertical_grid", 7, "uniform");
     CHECK_ERR
     dattr = 400.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_bottom_depth", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_bottom_depth", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 0.100000001490116;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_max_windstress",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_max_windstress",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 9.99999974737875e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_coriolis_parameter",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_cvmix_WSwSBF_coriolis_parameter",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 100;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_vert_levels", MPI_INT, 1, &iattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_vert_levels", MPI_INT, 1, &iattr);
     CHECK_ERR
     dattr = 4000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_main_channel_depth", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_main_channel_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -50.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_north_wall_lat", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_north_wall_lat", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -70.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_south_wall_lat", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_south_wall_lat", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_ridge_flag", 3, "YES");
     CHECK_ERR
     dattr = 180.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_ridge_center_lon", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_ridge_center_lon", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 2000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_ridge_height", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_ridge_height", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 2000000.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_ridge_width", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_ridge_width", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_flag", 3, "YES");
     CHECK_ERR
     dattr = 300.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_center_lon", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_center_lon", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -58.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_center_lat", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_center_lat", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 2000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_height", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_height", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 200000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_radius", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_radius", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 1000000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_slope_width", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_plateau_slope_width", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_shelf_flag", 3, "YES");
     CHECK_ERR
     dattr = 500.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_shelf_depth", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_shelf_depth", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 120000.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_shelf_width", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_shelf_width", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_cont_slope_flag", 3, "YES");
     CHECK_ERR
     dattr = 0.00999999977648258;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_max_cont_slope", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_max_cont_slope", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_embayment_flag", 3, "YES");
     CHECK_ERR
     dattr = 60.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_embayment_center_lon", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_embayment_center_lon", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = -71.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_embayment_center_lat", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_embayment_center_lat", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 500000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_embayment_radius", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_embayment_radius", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 2000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_embayment_depth", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_embayment_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_flag", 3, "YES");
     CHECK_ERR
     dattr = 60.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_center_lon", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_center_lon", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = -72.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_south_lat", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_south_lat", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = -65.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_north_lat", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_north_lat", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 480000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_width", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_width", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 800.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_depth", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_depression_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 35.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_salinity", MPI_DOUBLE, 1, &dattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_salinity", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.00999999977648258;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_wind_stress_max", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_wind_stress_max", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.200000002980232;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_acc_wind", MPI_DOUBLE, 1, &dattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_acc_wind", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -0.0500000007450581;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_asf_wind", MPI_DOUBLE, 1, &dattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_asf_wind", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -65.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_wind_trans", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_wind_trans", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -5.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_south", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_south", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 10.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_middle", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_middle", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -5.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_north", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_north", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -70.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_lat_ss", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_lat_ss", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -65.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_lat_sm", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_lat_sm", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -53.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_lat_mn", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_lat_mn", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 60.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region1_center_lon", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region1_center_lon", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -75.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region1_center_lat", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region1_center_lat", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 150.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region2_center_lon", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region2_center_lon", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -71.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region2_center_lat", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region2_center_lat", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 240.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region3_center_lon", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region3_center_lon", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -71.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region3_center_lat", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region3_center_lat", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 330.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region4_center_lon", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region4_center_lon", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -71.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region4_center_lat", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_region4_center_lat", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_region1_flag", 2, "NO");
     CHECK_ERR
     dattr = -5.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_region1", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_region1", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 300000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_region1_radius",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_region1_radius",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_region2_flag", 2, "NO");
     CHECK_ERR
     dattr = -5.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_region2", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_region2", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 240000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_region2_radius",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_heat_flux_region2_radius",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 5.80000014451798e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_iso_surface_temperature_piston_velocity", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 3.5;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_t1", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_t1", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 4.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_t2", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_t2", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 1200.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_h0", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_h0", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_h1", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_h1", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 7.50000035623088e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_mt", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_mt", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -75.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_latS", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_latS", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -50.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_latN", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_initial_temp_latN", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 10.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_sponge_t1", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_sponge_t1", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 1000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_sponge_h1", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_sponge_h1", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 120000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_sponge_l1", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_sponge_l1", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 10.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_sponge_tau1",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_sponge_tau1",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_region1_flag", 3,
                         "YES");
     CHECK_ERR
     dattr = -1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_t1",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_t1",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 600000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcx1",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcx1",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 600000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcy1",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcy1",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_region2_flag", 3,
                         "YES");
     CHECK_ERR
     dattr = -1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_t2",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_t2",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 600000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcx2",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcx2",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 250000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcy2",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcy2",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_region3_flag", 3,
                         "YES");
     CHECK_ERR
     dattr = -1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_t3",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_t3",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 600000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcx3",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcx3",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 250000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcy3",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcy3",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_region4_flag", 3,
                         "YES");
     CHECK_ERR
     dattr = -1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_t4",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_t4",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 600000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcx4",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcx4",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 250000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcy4",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_iso_temperature_restore_lcy4",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 100;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_vert_levels", MPI_INT, 1, &iattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_vert_levels", MPI_INT, 1, &iattr);
     CHECK_ERR
     dattr = 1250000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_domain_width", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_domain_width", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 35.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_center_latitude", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_center_latitude", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_center_longitude", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_center_longitude", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.100000001490116;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_phi", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_phi", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 2500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_bottom_depth", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_bottom_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -0.400000005960464;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_shelf_width", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_shelf_width", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 100.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_shelf_depth", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_shelf_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 1000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_ref_density", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_ref_density", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 4.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_density_difference", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_density_difference", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 300.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_thermocline_depth", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_thermocline_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.0500000007450581;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_density_difference_linear",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_density_difference_linear",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 20.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_surface_temperature", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_surface_temperature", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 33.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_surface_salinity", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_surface_salinity", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err =
         PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_use_surface_temp_restoring", 2, "NO");
     CHECK_ERR
     dattr = 7.5;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_soma_surface_temp_restoring_at_center_latitude", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.5;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_soma_surface_temp_restoring_latitude_gradient", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 9.99999974737875e-06;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_restoring_temp_piston_vel",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_soma_restoring_temp_piston_vel",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 100;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_vert_levels", MPI_INT, 1, &iattr);
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_vert_levels", MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_add_easterly_wind_stress_ASF", 2,
                         "NO");
     CHECK_ERR
     dattr = 800000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_wind_transition_position",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_wind_transition_position",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 600000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_antarctic_shelf_front_width",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_antarctic_shelf_front_width",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -0.0500000007450581;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_wind_stress_shelf_front_max",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_wind_stress_shelf_front_max",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_use_slopping_bathymetry", 2, "NO");
     CHECK_ERR
     dattr = 2000000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_meridional_extent", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_meridional_extent", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 1000000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_zonal_extent", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_zonal_extent", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 2500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_bottom_depth", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_bottom_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_shelf_depth", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_shelf_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 100000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_slope_half_width", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_slope_half_width", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 500000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_slope_center_position",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_slope_center_position",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -9.99999974737875e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_reference_coriolis", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_reference_coriolis", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_coriolis_gradient", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_coriolis_gradient", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.200000002980232;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_wind_stress_max", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_wind_stress_max", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 3.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_mean_restoring_temp", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_mean_restoring_temp", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 2.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_temp_dev_ta",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_temp_dev_ta",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 2.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_temp_dev_tb",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_temp_dev_tb",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 30.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_temp_tau", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_temp_tau", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 1.89999991562217e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_temp_piston_vel",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_temp_piston_vel",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1250.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_temp_ze", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_temp_ze", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 80000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_sponge_l", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_restoring_sponge_l", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 6.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_initial_temp_t1", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_initial_temp_t1", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 3.59999990463257;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_initial_temp_t2", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_initial_temp_t2", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 300.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_initial_temp_h1", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_initial_temp_h1", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 7.50000035623088e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_initial_temp_mt", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_initial_temp_mt", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_frazil_enable", 2, "NO");
     CHECK_ERR
     dattr = -3.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_frazil_temperature_anomaly",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ziso_frazil_temperature_anomaly",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 20;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_vert_levels", MPI_INT,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_vert_levels", MPI_INT,
                           1, &iattr);
     CHECK_ERR
     dattr = 2000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_bottom_depth",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_bottom_depth",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 25.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_cavity_thickness",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_cavity_thickness",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_slope_height",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_slope_height",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 15000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_edge_width",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_edge_width",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 30000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_y1", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_y1", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 60000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_y2", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_y2", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_temperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_temperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 34.5;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_surface_salinity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_surface_salinity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 34.7000007629395;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_bottom_salinity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sub_ice_shelf_2D_bottom_salinity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 100;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_periodic_planar_vert_levels", MPI_INT,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_periodic_planar_vert_levels", MPI_INT,
                           1, &iattr);
     CHECK_ERR
     dattr = 2500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_periodic_planar_bottom_depth",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_periodic_planar_bottom_depth",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_periodic_planar_velocity_strength",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_periodic_planar_velocity_strength",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 100;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ecosys_column_vert_levels", MPI_INT, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ecosys_column_vert_levels", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ecosys_column_vertical_grid", 14,
@@ -1917,11 +1918,11 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "unknown");
     CHECK_ERR
     dattr = 6000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ecosys_column_bottom_depth",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ecosys_column_bottom_depth",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 10;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_vert_levels", MPI_INT, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_vert_levels", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_layer_type", 5, "sigma");
@@ -1930,230 +1931,230 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "exponential");
     CHECK_ERR
     dattr = 1024.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_coef_linear",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_coef_linear",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1028.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_coef_exp",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_coef_exp",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.100000001490116;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_gradient_linear",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_gradient_linear",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 3.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_gradient_exp",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_gradient_exp",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 4500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_depth_linear",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_depth_linear",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_depth_exp",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_depth_exp",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1028.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_ref", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_ref", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 5.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_Tref", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_Tref", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 0.200000002980232;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_alpha", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_density_alpha", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 5000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_bottom_depth", MPI_DOUBLE, 1,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_bottom_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 4500.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_height", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_height", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 10000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_radius", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_radius", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 40000.;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_width", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_width", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 35.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_salinity", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_salinity", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -9.99999974737875e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_coriolis_parameter",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_sea_mount_coriolis_parameter",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 30;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_vert_levels", MPI_INT, 1, &iattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_vert_levels", MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_vertical_level_distribution", 8,
                         "constant");
     CHECK_ERR
     dattr = -900.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_bottom_depth", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_bottom_depth", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -1.89999997615814;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_temperature", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_temperature", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 34.4000015258789;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_salinity", MPI_DOUBLE, 1, &dattr);
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_salinity", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -1.89999997615814;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_restoring_temperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_restoring_temperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.20000004244503e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_temperature_piston_velocity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_temperature_piston_velocity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 34.4000015258789;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_restoring_salinity", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_restoring_salinity", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 1.20000004244503e-05;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_salinity_piston_velocity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_salinity_piston_velocity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -0.00014000000373926;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_coriolis_parameter", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_coriolis_parameter", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_southern_boundary", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_southern_boundary", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 1000000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_northern_boundary", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_northern_boundary", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_western_boundary", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_western_boundary", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 500000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_eastern_boundary", MPI_DOUBLE,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_eastern_boundary", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 0.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_y1", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_y1", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -700.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_z1", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_z1", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_ice_fraction1", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_ice_fraction1", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 400000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_y2", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_y2", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -200.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_z2", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_z2", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_ice_fraction2", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_ice_fraction2", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 1000000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_y3", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_y3", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -200.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_z3", MPI_DOUBLE, 1, &dattr);
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_z3", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_ice_fraction3", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_ice_fraction3", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     iattr = 36;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_vert_levels", MPI_INT, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_vert_levels", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_vertical_level_distribution",
                         8, "constant");
     CHECK_ERR
     dattr = -720.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_max_bottom_depth",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_max_bottom_depth",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 3;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_minimum_levels", MPI_INT,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_minimum_levels", MPI_INT,
                           1, &iattr);
     CHECK_ERR
     dattr = 10.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_min_column_thickness",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_min_column_thickness",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.5;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_min_ocean_fraction",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_min_ocean_fraction",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_topography_file", 27,
                         "input_geometry_processed.nc");
     CHECK_ERR
     dattr = -1.89999997615814;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_init_top_temp", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_init_top_temp", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = -1.89999997615814;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_init_bot_temp", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_init_bot_temp", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 33.7999992370605;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_init_top_sal", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_init_top_sal", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 34.5;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_init_bot_sal", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_init_bot_sal", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = -1.89999997615814;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_top_temp",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_top_temp",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_bot_temp",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_bot_temp",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 33.7999992370605;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_top_sal",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_top_sal",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 34.7000007629395;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_bot_sal",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_bot_sal",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 10.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_rate", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_rate", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 200.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_evap_rate",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_evap_rate",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 790000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_xMin", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_xMin", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = 800000.;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_xMax", MPI_DOUBLE,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_restore_xMax", MPI_DOUBLE,
                           1, &dattr);
     CHECK_ERR
     dattr = -0.000140999996801838;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_coriolis_parameter",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_coriolis_parameter",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1026.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_effective_density",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_isomip_plus_effective_density",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_activeTracers", 3, "YES");
@@ -2183,12 +2184,12 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "0000-00-01_00:00:00");
     CHECK_ERR
     dattr = 1.585e-06;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_salinity_restoring_constant_piston_velocity", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 100;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_salinity_restoring_max_difference",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_salinity_restoring_max_difference",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_salinity_restoring_under_sea_ice", 2,
@@ -2223,7 +2224,7 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ecosys_atm_alt_co2_use_eco", 2, "NO");
     CHECK_ERR
     dattr = 379.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_ecosys_atm_co2_constant_value",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_ecosys_atm_co2_constant_value",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_use_ecosysTracers_surface_bulk_forcing",
@@ -2365,19 +2366,19 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "NO");
     CHECK_ERR
     dattr = -2.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_waterMassCensus_minTemperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_waterMassCensus_minTemperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 30.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_waterMassCensus_maxTemperature",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_waterMassCensus_maxTemperature",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 32.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_waterMassCensus_minSalinity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_waterMassCensus_minSalinity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 37.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_waterMassCensus_maxSalinity",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_waterMassCensus_maxSalinity",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR,
@@ -2416,15 +2417,15 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "zonalMeanOutput");
     CHECK_ERR
     iattr = 180;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_zonalMean_num_bins", MPI_INT, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_zonalMean_num_bins", MPI_INT, 1,
                           &iattr);
     CHECK_ERR
     dattr = -1.e+34;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_zonalMean_min_bin", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_zonalMean_min_bin", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = -1.e+34;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_zonalMean_max_bin", MPI_DOUBLE, 1,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_zonalMean_max_bin", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_okuboWeiss_enable", 2, "NO");
@@ -2445,15 +2446,15 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "analysis_members");
     CHECK_ERR
     dattr = -0.2;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_okuboWeiss_threshold_value",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_okuboWeiss_threshold_value",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.e-10;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_okuboWeiss_normalization",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_okuboWeiss_normalization",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1.e-10;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_okuboWeiss_lambda2_normalization",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_okuboWeiss_lambda2_normalization",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_okuboWeiss_use_lat_lon_coords", 3,
@@ -2463,7 +2464,7 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "YES");
     CHECK_ERR
     iattr = 20;
-    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_okuboWeiss_eddy_min_cells", MPI_INT,
+    err = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_okuboWeiss_eddy_min_cells", MPI_INT,
                           1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_meridionalHeatTransport_enable", 3,
@@ -2484,15 +2485,15 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                       29, "meridionalHeatTransportOutput");
     CHECK_ERR
     iattr = 180;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_meridionalHeatTransport_num_bins",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_meridionalHeatTransport_num_bins",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     dattr = -1.e+34;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_meridionalHeatTransport_min_bin",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_meridionalHeatTransport_min_bin",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -1.e+34;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_meridionalHeatTransport_max_bin",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_meridionalHeatTransport_max_bin",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_meridionalHeatTransport_region_group",
@@ -2573,11 +2574,11 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         "NO");
     CHECK_ERR
     iattr = 0;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_lagrPartTrack_filter_number",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_lagrPartTrack_filter_number",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     iattr = 2;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_lagrPartTrack_timeIntegration",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_lagrPartTrack_timeIntegration",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_lagrPartTrack_reset_criteria", 4,
@@ -2615,15 +2616,15 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_eliassenPalm_debug", 2, "NO");
     CHECK_ERR
     iattr = 45;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_eliassenPalm_nBuoyancyLayers",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_eliassenPalm_nBuoyancyLayers",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     dattr = 900.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_eliassenPalm_rhomin_buoycoor",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_eliassenPalm_rhomin_buoycoor",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 1080.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_eliassenPalm_rhomax_buoycoor",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_eliassenPalm_rhomax_buoycoor",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mixedLayerDepths_enable", 3, "YES");
@@ -2647,15 +2648,15 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
         PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mixedLayerDepths_Dthreshold", 3, "YES");
     CHECK_ERR
     dattr = 0.2;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_AM_mixedLayerDepths_crit_temp_threshold", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 0.03;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_AM_mixedLayerDepths_crit_dens_threshold", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = 100000.;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_AM_mixedLayerDepths_reference_pressure", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mixedLayerDepths_Tgradient", 2, "NO");
@@ -2663,17 +2664,17 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mixedLayerDepths_Dgradient", 2, "NO");
     CHECK_ERR
     dattr = 5.e-07;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                           "config_AM_mixedLayerDepths_temp_gradient_threshold", MPI_DOUBLE, 1,
                           &dattr);
     CHECK_ERR
     dattr = 5.e-08;
     err =
-        driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR,
+        PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR,
                         "config_AM_mixedLayerDepths_den_gradient_threshold", MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 1;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mixedLayerDepths_interp_method",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mixedLayerDepths_interp_method",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_regionalStatsDaily_enable", 2, "NO");
@@ -3160,15 +3161,15 @@ static int define_global_attributes (e3sm_io_driver &driver, int ncid) {
                         2, "NO");
     CHECK_ERR
     dattr = -1.e+34;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mocStreamfunction_min_bin",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mocStreamfunction_min_bin",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     dattr = -1.e+34;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mocStreamfunction_max_bin",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mocStreamfunction_max_bin",
                           MPI_DOUBLE, 1, &dattr);
     CHECK_ERR
     iattr = 180;
-    err   = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mocStreamfunction_num_bins",
+    err   = PUT_ATT (ncid, E3SM_IO_GLOBAL_ATTR, "config_AM_mocStreamfunction_num_bins",
                           MPI_INT, 1, &iattr);
     CHECK_ERR
     err =

--- a/src/drivers/e3sm_io_driver.hpp
+++ b/src/drivers/e3sm_io_driver.hpp
@@ -38,7 +38,7 @@ class e3sm_io_driver {
     virtual int redef (int fid)                                                              = 0;
     virtual int wait (int fid)                                                               = 0;
     virtual int put_att (
-        int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf)      = 0;
+        int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf, e3sm_io_op_mode mode)      = 0;
     virtual int get_att (int fid, int vid, std::string name, void *buf)                         = 0;
     virtual int put_varl (int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode) = 0;
     virtual int put_vara (int fid,

--- a/src/drivers/e3sm_io_driver.hpp
+++ b/src/drivers/e3sm_io_driver.hpp
@@ -6,7 +6,7 @@
 
 #define E3SM_IO_DRIVER_MAX_RANK 32
 
-typedef enum e3sm_io_op_mode { coll, indep, nb, nbe } e3sm_io_op_mode;
+typedef enum e3sm_io_op_mode { coll, indep, nb, nbe, master } e3sm_io_op_mode;
 
 class e3sm_io_driver {
    protected:

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -494,7 +494,7 @@ err_out:;
 }
 
 int e3sm_io_driver_adios2::put_att (
-    int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf) {
+    int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf, e3sm_io_op_mode mode) {
     int nerrs = 0;
     adios2_error aerr;
     adios2_file *fp = this->files[fid];

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -82,7 +82,7 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
     int enddef (int fid);
     int redef (int fid);
     int wait (int fid);
-    int put_att (int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf);
+    int put_att (int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf, e3sm_io_op_mode mode);
     int get_att (int fid, int vid, std::string name, void *buf);
     int put_varl (int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode);
     int put_vara (int fid,

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -54,6 +54,7 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
         adios2_operator *op;
         MPI_Offset putsize = 0;
         MPI_Offset getsize = 0;
+        int rank;
     } adios2_file;
     std::vector<adios2_file *> files;
     double tsel, twrite, tread, text;

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -492,7 +492,7 @@ err_out:;
 }
 
 int e3sm_io_driver_hdf5::put_att (
-    int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf) {
+    int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf, e3sm_io_op_mode mode) {
     int nerrs = 0;
     int err;
     herr_t herr;

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -104,7 +104,7 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
     int enddef (int fid);
     int redef (int fid);
     int wait (int fid);
-    int put_att (int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf);
+    int put_att (int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf, e3sm_io_op_mode mode);
     int get_att (int fid, int vid, std::string name, void *buf);
     int put_varl (int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode);
     int put_vara (int fid,

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -307,7 +307,7 @@ err_out:;
 }
 
 int e3sm_io_driver_pnc::put_att (
-    int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf) {
+    int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf, e3sm_io_op_mode mode) {
     int err, nerrs = 0;
 
     if (vid == E3SM_IO_GLOBAL_ATTR) { vid = NC_GLOBAL; }

--- a/src/drivers/e3sm_io_driver_pnc.hpp
+++ b/src/drivers/e3sm_io_driver_pnc.hpp
@@ -65,7 +65,7 @@ class e3sm_io_driver_pnc : public e3sm_io_driver {
     int enddef (int fid);
     int redef (int fid);
     int wait (int fid);
-    int put_att (int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf);
+    int put_att (int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, void *buf, e3sm_io_op_mode mode);
     int get_att (int fid, int vid, std::string name, void *buf);
     int put_varl (int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode);
     int put_vara (int fid,


### PR DESCRIPTION
In Scorpio output file, the Scorpio internal attributes prefixed "\_\_pio\_\_" are only written by rank 0.
To mimic this in our blob test for ADIOS2 API, we add a I/O mode in attribute write API of the driver interface indicating that only rank 0 will write.
The I/O mode is only followed when the underlying API allow independent attribute write.
The I/O mode is set to rank 0 write only when writing "\_\_pio\_\_" prefixed  attributes.