### PR TITLE
Changes to improve consistency to Scorpio output file

### DIFF
--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -151,25 +151,27 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
 
         // Attributes for non-constant small vars
         if (cfg.rank == 0) {
-                ibuf = (int)mpi_type_to_adios2_type (type);
-                err  = driver.put_att (fid, var->data, "__pio__/adiostype", MPI_INT, 1, &ibuf);
-                CHECK_ERR
+            ibuf = (int)mpi_type_to_adios2_type (type);
+            err  = driver.put_att (fid, var->data, "__pio__/adiostype", MPI_INT, 1, &ibuf);
+            CHECK_ERR
 
+            // Scalar var does not have dims
+            if (ndim > 0) {
                 err =
                     driver.put_att (fid, var->data, "__pio__/dims", MPI_WCHAR, ndim, dnames_array.data());
                 CHECK_ERR
-
-                err =
-                    driver.put_att (fid, var->data, "__pio__/ncop", MPI_CHAR, 7, (void *)"put_var");
-                CHECK_ERR
-
-                ibuf = (int)mpitype2nctype (type);
-                err  = driver.put_att (fid, var->data, "__pio__/nctype", MPI_INT, 1, &ibuf);
-                CHECK_ERR
-
-                err = driver.put_att (fid, var->data, "__pio__/ndims", MPI_INT, 1, &ndim);
-                CHECK_ERR
             }
+
+            err =
+                driver.put_att (fid, var->data, "__pio__/ncop", MPI_CHAR, 7, (void *)"put_var");
+            CHECK_ERR
+
+            ibuf = (int)mpitype2nctype (type);
+            err  = driver.put_att (fid, var->data, "__pio__/nctype", MPI_INT, 1, &ibuf);
+            CHECK_ERR
+
+            err = driver.put_att (fid, var->data, "__pio__/ndims", MPI_INT, 1, &ndim);
+            CHECK_ERR
         }
 
         var->decomp_id  = -1;

--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -139,15 +139,21 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
             if (dsize[j] > 0) { j++; }
         }
 
-        // flatten into 1 dim
-        for (i = 0; i < j; i++) { vsize *= dsize[i]; }
-        // Convert into byte array
-        err = MPI_Type_size(type, &esize);
-        CHECK_MPIERR
-        vsize *= esize;
-        vsize += 8 * 2 * ndim; // Include start and count array
-        err = driver.def_local_var (fid, name, MPI_BYTE, 1, &vsize, &(var->data));
-        CHECK_ERR
+        // flatten into 1 dim only apply to non-scalar variables
+        if (ndim){
+            for (i = 0; i < j; i++) { vsize *= dsize[i]; }
+            // Convert into byte array
+            err = MPI_Type_size(type, &esize);
+            CHECK_MPIERR
+            vsize *= esize;
+            vsize += 8 * 2 * ndim; // Include start and count array
+            err = driver.def_local_var (fid, name, MPI_BYTE, 1, &vsize, &(var->data));
+            CHECK_ERR
+        }
+        else{
+            err = driver.def_local_var (fid, name, type, ndim, NULL, &(var->data));
+            CHECK_ERR
+        }
 
         // Attributes for non-constant small vars
         if (cfg.rank == 0) {

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -519,7 +519,9 @@ int e3sm_io_driver_adios2::put_att (
     if (size == 0) goto err_out;
 
     if (vid == E3SM_IO_GLOBAL_ATTR) {
-        if (atype == adios2_type_string) {
+        // ADIOS2 have no char type, we translate char array into unit sized string
+        // MPI has not string type, we use WCHAR to represent string
+        if (type == MPI_CHAR) {
             aid = adios2_define_attribute (fp->iop, name.c_str (), atype, buf);
         } else {
             aid = adios2_define_attribute_array (fp->iop, name.c_str (), atype, buf, (size_t)size);
@@ -533,7 +535,9 @@ int e3sm_io_driver_adios2::put_att (
         aerr = adios2_variable_name (vname, &namesize, did);
         CHECK_AERR
         vname[namesize] = '\0';
-        if (atype == adios2_type_string) {
+        // ADIOS2 have no char type, we translate char array into unit sized string
+        // MPI has not string type, we use WCHAR to represent string
+        if (type == MPI_CHAR) {
             aid = adios2_define_variable_attribute (fp->iop, name.c_str (), atype, buf, vname, "/");
         } else {
             aid = adios2_define_variable_attribute_array (fp->iop, name.c_str (), atype, buf,

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -30,6 +30,7 @@ inline adios2_type mpi_type_to_adios2_type (MPI_Datatype mpitype) {
         case MPI_LONG_LONG:
             return adios2_type_int64_t;
         case MPI_CHAR:
+        case MPI_WCHAR:
             return adios2_type_string;
         case MPI_BYTE:
             return adios2_type_uint8_t;

--- a/src/read_decomp.c
+++ b/src/read_decomp.c
@@ -283,7 +283,7 @@ int read_decomp(e3sm_io_config *cfg,
         for (i=0, j=0; i<decom->contig_nreqs[id]; i++)
             for (k=decom->disps[id][i];
                  k<(decom->disps[id][i] + decom->blocklens[id][i]); k++)
-                decom->raw_offsets[id][j++] = k;
+                decom->raw_offsets[id][j++] = k + 1;
 
         if (cfg->verbose) {
             int min_blocklen = decom->blocklens[id][0];


### PR DESCRIPTION
dims attribute should be array of strings.
scorpio attributes for scalar variables
do not flatten scalar variables as scorpio doesn't
add 1 into raw decomposition map