### PR TITLE
Changes to make adios blob output file more consistent to the scorpio output file

### DIFF
--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -228,20 +228,20 @@ inline int e3sm_io_scorpio_write_var (e3sm_io_driver &driver,
         memcpy(buf + var.ndim * sizeof(int64_t), var.bsize, var.ndim * sizeof(int64_t));
     }
 
-    err = driver.put_varl (fid, var.data, type, buf, mode);
+    err = driver.put_varl (fid, var.data, type, buf, nbe);
     CHECK_ERR
 
     if (var.frame_id >= 0) {
-        err = driver.put_varl (fid, var.frame_id, MPI_INT, &frameid, mode);
+        err = driver.put_varl (fid, var.frame_id, MPI_INT, &frameid, nbe);
         CHECK_ERR
 
-        err = driver.put_varl (fid, var.decomp_id, MPI_INT, &(var.decomid), mode);
+        err = driver.put_varl (fid, var.decomp_id, MPI_INT, &(var.decomid), nbe);
         CHECK_ERR
 
         if (var.fillval_id >= 0) {
             double fbuf = 1e+20;
 
-            err = driver.put_varl (fid, var.fillval_id, var.type, &fbuf, mode);
+            err = driver.put_varl (fid, var.fillval_id, var.type, &fbuf, nbe);
             CHECK_ERR
         }
     }

--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -111,7 +111,8 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
             if (cfg.rank == 0) {
                 // Decomposition map
                 ibuf = var->decomp_id + 512;
-                err  = driver.put_att (fid, var->data, "__pio__/decomp", MPI_INT, 1, &ibuf);
+                sprintf(cbuf, "%d", ibuf);
+                err  = driver.put_att (fid, var->data, "__pio__/decomp", MPI_CHAR, strlen(cbuf), &cbuf);
                 CHECK_ERR
 
                 err =

--- a/src/cases/var_io_F_case_scorpio.cpp
+++ b/src/cases/var_io_F_case_scorpio.cpp
@@ -482,7 +482,7 @@ int run_varn_F_case_scorpio (e3sm_io_config &cfg,
     if (dbl_bufp != NULL)
         dbl_buf = dbl_bufp;
     else {
-        dbl_buf = (double *)malloc (dbl_buflen * sizeof (double));
+        dbl_buf = (double *)malloc (dbl_buflen * sizeof (double) + 64);
         for (ii=0; ii<dbl_buflen; ii++) dbl_buf[ii] = rank;
     }
 
@@ -495,19 +495,19 @@ int run_varn_F_case_scorpio (e3sm_io_config &cfg,
     if (rec_bufp != NULL)
         rec_buf = rec_bufp;
     else {
-        rec_buf = (itype *)malloc (rec_buflen * sizeof (itype));
+        rec_buf = (itype *)malloc (rec_buflen * sizeof (itype) + 64);
         for (ii=0; ii<rec_buflen; ii++) rec_buf[ii] = rank;
     }
     if (int_bufp != NULL)
         int_buf = int_bufp;
     else {
-        int_buf = (int*) malloc(10 * sizeof(int));
+        int_buf = (int*) malloc(10 * sizeof(int) + 64);
         for (ii=0; ii<10; ii++) int_buf[ii] = rank;
     }
     if (txt_bufp != NULL)
         txt_buf = txt_bufp;
     else {
-        txt_buf = (char*) malloc(16 * sizeof(char));
+        txt_buf = (char*) malloc(16 * sizeof(char) + 64);
         for (ii=0; ii<16; ii++) txt_buf[ii] = 'a' + rank;
     }
 

--- a/src/cases/var_io_G_case_scorpio.cpp
+++ b/src/cases/var_io_G_case_scorpio.cpp
@@ -391,7 +391,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D1_fix_int_bufp != NULL) {
             D1_fix_int_buf = D1_fix_int_bufp;
         } else {
-            D1_fix_int_buf = (int *)malloc (nelems[0] * sizeof (int));
+            D1_fix_int_buf = (int *)malloc (nelems[0] * sizeof (int) + 64);
             for (ii = 0; ii < nelems[0]; ii++) D1_fix_int_buf[ii] = rank + ii;
         }
     } else
@@ -402,7 +402,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D2_fix_int_bufp != NULL) {
             D2_fix_int_buf = D2_fix_int_bufp;
         } else {
-            D2_fix_int_buf = (int *)malloc (2 * nelems[1] * sizeof (int));
+            D2_fix_int_buf = (int *)malloc (2 * nelems[1] * sizeof (int) + 64);
             for (ii = 0; ii < 2 * nelems[1]; ii++) D2_fix_int_buf[ii] = rank + ii;
         }
     } else
@@ -413,7 +413,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D3_fix_int_bufp != NULL) {
             D3_fix_int_buf = D3_fix_int_bufp;
         } else {
-            D3_fix_int_buf = (int *)malloc (nelems[2] * sizeof (int));
+            D3_fix_int_buf = (int *)malloc (nelems[2] * sizeof (int) + 64);
             for (ii = 0; ii < nelems[2]; ii++) D3_fix_int_buf[ii] = rank + ii;
         }
     } else
