### PR TITLE
Minor changes to conform with Scorpio output

### DIFF
--- a/src/cases/e3sm_io_case_pio.hpp
+++ b/src/cases/e3sm_io_case_pio.hpp
@@ -146,7 +146,7 @@ inline int e3sm_io_pio_define_var (e3sm_io_driver &driver,
         err = MPI_Type_size(type, &esize);
         CHECK_MPIERR
         vsize *= esize;
-        vsize += esize * 2; // Add 2 elements
+        vsize += 8 * 2 * ndim; // Include start and count array
         err = driver.def_local_var (fid, name, MPI_BYTE, 1, &vsize, &(var->data));
         CHECK_ERR
 

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -176,8 +176,8 @@ int e3sm_io_driver_adios2::close (int fid) {
     adios2_bool result;
 
     if (fp->ep) {
-        aerr = adios2_end_step (fp->ep);
-        CHECK_AERR
+        //aerr = adios2_end_step (fp->ep);
+        //CHECK_AERR
 
         aerr = adios2_close (fp->ep);
         CHECK_AERR
@@ -475,6 +475,7 @@ int e3sm_io_driver_adios2::wait (int fid) {
     adios2_file *fp = this->files[fid];
     adios2_step_status stat;
 
+    /*
     aerr = adios2_end_step (fp->ep);
     CHECK_AERR
 
@@ -488,6 +489,7 @@ int e3sm_io_driver_adios2::wait (int fid) {
         aerr = adios2_begin_step (fp->ep, adios2_step_mode_update, -1, &stat);
     }
     CHECK_AERR
+    */
 
 err_out:;
     return nerrs;


### PR DESCRIPTION
ADIOS2 only flush data on file close.
Small variables padding size is 2*8*ndim.