### PR TITLE
Inquire fire size after the file is closed:

### DIFF
--- a/src/cases/var_io_F_case.cpp
+++ b/src/cases/var_io_F_case.cpp
@@ -737,14 +737,15 @@ int run_vard_F_case (e3sm_io_config &cfg,
     err = driver.inq_put_size (ncid, &total_size);
     CHECK_ERR
     put_size = total_size - metadata_size;
-    if (cfg.rank == 0){
-        err = driver.inq_file_size(targetfname, &fsize);
-        CHECK_ERR
-    }
     err      = driver.close (ncid);
     CHECK_ERR
     close_timing = MPI_Wtime () - close_timing;
 
+    if (cfg.rank == 0){
+        err = driver.inq_file_size(targetfname, &fsize);
+        CHECK_ERR
+    }
+    
     for (j = 0; j < cfg.nrec; j++) MPI_Type_free (filetype_rec + j);
     free (filetype_rec);
     MPI_Type_free (&filetype_dbl);
@@ -1320,13 +1321,14 @@ int run_varn_F_case (e3sm_io_config &cfg,
     err = driver.inq_put_size (ncid, &total_size);
     CHECK_ERR
     put_size = total_size - metadata_size;
+    err      = driver.close (ncid);
+    CHECK_ERR
+    close_timing += MPI_Wtime () - timing;
+
     if (cfg.rank == 0){
         err = driver.inq_file_size(targetfname, &fsize);
         CHECK_ERR
     }
-    err      = driver.close (ncid);
-    CHECK_ERR
-    close_timing += MPI_Wtime () - timing;
 
     if (starts_D3 != NULL) {
         free (starts_D3[0]);
@@ -1766,13 +1768,14 @@ int run_varn_F_case_rd (e3sm_io_config &cfg,
     err = driver.inq_get_size (ncid, &total_size);
     CHECK_ERR
     put_size = total_size - metadata_size;
+    err      = driver.close (ncid);
+    CHECK_ERR
+    close_timing += MPI_Wtime () - timing;
+
     if (cfg.rank == 0){
         err = driver.inq_file_size(targetfname, &fsize);
         CHECK_ERR
     }
-    err      = driver.close (ncid);
-    CHECK_ERR
-    close_timing += MPI_Wtime () - timing;
 
     if (starts_D3 != NULL) {
         free (starts_D3[0]);

--- a/src/cases/var_io_F_case_pio.cpp
+++ b/src/cases/var_io_F_case_pio.cpp
@@ -814,14 +814,15 @@ int run_varn_F_case_pio (e3sm_io_config &cfg,
     err = driver.inq_put_size (ncid, &total_size);
     CHECK_ERR
     put_size = total_size - metadata_size;
-    if (cfg.rank == 0){
-        err = driver.inq_file_size(targetfname, &fsize);
-        CHECK_ERR
-    }
 
     err      = driver.close (ncid);
     CHECK_ERR
     close_timing += MPI_Wtime () - timing;
+
+    if (cfg.rank == 0){
+        err = driver.inq_file_size(targetfname, &fsize);
+        CHECK_ERR
+    }
 
     if (starts_D3 != NULL) {
         free (starts_D3[0]);

--- a/src/cases/var_io_G_case.cpp
+++ b/src/cases/var_io_G_case.cpp
@@ -686,14 +686,15 @@ int run_varn_G_case (e3sm_io_config &cfg,
     err = driver.inq_put_size (ncid, &total_size);
     CHECK_ERR
     put_size = total_size - metadata_size;
-    if (cfg.rank == 0){
-        err = driver.inq_file_size(outfname, &fsize);
-        CHECK_ERR
-    }
 
     err = driver.close (ncid);
     CHECK_ERR
     close_timing += MPI_Wtime () - timing;
+
+    if (cfg.rank == 0){
+        err = driver.inq_file_size(outfname, &fsize);
+        CHECK_ERR
+    }
 
     if (dummy_double_buf != NULL) free (dummy_double_buf);
 
@@ -1282,14 +1283,15 @@ int run_varn_G_case_rd (e3sm_io_config &cfg,
     err = driver.inq_get_size (ncid, &total_size);
     CHECK_ERR
     get_size = total_size - metadata_size;
-    if (cfg.rank == 0){
-        err = driver.inq_file_size(outfname, &fsize);
-        CHECK_ERR
-    }
 
     err = driver.close (ncid);
     CHECK_ERR
     close_timing += MPI_Wtime () - timing;
+
+    if (cfg.rank == 0){
+        err = driver.inq_file_size(outfname, &fsize);
+        CHECK_ERR
+    }
 
     if (decom.contig_nreqs[0] > 0) {
         free (fix_starts_D1[0]);


### PR DESCRIPTION
Some I/O libraries flush out all data after the file is closed.
To report the correct file size, we have to wait until the the file is
closed before querying the file size.