@@ -424,7 +424,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D4_fix_int_bufp != NULL) {
             D4_fix_int_buf = D4_fix_int_bufp;
         } else {
-            D4_fix_int_buf = (int *)malloc (nelems[3] * sizeof (int));
+            D4_fix_int_buf = (int *)malloc (nelems[3] * sizeof (int) + 64);
             for (ii = 0; ii < nelems[3]; ii++) D4_fix_int_buf[ii] = rank + ii;
         }
     } else
@@ -435,7 +435,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D5_fix_int_bufp != NULL) {
             D5_fix_int_buf = D5_fix_int_bufp;
         } else {
-            D5_fix_int_buf = (int *)malloc (nelems[4] * sizeof (int));
+            D5_fix_int_buf = (int *)malloc (nelems[4] * sizeof (int) + 64);
             for (ii = 0; ii < nelems[4]; ii++) D5_fix_int_buf[ii] = rank + ii;
         }
     } else
@@ -446,7 +446,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D1_fix_dbl_bufp != NULL) {
             D1_fix_dbl_buf = D1_fix_dbl_bufp;
         } else {
-            D1_fix_dbl_buf = (double *)malloc (nelems[0] * sizeof (double));
+            D1_fix_dbl_buf = (double *)malloc (nelems[0] * sizeof (double) + 64);
             for (ii = 0; ii < nelems[0]; ii++) D1_fix_dbl_buf[ii] = rank + ii;
         }
     } else
@@ -469,7 +469,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D3_rec_dbl_bufp != NULL) {
             D3_rec_dbl_buf = D3_rec_dbl_bufp;
         } else {
-            D3_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double));
+            D3_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double) + 64);
             for (ii = 0; ii < rec_buflen; ii++) D3_rec_dbl_buf[ii] = rank + ii;
         }
     } else
@@ -480,7 +480,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D4_rec_dbl_bufp != NULL) {
             D4_rec_dbl_buf = D4_rec_dbl_bufp;
         } else {
-            D4_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double));
+            D4_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double) + 64);
             for (ii = 0; ii < rec_buflen; ii++) D4_rec_dbl_buf[ii] = rank + ii;
         }
     } else
@@ -491,7 +491,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D5_rec_dbl_bufp != NULL) {
             D5_rec_dbl_buf = D5_rec_dbl_bufp;
         } else {
-            D5_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double));
+            D5_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double) + 64);
             for (ii = 0; ii < rec_buflen; ii++) D5_rec_dbl_buf[ii] = rank + ii;
         }
     } else
@@ -502,7 +502,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D6_rec_dbl_bufp != NULL) {
             D6_rec_dbl_buf = D6_rec_dbl_bufp;
         } else {
-            D6_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double));
+            D6_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double) + 64);
             for (ii = 0; ii < rec_buflen; ii++) D6_rec_dbl_buf[ii] = rank + ii;
         }
     } else

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -56,6 +56,8 @@ size_t adios2_type_size (adios2_type type) {
             return 8;
         case adios2_type_uint8_t:
             return 1;
+        case adios2_type_int8_t:
+            return 1;
         case adios2_type_string:
             return 1;
         default:
@@ -522,7 +524,7 @@ int e3sm_io_driver_adios2::put_att (
         // ADIOS2 have no char type, we translate char array into unit sized string
         // MPI has not string type, we use WCHAR to represent string
         if (type == MPI_CHAR) {
-            aid = adios2_define_attribute (fp->iop, name.c_str (), atype, buf);
+            aid = adios2_define_attribute (fp->iop, name.c_str (), adios2_type_string, buf);
         } else {
             aid = adios2_define_attribute_array (fp->iop, name.c_str (), atype, buf, (size_t)size);
         }
@@ -538,7 +540,7 @@ int e3sm_io_driver_adios2::put_att (
         // ADIOS2 have no char type, we translate char array into unit sized string
         // MPI has not string type, we use WCHAR to represent string
         if (type == MPI_CHAR) {
-            aid = adios2_define_variable_attribute (fp->iop, name.c_str (), atype, buf, vname, "/");
+            aid = adios2_define_variable_attribute (fp->iop, name.c_str (), adios2_type_string, buf, vname, "/");
         } else {
             aid = adios2_define_variable_attribute_array (fp->iop, name.c_str (), atype, buf,
                                                           (size_t)size, vname, "/");

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -30,6 +30,7 @@ inline adios2_type mpi_type_to_adios2_type (MPI_Datatype mpitype) {
         case MPI_LONG_LONG:
             return adios2_type_int64_t;
         case MPI_CHAR:
+            return adios2_type_int8_t;
         case MPI_WCHAR:
             return adios2_type_string;
         case MPI_BYTE:


### PR DESCRIPTION
Scorpio save "decom" attribute as string not int.
The start and count field in small variable block must match the actual size of the data.
MPI_CHAR type should translate to adios type int8_t.

These changes allows the bp2nc tool to convert all E3SM variables without problem. However, it still fails to convert decomposition variables.