### PR TITLE
Only rank 0 count attribute write size:

### DIFF
--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -56,6 +56,7 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
         adios2_operator *op;
         MPI_Offset putsize = 0;
         MPI_Offset getsize = 0;
+        int rank;
     } adios2_file;
     std::vector<adios2_file *> files;
     double tsel, twrite, tread, text;

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -34,6 +34,7 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
         MPI_Offset recsize = 0;
         MPI_Offset putsize = 0;
         MPI_Offset getsize = 0;
+        int rank;
 
 #ifndef HDF5_HAVE_DWRITE_MULTI
         typedef struct H5D_rw_multi_t {


### PR DESCRIPTION
Attribute write is collective. However, only one process will actually write the attribute.
In HDF5 and ADIOS2 driver, when counting application write size, attirbute write should only be count on one process.
We count attribute write size at rank 0.
Attribute read size is still counted on all processes.