### PR TITLE
Add HDF5 blob I/O

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -544,9 +544,10 @@ echo \
    ${PACKAGE_NAME} Version ${PACKAGE_VERSION}
 
    Features:  Internal debug mode         - ${debug}
-              ADIOS-2 support             - ${have_adios2}
+              HDF5 support                - ${have_hdf5}
               HDF5 log-based VOL support  - ${have_logvol}
               HDF5 multi-dataset support  - ${have_multi_dset}
+              ADIOS-2 support             - ${have_adios2}
 
    Compilers: MPICC    = ${MPICC}
               MPICXX   = ${MPICXX}"

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ dnl
 
 dnl autoconf v2.69 was released in 2012-04-24
 AC_PREREQ([2.69])
-AC_INIT([e3sm_io],[1.0.0],[],[e3sm_io],[])
+AC_INIT([e3sm_io],[1.3.0],[],[e3sm_io],[])
 
 AM_EXTRA_RECURSIVE_TARGETS([tests])
 

--- a/src/cases/Makefile.am
+++ b/src/cases/Makefile.am
@@ -16,27 +16,27 @@ CXX_SRCS =  var_io_F_case.cpp \
             e3sm_io_case_F.cpp \
             e3sm_io_case_G.cpp \
             header_def_F_case.cpp \
-            header_inq_F_case.cpp \
             header_def_G_case.cpp \
+            header_inq_F_case.cpp \
             header_inq_G_case.cpp \
-            pnetcdf_blob_var_io_F_case.cpp \
-            pnetcdf_blob_var_io_G_case.cpp
+            var_io_F_case_blob.cpp \
+            var_io_G_case_blob.cpp
 
 H_SRCS =    e3sm_io_case.hpp \
-            e3sm_io_F_case.hpp \
-            e3sm_io_G_case.hpp 
+            e3sm_io_case_F.hpp \
+            e3sm_io_case_G.hpp
 
 if ENABLE_ADIOS2
 CXX_SRCS += var_io_F_case_scorpio.cpp \
-            e3sm_io_case_F_scorpio.cpp \
-            header_io_F_case_scorpio.cpp \
             var_io_G_case_scorpio.cpp \
-            e3sm_io_case_G_scorpio.cpp \
-            header_io_G_case_scorpio.cpp
+            header_io_F_case_scorpio.cpp \
+            header_io_G_case_scorpio.cpp \
+            e3sm_io_case_F_scorpio.cpp \
+            e3sm_io_case_G_scorpio.cpp
 
-H_SRCS +=   e3sm_io_case_scorpio.hpp \
-            e3sm_io_F_case_scorpio.hpp \
-            e3sm_io_G_case_scorpio.hpp
+H_SRCS   += e3sm_io_case_scorpio.hpp \
+            e3sm_io_case_F_scorpio.hpp \
+            e3sm_io_case_G_scorpio.hpp
 endif
 
 libe3sm_io_cases_a_SOURCES = $(CXX_SRCS) $(H_SRCS)

--- a/src/cases/e3sm_io_case_F.hpp
+++ b/src/cases/e3sm_io_case_F.hpp
@@ -53,11 +53,6 @@ extern int run_varn_F_case_rd (e3sm_io_config &cfg,
                                int *int_buf);       /* buffer for int var */
 
 extern int
-pnetcdf_blob_F_case(e3sm_io_config &cfg,
-                    e3sm_io_decom &decom,
-                    e3sm_io_driver &driver);
-
-extern int
 def_F_case_h0(e3sm_io_config &cfg,
               e3sm_io_decom  &decom,
               e3sm_io_driver &driver,
@@ -70,4 +65,9 @@ def_F_case_h1(e3sm_io_config &cfg,
               e3sm_io_driver &driver,
               int ncid,
               int *varids);
+
+extern int
+blob_F_case(e3sm_io_config &cfg,
+            e3sm_io_decom &decom,
+            e3sm_io_driver &driver);
 

--- a/src/cases/e3sm_io_case_G.hpp
+++ b/src/cases/e3sm_io_case_G.hpp
@@ -69,9 +69,9 @@ extern int run_varn_G_case_rd (e3sm_io_config &cfg,
                                double **D1_fix_dbl_bufp); /* D1 fix double buffer */
 
 extern int
-pnetcdf_blob_G_case(e3sm_io_config &cfg,
-                    e3sm_io_decom &decom,
-                    e3sm_io_driver &driver);
+blob_G_case(e3sm_io_config &cfg,
+            e3sm_io_decom &decom,
+            e3sm_io_driver &driver);
 
 extern int
 def_G_case(e3sm_io_config &cfg,

--- a/src/cases/var_io_F_case_blob.cpp
+++ b/src/cases/var_io_F_case_blob.cpp
@@ -1,0 +1,849 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <unistd.h> /* unlink() */
+
+#include <mpi.h>
+
+#include <e3sm_io_case_F.hpp>
+#include <e3sm_io.h>
+#include <e3sm_io_err.h>
+#include <e3sm_io_driver.hpp>
+
+#ifdef USE_PNETCDF_DIRECTLY
+#define CHECK_VAR_ERR(varid) {                                      \
+    if (err != NC_NOERR) {                                          \
+        char name[64];                                              \
+        ncmpi_inq_varname(ncid, varid, name);                       \
+        printf("Error in %s:%d: var %s - %s\n", __FILE__, __LINE__, \
+               name, ncmpi_strerror(err));                          \
+        goto err_out;                                               \
+    }                                                               \
+}
+#define FILE_CREATE(filename) { \
+    err = ncmpi_create(cfg.sub_comm, filename, NC_CLOBBER|NC_64BIT_DATA, cfg.info, &ncid); \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+}
+#define FILE_CLOSE {                                       \
+    err = ncmpi_close(ncid);                               \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+}
+#define ENDDEF {                                           \
+    err = ncmpi_enddef(ncid);                              \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+}
+#define INQ_PUT_SIZE(size) {                               \
+    err = ncmpi_inq_put_size(ncid, &size);                 \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+}
+#define INQ_FILE_INFO(info) {                              \
+    err = ncmpi_inq_file_info(ncid, &info);                \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+}
+#define IPUT_VAR_DBL(buf, adv) { \
+    err = ncmpi_iput_var_double(ncid, varids[i], buf, NULL); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    i++; \
+}
+#define IPUT_VAR_INT(buf, adv) { \
+    err = ncmpi_iput_var_int(ncid, varids[i], buf, NULL); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VAR1_DBL(buf, adv) { \
+    err = ncmpi_iput_var1_double(ncid, varids[i], start, buf, NULL); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VAR1_INT(buf, adv) { \
+    err = ncmpi_iput_var1_int(ncid, varids[i], start, buf, NULL); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA_INT(buf, adv) { \
+    err = ncmpi_iput_vara_int(ncid, varids[i], start, count, buf, NULL); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (len); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA_INT_NOADV(buf) { \
+    err = ncmpi_iput_vara_int(ncid, varids[i], start, count, buf, NULL); \
+    CHECK_VAR_ERR(varids[i]) \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA_INT64_NOADV(buf) { \
+    err = ncmpi_iput_vara_longlong(ncid, varids[i], start, count, buf, NULL); \
+    CHECK_VAR_ERR(varids[i]) \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA_DBL(buf, adv) { \
+    err = ncmpi_iput_vara_double(ncid, varids[i], start, count, buf, NULL); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA_TXT(buf, adv) { \
+    err = ncmpi_iput_vara_text(ncid, varids[i], start, count, buf, NULL); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#ifdef _DOUBLE_TYPE_
+#define IPUT_VARA(varid, start, count, buf) { \
+    err = ncmpi_iput_vara_double(ncid, varid, start, count, buf, NULL); \
+    CHECK_VAR_ERR(varid) \
+    my_nreqs++; \
+}
+#else
+#define IPUT_VARA(varid, start, count, buf) { \
+    err = ncmpi_iput_vara_float(ncid, varid, start, count, buf, NULL); \
+    CHECK_VAR_ERR(varid) \
+    my_nreqs++; \
+}
+#endif
+#define WAIT_ALL_REQS {                                    \
+    err = ncmpi_wait_all(ncid, NC_REQ_ALL, NULL, NULL);    \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+    nflushes++;                                            \
+}
+#else
+#define CHECK_VAR_ERR(varid) {                                \
+    if (err != 0) {                                           \
+        char var_name[64];                                    \
+        driver.inq_var_name(ncid, varid, var_name);           \
+        printf("Error in %s:%d: %s() var %s\n"     ,          \
+               __FILE__, __LINE__, __func__, var_name);       \
+        goto err_out;                                         \
+    }                                                         \
+}
+#define FILE_CREATE(filename) { \
+    err = driver.create(filename, cfg.sub_comm, cfg.info, &ncid); \
+    CHECK_ERR \
+}
+#define FILE_CLOSE {            \
+    err = driver.close(ncid);   \
+    CHECK_ERR                   \
+}
+#define ENDDEF {                \
+    err = driver.enddef(ncid);  \
+    CHECK_ERR                   \
+}
+#define INQ_PUT_SIZE(size) {                 \
+    err = driver.inq_put_size(ncid, &size);  \
+    CHECK_ERR                                \
+}
+#define INQ_FILE_INFO(info) {                \
+    err = driver.inq_file_info(ncid, &info); \
+    CHECK_ERR                                \
+}
+#define IPUT_VAR_DBL(buf, adv) { \
+    err = driver.put_vara(ncid, varids[i], MPI_DOUBLE, NULL, NULL, buf, nb); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    i++; \
+}
+#define IPUT_VAR_INT(buf, adv) { \
+    err = driver.put_vara(ncid, varids[i], MPI_INT, NULL, NULL, buf, nb); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VAR1_DBL(buf, adv) { \
+    err = driver.put_vara(ncid, varids[i], MPI_DOUBLE, start, NULL, buf, nb); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VAR1_INT(buf, adv) { \
+    err = driver.put_vara(ncid, varids[i], MPI_INT, start, NULL, buf, nb); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA_INT(buf, adv) { \
+    err = driver.put_vara(ncid, varids[i], MPI_INT, start, count, buf, nb); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA_INT_NOADV(buf) { \
+    err = driver.put_vara(ncid, varids[i], MPI_INT, start, count, buf, nb); \
+    CHECK_VAR_ERR(varids[i]) \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA_INT64_NOADV(buf) { \
+    err = driver.put_vara(ncid, varids[i], MPI_LONG_LONG, start, count, buf, nb); \
+    CHECK_VAR_ERR(varids[i]) \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA_DBL(buf, adv) { \
+    err = driver.put_vara(ncid, varids[i], MPI_DOUBLE, start, count, buf, nb); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA_TXT(buf, adv) { \
+    err = driver.put_vara(ncid, varids[i], MPI_CHAR, start, count, buf, nb); \
+    CHECK_VAR_ERR(varids[i]) \
+    buf += (adv); \
+    my_nreqs++; \
+    i++; \
+}
+#define IPUT_VARA(varid, start, count, buf) { \
+    err = driver.put_vara(ncid, varid, REC_ITYPE, start, count, buf, nb); \
+    CHECK_VAR_ERR(varid) \
+    my_nreqs++; \
+}
+#define WAIT_ALL_REQS { \
+    err = driver.wait(ncid); \
+    CHECK_ERR \
+    nflushes++; \
+}
+#endif
+
+/*----< write_small_vars_F_case() >------------------------------------------*/
+static
+int write_small_vars_F_case(e3sm_io_driver &driver,
+                            int             ncid,
+                            int             vid, /* starting variable ID */
+                            int            *varids,
+                            int             rec_no,
+                            int             gap,
+                            MPI_Offset      lev,
+                            MPI_Offset      ilev,
+                            MPI_Offset      nbnd,
+                            MPI_Offset      nchars,
+                            int           **int_buf,
+                            char          **txt_buf,
+                            double        **dbl_buf,
+                            int            *nreqs)
+{
+    int i, err, my_nreqs=0;
+    MPI_Offset start[2], count[2];
+
+    /* There are 27 variables in total written in this function.
+     * double type:
+     *        3 [lev], 3 [ilev], 1 [nbnd], 8 [1]
+     * int type:
+     *        10 [1]
+     * char type:
+     *        2 [nchars]
+     */
+
+    /* scalar and small variables are written by sub_rank 0 only */
+    i = vid;
+
+    if (rec_no == 0) {
+        /* write 7 fixed-size variables */
+        IPUT_VAR_DBL(*dbl_buf,  lev + gap) /* lev */
+        IPUT_VAR_DBL(*dbl_buf,  lev + gap) /* hyam */
+        IPUT_VAR_DBL(*dbl_buf,  lev + gap) /* hybm */
+        IPUT_VAR_DBL(*dbl_buf,    1 + gap) /* P0 */
+        IPUT_VAR_DBL(*dbl_buf, ilev + gap) /* ilev */
+        IPUT_VAR_DBL(*dbl_buf, ilev + gap) /* hyai */
+        IPUT_VAR_DBL(*dbl_buf, ilev + gap) /* hybi */
+    } else
+        i += 7;
+
+    /* below are all record variables */
+    start[0] = rec_no;
+    start[1] = 0;
+    count[0] = 1;
+
+    IPUT_VAR1_DBL(*dbl_buf,       1 + gap) /* time */
+    IPUT_VAR1_INT(*int_buf,       1 + gap) /* date */
+    IPUT_VAR1_INT(*int_buf,       1 + gap) /* datesec */
+    count[1] = nbnd;
+    IPUT_VARA_DBL(*dbl_buf,    nbnd + gap) /* time_bnds */
+    count[1] = nchars;
+    IPUT_VARA_TXT(*txt_buf, nchars + gap) /* date_written */
+    count[1] = nchars;
+    IPUT_VARA_TXT(*txt_buf, nchars + gap) /* time_written */
+
+    if (rec_no == 0) {
+        IPUT_VAR_INT(*int_buf, 1) /* ndbase */
+        IPUT_VAR_INT(*int_buf, 1) /* nsbase */
+        IPUT_VAR_INT(*int_buf, 1) /* nbdate */
+        IPUT_VAR_INT(*int_buf, 1) /* nbsec */
+        IPUT_VAR_INT(*int_buf, 1) /* mdt */
+    } else
+        i += 5;
+
+    IPUT_VAR1_INT(*int_buf, 1 + gap) /* ndcur */
+    IPUT_VAR1_INT(*int_buf, 1 + gap) /* nscur */
+    IPUT_VAR1_DBL(*dbl_buf, 1 + gap) /* co2vmr */
+    IPUT_VAR1_DBL(*dbl_buf, 1 + gap) /* ch4vmr */
+    IPUT_VAR1_DBL(*dbl_buf, 1 + gap) /* n2ovmr */
+    IPUT_VAR1_DBL(*dbl_buf, 1 + gap) /* f11vmr */
+    IPUT_VAR1_DBL(*dbl_buf, 1 + gap) /* f12vmr */
+    IPUT_VAR1_DBL(*dbl_buf, 1 + gap) /* sol_tsi */
+    IPUT_VAR1_INT(*int_buf, 1 + gap) /* nsteph */
+
+    *nreqs = my_nreqs;
+
+err_out:
+    return err;
+}
+
+#define POST_VARA(decomp, numVars, vid) {                                 \
+    int varid = vid + num_decomp_vars;                                    \
+    for (j=0; j<numVars; j++) {                                           \
+        IPUT_VARA(varid+j, start_D##decomp, count_D##decomp, rec_buf_ptr) \
+        rec_buf_ptr += count_D##decomp[1] + gap;                          \
+        if (rec_no == 0) nvars_D[decomp - 1]++;                           \
+    }                                                                     \
+}
+
+/*----< blob_F_case() >-------------------------------------------------------*/
+int blob_F_case(e3sm_io_config &cfg,
+                e3sm_io_decom  &decom,
+                e3sm_io_driver &driver)
+{
+    char outfile[1040], *ext;;
+    const char *hist;
+    int i, j, err, sub_rank, global_rank, ncid=-1, nflushes=0, *varids;
+    int rec_no, gap = 0, my_nreqs, num_decomp_vars;
+    int contig_nreqs[MAX_NUM_DECOMP], nvars_D[MAX_NUM_DECOMP];
+    double pre_timing, open_timing, post_timing, wait_timing, close_timing;
+    double def_timing, timing, total_timing;
+    MPI_Offset metadata_size, put_size, total_size, max_nreqs, total_nreqs;
+    MPI_Offset start[2], count[2];
+    MPI_Offset start_D2[2], count_D2[2], start_D3[2], count_D3[2];
+    MPI_Offset blob_start[MAX_NUM_DECOMP], blob_count[MAX_NUM_DECOMP];
+    MPI_Offset previous_size, sum_size, m_alloc=0, max_alloc;
+    MPI_Info info_used = MPI_INFO_NULL;
+    size_t ii, txt_buflen, int_buflen, dbl_buflen, rec_buflen;
+    itype  *rec_buf=NULL, *rec_buf_ptr; /* buffer for rec float var */
+    double *dbl_buf=NULL, *dbl_buf_ptr; /* buffer for fixed double var */
+    char   *txt_buf=NULL, *txt_buf_ptr; /* buffer for char var */
+    int    *int_buf=NULL, *int_buf_ptr; /* buffer for int var */
+
+    MPI_Barrier(cfg.io_comm); /*-----------------------------------------*/
+    total_timing = pre_timing = MPI_Wtime();
+
+    post_timing  = 0.0;
+    open_timing  = 0.0;
+    def_timing   = 0.0;
+    wait_timing  = 0.0;
+    close_timing = 0.0;
+
+    if (cfg.api == hdf5) /* I/O amount from previous I/O */
+        INQ_PUT_SIZE(previous_size)
+    else
+        previous_size = 0;
+
+    MPI_Comm_rank(cfg.io_comm,  &global_rank);
+    MPI_Comm_rank(cfg.sub_comm, &sub_rank);
+
+    if (cfg.non_contig_buf) gap = 10;
+
+    /* allocate write buffer for small climate variables */
+    dbl_buflen = decom.count[1] * 2          /* lat[ncol] and lon[ncol] */
+               + decom.count[0]              /* area[ncol] */
+               + 3 * gap
+               + 3 * decom.dims[2][0]        /* 3 [lev] */
+               + 3 * (decom.dims[2][0] + 1)  /* 3 [ilev] */
+               + 2                           /* 1 [nbnd] */
+               + 8                           /* 8 single-element variables */
+               + 15 * gap;
+
+    txt_buflen = 2 * 8     /* 2 [nchars] */
+               + 10 * gap;
+    int_buflen = 10        /* 10 [1] */
+               + 10 * gap;
+
+    /* allocate and initialize write buffer for large variables */
+    if (cfg.nvars == 414)
+        rec_buflen = decom.count[1] * 323
+                   + decom.count[2] * 63
+                   + (323 + 63) * gap;
+    else
+        rec_buflen = decom.count[1] * 22
+                   + decom.count[2]
+                   + (22 + 1) * gap;
+
+#define FLUSH_ALL_RECORDS_AT_ONCE
+#ifdef FLUSH_ALL_RECORDS_AT_ONCE
+    dbl_buflen *= cfg.nrec;
+    txt_buflen *= cfg.nrec;
+    int_buflen *= cfg.nrec;
+    rec_buflen *= cfg.nrec;
+#else
+    if (cfg.api == hdf5) {
+        printf("Error in %s:%d: %s() FLUSH_ALL_RECORDS_AT_ONCE must be enabled when using HDF5 blob I/O",
+               __FILE__, __LINE__, __func__);
+        err = -1;
+        goto err_out;
+    }
+#endif
+
+    dbl_buf = (double*) malloc(dbl_buflen * sizeof(double));
+    txt_buf = (char*)   malloc(txt_buflen * sizeof(char));
+    int_buf = (int*)    malloc(int_buflen * sizeof(int));
+    rec_buf = (itype*)  malloc(rec_buflen * sizeof(itype));
+
+    for (ii=0; ii<dbl_buflen; ii++) dbl_buf[ii] = global_rank;
+    for (ii=0; ii<txt_buflen; ii++) txt_buf[ii] = 'a' + global_rank;
+    for (ii=0; ii<rec_buflen; ii++) rec_buf[ii] = global_rank;
+    for (ii=0; ii<int_buflen; ii++) int_buf[ii] = global_rank;
+
+    /* there are num_decomp_vars number of decomposition variables */
+    num_decomp_vars = decom.num_decomp * NVARS_DECOMP;
+
+    /* allocate space for all variable IDs */
+    varids = (int*) malloc((cfg.nvars + num_decomp_vars) * sizeof(int));
+
+    pre_timing = MPI_Wtime() - pre_timing;
+
+    MPI_Barrier(cfg.sub_comm); /*-----------------------------------------*/
+    timing = MPI_Wtime();
+
+    /* construct h0/h1 file name */
+    hist = (cfg.nvars == 414) ? "_h0" :  "_h1";
+    ext = strrchr(cfg.out_path, '.');
+    if (ext == NULL || (strcmp(ext, ".nc") && strcmp(ext, ".h5")))
+        sprintf(outfile, "%s%s.%04d", cfg.out_path, hist, cfg.subfile_ID);
+    else {
+        sprintf(outfile, "%s", cfg.out_path);
+        sprintf(outfile + (ext - cfg.out_path), "%s%s.%04d", hist, ext, cfg.subfile_ID);
+    }
+
+    /* set output subfile name */
+    if (cfg.verbose && sub_rank == 0)
+        printf("global_rank=%d sub_rank=%d outfile=%s\n",global_rank,sub_rank,outfile);
+
+    /* create the output file */
+    FILE_CREATE(outfile)
+
+    open_timing += MPI_Wtime() - timing;
+
+    MPI_Barrier(cfg.sub_comm); /*-----------------------------------------*/
+    timing = MPI_Wtime();
+
+    /* define dimensions, variables, and attributes */
+    if (cfg.nvars == 414) { /* for h0 file */
+        err = def_F_case_h0(cfg, decom, driver, ncid, varids);
+        CHECK_ERR
+    }
+    else { /* for h1 file */
+        err = def_F_case_h1(cfg, decom, driver, ncid, varids);
+        CHECK_ERR
+    }
+
+    /* exit define mode and enter data mode */
+    ENDDEF
+
+    /* I/O amount so far */
+    INQ_PUT_SIZE(metadata_size)
+    metadata_size -= previous_size;
+
+    INQ_FILE_INFO(info_used)
+
+    def_timing += MPI_Wtime() - timing;
+
+    MPI_Barrier(cfg.sub_comm); /*-----------------------------------------*/
+    timing = MPI_Wtime();
+
+    i = 0;
+    my_nreqs = 0;
+
+    /* First, write decomposition variables */
+    for (j=0; j<decom.num_decomp; j++) {
+        nvars_D[j] = 0; /* number of variables using decomposition j */
+        start[0] = sub_rank;
+        count[0] = 1;
+        start[1] = 0;
+        count[1] = decom.contig_nreqs[j];
+
+        /* write to D*.nreqs, 1D array */
+        contig_nreqs[j] = decom.contig_nreqs[j];
+        IPUT_VARA_INT_NOADV(contig_nreqs+j)
+
+        /* write to D*.blob_start, 1D array */
+        blob_start[j] = decom.start[j];
+        IPUT_VARA_INT64_NOADV(blob_start+j)
+
+        /* write to D*.blob_count, 1D array */
+        blob_count[j] = decom.count[j];
+        IPUT_VARA_INT64_NOADV(blob_count+j);
+
+        /* write to D*.offsets, 2D array */
+        IPUT_VARA_INT_NOADV(decom.disps[j])
+
+        /* write to D*.lengths, 2D array */
+        IPUT_VARA_INT_NOADV(decom.blocklens[j])
+    }
+
+    /* Now, write climate variables */
+    dbl_buf_ptr = dbl_buf;
+
+    /* lat */
+    start[0] = decom.start[1];
+    count[0] = decom.count[1];
+    IPUT_VARA_DBL(dbl_buf_ptr, decom.count[1])
+    nvars_D[1]++;
+
+    /* lon */
+    IPUT_VARA_DBL(dbl_buf_ptr, decom.count[1])
+    nvars_D[1]++;
+
+    /* area */
+    start[0] = decom.start[0];
+    count[0] = decom.count[0];
+    IPUT_VARA_DBL(dbl_buf_ptr, decom.count[0])
+    nvars_D[0]++;
+
+#ifdef FLUSH_ALL_RECORDS_AT_ONCE
+    rec_buf_ptr = rec_buf;
+    int_buf_ptr = int_buf;
+    txt_buf_ptr = txt_buf;
+#endif
+
+    for (rec_no=0; rec_no<cfg.nrec; rec_no++) {
+#ifndef FLUSH_ALL_RECORDS_AT_ONCE
+        dbl_buf_ptr = dbl_buf + decom.count[1] * 2 + decom.count[0] + gap * 3;
+        int_buf_ptr = int_buf;
+        txt_buf_ptr = txt_buf;
+        rec_buf_ptr = rec_buf;
+#endif
+        i = 3 + num_decomp_vars;   /* 3 is lat, lon, and area */
+
+        /* next 27 small variables are written by sub_rank 0 only */
+        if (sub_rank == 0) {
+            /* post nonblocking requests for small datasets */
+	    err = write_small_vars_F_case(driver, ncid, i, varids, rec_no, gap,
+					  decom.dims[2][0], decom.dims[2][0] +
+					  1, 2, 8, &int_buf_ptr, &txt_buf_ptr,
+                                          &dbl_buf_ptr, &my_nreqs);
+            CHECK_ERR
+        }
+        i += 27;
+
+        start_D2[0] = rec_no; start_D2[1] = decom.start[1];
+        count_D2[0] = 1;      count_D2[1] = decom.count[1];
+        start_D3[0] = rec_no; start_D3[1] = decom.start[2];
+        count_D3[0] = 1;      count_D3[1] = decom.count[2];
+
+        if (cfg.nvars == 414) { /* h0 file */
+            if (cfg.two_buf) {
+                /* write 2D variables */
+                POST_VARA(2,   1,  30)  /* AEROD_v */
+                POST_VARA(2,  19,  33)  /* AODABS ... AODVIS */
+                POST_VARA(2,   6,  54)  /* AQ_DMS ... AQ_SOAG */
+                POST_VARA(2,   4,  64)  /* BURDEN1 ... BURDEN4 */
+                POST_VARA(2,   2,  69)  /* CDNUMC and CLDHGH */
+                POST_VARA(2,   3,  73)  /* CLDLOW ... CLDTOT */
+                POST_VARA(2,  11,  80)  /* DF_DMS ... DSTSFMBL */
+                POST_VARA(2,   2,  92)  /* DTENDTH and DTENDTQ */
+                POST_VARA(2,   7,  96)  /* FLDS ... FLUTC */
+                POST_VARA(2,  15, 107)  /* FSDS ... ICEFRAC */
+                POST_VARA(2,   2, 125)  /* LANDFRAC and LHFLX */
+                POST_VARA(2,   1, 131)  /* LINOZ_SFCSINK */
+                POST_VARA(2,   3, 133)  /* LINOZ_SZA ... LWCF */
+                POST_VARA(2,   2, 148)  /* O3_SRF and OCNFRAC */
+                POST_VARA(2,   1, 151)  /* OMEGA500 */
+                POST_VARA(2,   8, 153)  /* PBLH ... PSL */
+                POST_VARA(2,   2, 162)  /* QFLX and QREFHT */
+                POST_VARA(2,   1, 167)  /* RAM1 */
+                POST_VARA(2,  37, 169)  /* SFDMS ... SNOWHLND */
+                POST_VARA(2,  10, 208)  /* SO2_CLXF ... SWCF */
+                POST_VARA(2,  19, 219)  /* TAUGWX ... TVQ */
+                POST_VARA(2,   1, 239)  /* U10 */
+                POST_VARA(2,   3, 246)  /* WD_H2O2 ... WD_SO2 */
+                POST_VARA(2,  32, 252)  /* airFV ... dst_c3SFWET */
+                POST_VARA(2, 129, 285)  /* mlip ... soa_c3SFWET */
+                /* write 3D variables */
+                POST_VARA(3,   2,  31)  /* ANRAIN and ANSNOW */
+                POST_VARA(3,   2,  52)  /* AQRAIN and AQSNOW */
+                POST_VARA(3,   4,  60)  /* AREI ... AWNI */
+                POST_VARA(3,   1,  68)  /* CCN3 */
+                POST_VARA(3,   2,  71)  /* CLDICE and CLDLIQ */
+                POST_VARA(3,   4,  76)  /* CLOUD ... DCQ */
+                POST_VARA(3,   1,  91)  /* DTCOND */
+                POST_VARA(3,   2,  94)  /* EXTINCT and FICE */
+                POST_VARA(3,   4, 103)  /* FREQI ... FREQS */
+                POST_VARA(3,   3, 122)  /* ICIMR ... IWC */
+                POST_VARA(3,   4, 127)  /* LINOZ_DO3 ... LINOZ_O3COL */
+                POST_VARA(3,   1, 132)  /* LINOZ_SSO3 */
+                POST_VARA(3,  12, 136)  /* Mass_bc ... O3 */
+                POST_VARA(3,   1, 150)  /* OMEGA */
+                POST_VARA(3,   1, 152)  /* OMEGAT */
+                POST_VARA(3,   1, 161)  /* Q */
+                POST_VARA(3,   3, 164)  /* QRL ... RAINQM */
+                POST_VARA(3,   1, 168)  /* RELHUM */
+                POST_VARA(3,   2, 206)  /* SNOWQM and SO2 */
+                POST_VARA(3,   1, 218)  /* T */
+                POST_VARA(3,   1, 238)  /* U */
+                POST_VARA(3,   6, 240)  /* UU ... VV */
+                POST_VARA(3,   3, 249)  /* WSUB ... aero_water */
+                POST_VARA(3,   1, 284)  /* hstobie_linoz */
+            } else {
+                /* write variables in the same order as they defined */
+                POST_VARA(2,   1,  30)  /* AEROD_v */
+                POST_VARA(3,   2,  31)  /* ANRAIN and ANSNOW */
+                POST_VARA(2,  19,  33)  /* AODABS ... AODVIS */
+                POST_VARA(3,   2,  52)  /* AQRAIN and AQSNOW */
+                POST_VARA(2,   6,  54)  /* AQ_DMS ... AQ_SOAG */
+                POST_VARA(3,   4,  60)  /* AREI ... AWNI */
+                POST_VARA(2,   4,  64)  /* BURDEN1 ... BURDEN4 */
+                POST_VARA(3,   1,  68)  /* CCN3 */
+                POST_VARA(2,   2,  69)  /* CDNUMC and CLDHGH */
+                POST_VARA(3,   2,  71)  /* CLDICE and CLDLIQ */
+                POST_VARA(2,   3,  73)  /* CLDLOW ... CLDTOT */
+                POST_VARA(3,   4,  76)  /* CLOUD ... DCQ */
+                POST_VARA(2,  11,  80)  /* DF_DMS ... DSTSFMBL */
+                POST_VARA(3,   1,  91)  /* DTCOND */
+                POST_VARA(2,   2,  92)  /* DTENDTH and DTENDTQ */
+                POST_VARA(3,   2,  94)  /* EXTINCT and FICE */
+                POST_VARA(2,   7,  96)  /* FLDS ... FLUTC */
+                POST_VARA(3,   4, 103)  /* FREQI ... FREQS */
+                POST_VARA(2,  15, 107)  /* FSDS ... ICEFRAC */
+                POST_VARA(3,   3, 122)  /* ICIMR ... IWC */
+                POST_VARA(2,   2, 125)  /* LANDFRAC and LHFLX */
+                POST_VARA(3,   4, 127)  /* LINOZ_DO3 ... LINOZ_O3COL */
+                POST_VARA(2,   1, 131)  /* LINOZ_SFCSINK */
+                POST_VARA(3,   1, 132)  /* LINOZ_SSO3 */
+                POST_VARA(2,   3, 133)  /* LINOZ_SZA ... LWCF */
+                POST_VARA(3,  12, 136)  /* Mass_bc ... O3 */
+                POST_VARA(2,   2, 148)  /* O3_SRF and OCNFRAC */
+                POST_VARA(3,   1, 150)  /* OMEGA */
+                POST_VARA(2,   1, 151)  /* OMEGA500 */
+                POST_VARA(3,   1, 152)  /* OMEGAT */
+                POST_VARA(2,   8, 153)  /* PBLH ... PSL */
+                POST_VARA(3,   1, 161)  /* Q */
+                POST_VARA(2,   2, 162)  /* QFLX and QREFHT */
+                POST_VARA(3,   3, 164)  /* QRL ... RAINQM */
+                POST_VARA(2,   1, 167)  /* RAM1 */
+                POST_VARA(3,   1, 168)  /* RELHUM */
+                POST_VARA(2,  37, 169)  /* SFDMS ... SNOWHLND */
+                POST_VARA(3,   2, 206)  /* SNOWQM and SO2 */
+                POST_VARA(2,  10, 208)  /* SO2_CLXF ... SWCF */
+                POST_VARA(3,   1, 218)  /* T */
+                POST_VARA(2,  19, 219)  /* TAUGWX ... TVQ */
+                POST_VARA(3,   1, 238)  /* U */
+                POST_VARA(2,   1, 239)  /* U10 */
+                POST_VARA(3,   6, 240)  /* UU ... VV */
+                POST_VARA(2,   3, 246)  /* WD_H2O2 ... WD_SO2 */
+                POST_VARA(3,   3, 249)  /* WSUB ... aero_water */
+                POST_VARA(2,  32, 252)  /* airFV ... dst_c3SFWET */
+                POST_VARA(3,   1, 284)  /* hstobie_linoz */
+                POST_VARA(2, 129, 285)  /* mlip ... soa_c3SFWET */
+            }
+        } else { /* h1 file */
+            if (cfg.two_buf) {
+                /* write 2D variables followed by 3D variables */
+                POST_VARA(2, 13, 30)  /* CLDHGH ... T5 */
+                POST_VARA(2,  7, 44)  /* U250 ... Z500 */
+                POST_VARA(3,  1, 43)  /* U */
+            } else {
+                /* write variables in the same order as they defined */
+                POST_VARA(2, 13, 30)  /* CLDHGH ... T5 */
+                POST_VARA(3,  1, 43)  /* U */
+                POST_VARA(2,  7, 44)  /* U250 ... Z500 */
+            }
+        }
+#ifndef FLUSH_ALL_RECORDS_AT_ONCE
+        post_timing += MPI_Wtime() - timing;
+
+        MPI_Barrier(cfg.sub_comm); /*---------------------------------------*/
+        timing = MPI_Wtime();
+
+        /* flush once per time record */
+        WAIT_ALL_REQS
+
+        wait_timing += MPI_Wtime() - timing;
+
+        timing = MPI_Wtime();
+#endif
+        if (cfg.nvars == 414)
+            break; /* h0 file stores only one time stamp */
+    }
+#ifdef FLUSH_ALL_RECORDS_AT_ONCE
+    post_timing += MPI_Wtime() - timing;
+
+    MPI_Barrier(cfg.sub_comm); /*---------------------------------------*/
+    timing = MPI_Wtime();
+
+    /* flush once for all time records */
+    WAIT_ALL_REQS
+
+    wait_timing += MPI_Wtime() - timing;
+#endif
+    MPI_Barrier(cfg.sub_comm); /*---------------------------------------*/
+    timing = MPI_Wtime();
+
+    if (rec_buf != NULL) free(rec_buf);
+    if (dbl_buf != NULL) free(dbl_buf);
+    if (txt_buf != NULL) free(txt_buf);
+    if (int_buf != NULL) free(int_buf);
+    free(varids);
+
+    if (cfg.api == pnetcdf) INQ_PUT_SIZE(total_size)
+
+    FILE_CLOSE
+
+    close_timing += MPI_Wtime() - timing;
+
+    if (cfg.api == hdf5) INQ_PUT_SIZE(total_size)
+
+    total_size -= previous_size;
+    put_size = total_size - metadata_size;
+
+    total_timing = MPI_Wtime() - total_timing;
+
+    /* check if there is any PnetCDF internal malloc residue */
+    if (cfg.api == pnetcdf) {
+        MPI_Offset malloc_size;
+        err = driver.inq_malloc_size(&malloc_size);
+        if (err == NC_NOERR) {
+            MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, cfg.io_comm);
+            if (global_rank == 0 && sum_size > 0) {
+                printf("-----------------------------------------------------------\n");
+                printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+                        sum_size);
+            }
+        }
+        driver.inq_malloc_max_size(&m_alloc);
+    }
+
+    MPI_Offset off_tmp[3], sum_off[3];
+    off_tmp[0] = my_nreqs;
+    off_tmp[1] = put_size;
+    off_tmp[2] = total_size;
+    MPI_Reduce(off_tmp, sum_off, 3, MPI_OFFSET, MPI_SUM, 0, cfg.io_comm);
+    total_nreqs = sum_off[0];
+    put_size    = sum_off[1];
+    total_size  = sum_off[2];
+
+    MPI_Offset max_off[2];
+    off_tmp[0] = my_nreqs;
+    off_tmp[1] = m_alloc;
+    MPI_Reduce(off_tmp, max_off, 2, MPI_OFFSET, MPI_MAX, 0, cfg.io_comm);
+    max_nreqs = max_off[0];
+    max_alloc = max_off[1];
+
+    double dbl_tmp[7], max_dbl[7];
+    dbl_tmp[0] =   pre_timing;
+    dbl_tmp[1] =  open_timing;
+    dbl_tmp[2] =   def_timing;
+    dbl_tmp[3] =  post_timing;
+    dbl_tmp[4] =  wait_timing;
+    dbl_tmp[5] = close_timing;
+    dbl_tmp[6] = total_timing;
+    MPI_Reduce(dbl_tmp, max_dbl, 7, MPI_DOUBLE, MPI_MAX, 0, cfg.io_comm);
+      pre_timing = max_dbl[0];
+     open_timing = max_dbl[1];
+      def_timing = max_dbl[2];
+     post_timing = max_dbl[3];
+     wait_timing = max_dbl[4];
+    close_timing = max_dbl[5];
+    total_timing = max_dbl[6];
+
+    if (global_rank == 0) {
+        int nvars_noD = cfg.nvars;
+        for (i = 0; i < 3; i++) nvars_noD -= nvars_D[i];
+        printf("History output file                = %s\n", outfile);
+        printf("No. decomposition variables        = %3d\n", num_decomp_vars);
+        printf("No. variables use no decomposition = %3d\n", nvars_noD);
+        printf("No. variables use decomposition D1 = %3d\n", nvars_D[0]);
+        printf("No. variables use decomposition D2 = %3d\n", nvars_D[1]);
+        printf("No. variables use decomposition D3 = %3d\n", nvars_D[2]);
+        printf("Total number of variables          = %3d\n", cfg.nvars + num_decomp_vars);
+        if (cfg.api == pnetcdf)
+            printf("MAX heap memory allocated by PnetCDF internally is %.2f MiB\n",
+                   (float)max_alloc / 1048576);
+        printf("Total write amount                 = %.2f MiB = %.2f GiB\n",
+               (double)total_size / 1048576, (double)total_size / 1073741824);
+        printf("Total no. noncontiguous requests   = %lld\n", total_nreqs);
+        printf("Max   no. noncontiguous requests   = %lld\n", max_nreqs);
+        if (cfg.api == pnetcdf)
+            printf("No. I/O flush calls                = %d\n", nflushes);
+        printf("Max Time of I/O preparing          = %.4f sec\n",   pre_timing);
+        printf("Max Time of file open/create       = %.4f sec\n",  open_timing);
+        printf("Max Time of define variables       = %.4f sec\n",   def_timing);
+        printf("Max Time of posting iput requests  = %.4f sec\n",  post_timing);
+        if (cfg.api == pnetcdf)
+            printf("Max Time of write flushing         = %.4f sec\n",  wait_timing);
+        printf("Max Time of close                  = %.4f sec\n", close_timing);
+        printf("Max Time of TOTAL                  = %.4f sec\n", total_timing);
+        printf("I/O bandwidth (open-to-close)      = %.4f MiB/sec\n",
+               (double)total_size / 1048576.0 / total_timing);
+        if (cfg.api == pnetcdf)
+            printf("I/O bandwidth (write-only)         = %.4f MiB/sec\n",
+                   (double)put_size / 1048576.0 / wait_timing);
+        if (cfg.verbose) print_info(&info_used);
+        printf("-----------------------------------------------------------\n");
+    }
+
+err_out:
+    if (err < 0 && ncid >= 0)
+#ifdef USE_PNETCDF_DIRECTLY
+        ncmpi_close(ncid);
+#else
+        driver.close(ncid);
+#endif
+
+    if (info_used != MPI_INFO_NULL) MPI_Info_free(&info_used);
+    if (!cfg.keep_outfile && sub_rank == 0) unlink(outfile);
+    fflush(stdout);
+
+    return err;
+}
+

--- a/src/cases/var_io_F_case_blob.cpp
+++ b/src/cases/var_io_F_case_blob.cpp
@@ -806,6 +806,8 @@ int blob_F_case(e3sm_io_config &cfg,
         printf("No. variables use decomposition D2 = %3d\n", nvars_D[1]);
         printf("No. variables use decomposition D3 = %3d\n", nvars_D[2]);
         printf("Total number of variables          = %3d\n", cfg.nvars + num_decomp_vars);
+        printf("Write number of records (time dim) = %3d\n",
+               (cfg.nvars == 414) ? 1 : cfg.nrec);
         if (cfg.api == pnetcdf)
             printf("MAX heap memory allocated by PnetCDF internally is %.2f MiB\n",
                    (float)max_alloc / 1048576);

--- a/src/cases/var_io_G_case_blob.cpp
+++ b/src/cases/var_io_G_case_blob.cpp
@@ -756,6 +756,7 @@ int blob_G_case(e3sm_io_config &cfg,
         printf("No. variables use decomposition D5 = %3d\n", nvars_D[4]);
         printf("No. variables use decomposition D6 = %3d\n", nvars_D[5]);
         printf("Total number of variables          = %3d\n", cfg.nvars + num_decomp_vars);
+        printf("Write number of records (time dim) = %3d\n", cfg.nrec);
         if (cfg.api == pnetcdf)
             printf("MAX heap memory allocated by PnetCDF internally is %.2f MiB\n",
                    (float)max_alloc / 1048576);

--- a/src/cases/var_io_G_case_blob.cpp
+++ b/src/cases/var_io_G_case_blob.cpp
@@ -1,0 +1,799 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h> /* strtoll() */
+#include <string.h> /* strcpy(), strncpy() */
+#include <string>
+
+#include <unistd.h> /* getopt() unlink() */
+
+#include <mpi.h>
+
+#include <e3sm_io_case_G.hpp>
+#include <e3sm_io.h>
+#include <e3sm_io_err.h>
+#include <e3sm_io_driver.hpp>
+
+#ifdef USE_PNETCDF_DIRECTLY
+#define CHECK_VAR_ERR(varid) {                                      \
+    if (err != NC_NOERR) {                                          \
+        char name[64];                                              \
+        ncmpi_inq_varname(ncid, varid, name);                       \
+        printf("Error in %s:%d: var %s - %s\n", __FILE__, __LINE__, \
+               name, ncmpi_strerror(err));                          \
+        goto err_out;                                               \
+    }                                                               \
+}
+#define FILE_CREATE(filename) { \
+    err = ncmpi_create(cfg.sub_comm, filename, NC_CLOBBER|NC_64BIT_DATA, cfg.info, &ncid); \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+}
+#define FILE_CLOSE {                                       \
+    err = ncmpi_close(ncid);                               \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+}
+#define ENDDEF {                                           \
+    err = ncmpi_enddef(ncid);                              \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+}
+#define INQ_PUT_SIZE(size) {                               \
+    err = ncmpi_inq_put_size(ncid, &size);                 \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+}
+#define INQ_FILE_INFO(info) {                              \
+    err = ncmpi_inq_file_info(ncid, &info);                \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+}
+#define IPUT_VAR_DBL(adv) { \
+    err = ncmpi_iput_var_double(ncid, *varid, dbl_buf_ptr, NULL); \
+    CHECK_VAR_ERR(*varid) \
+    dbl_buf_ptr += (adv); \
+    varid++; \
+}
+#define IPUT_VAR_INT(adv) { \
+    err = ncmpi_iput_var_int(ncid, *varid, int_buf_ptr, NULL); \
+    CHECK_VAR_ERR(*varid) \
+    int_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VAR1_DBL(adv) { \
+    err = ncmpi_iput_var1_double(ncid, *varid, start, dbl_buf_ptr, NULL); \
+    CHECK_VAR_ERR(*varid) \
+    dbl_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VAR1_INT(adv) { \
+    err = ncmpi_iput_var1_int(ncid, *varid, start, int_buf_ptr, NULL); \
+    CHECK_VAR_ERR(*varid) \
+    int_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA_INT(adv) { \
+    err = ncmpi_iput_vara_int(ncid, *varid, start, count, int_buf_ptr, NULL); \
+    CHECK_VAR_ERR(*varid) \
+    int_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA_INT_NOADV(buf) { \
+    err = ncmpi_iput_vara_int(ncid, *varid, start, count, buf, NULL); \
+    CHECK_VAR_ERR(*varid) \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA_INT64_NOADV(buf) { \
+    err = ncmpi_iput_vara_longlong(ncid, *varid, start, count, buf, NULL); \
+    CHECK_VAR_ERR(*varid) \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA_DBL(adv) { \
+    err = ncmpi_iput_vara_double(ncid, *varid, start, count, dbl_buf_ptr, NULL); \
+    CHECK_VAR_ERR(*varid) \
+    dbl_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA_CHR(adv) { \
+    err = ncmpi_iput_vara_text(ncid, *varid, start, count, chr_buf_ptr, NULL); \
+    CHECK_VAR_ERR(*varid) \
+    chr_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#ifdef _DOUBLE_TYPE_
+#define IPUT_VARA(varid, start, count, buf) { \
+    err = ncmpi_iput_vara_double(ncid, varid, start, count, buf, NULL); \
+    CHECK_VAR_ERR(varid) \
+    my_nreqs++; \
+}
+#else
+#define IPUT_VARA(varid, start, count, buf) { \
+    err = ncmpi_iput_vara_float(ncid, varid, start, count, buf, NULL); \
+    CHECK_VAR_ERR(varid) \
+    my_nreqs++; \
+}
+#endif
+#define POST_VARA_DBL(decomp) {                                       \
+    err = ncmpi_iput_vara_double(ncid, *varid, start_D[decomp],       \
+                                 count_D[decomp], dbl_buf_ptr, NULL); \
+    CHECK_VAR_ERR(*varid)                                             \
+    dbl_buf_ptr += count_D[decomp][1] + gap;                          \
+    my_nreqs++;                                                       \
+    varid++;                                                          \
+    if (rec_no == 0) nvars_D[decomp]++;                               \
+}
+#define WAIT_ALL_REQS {                                    \
+    err = ncmpi_wait_all(ncid, NC_REQ_ALL, NULL, NULL);    \
+    if (err != NC_NOERR) {                                 \
+        printf("Error in %s:%d: %s\n", __FILE__, __LINE__, \
+               ncmpi_strerror(err));                       \
+        goto err_out;                                      \
+    }                                                      \
+    nflushes++;                                            \
+}
+#else
+#define CHECK_VAR_ERR(varid) {                                \
+    if (err != 0) {                                           \
+        char var_name[64];                                    \
+        driver.inq_var_name(ncid, varid, var_name);           \
+        printf("Error in %s:%d: %s() var %s\n"     ,          \
+               __FILE__, __LINE__, __func__, var_name);       \
+        goto err_out;                                         \
+    }                                                         \
+}
+#define FILE_CREATE(filename) { \
+    err = driver.create(filename, cfg.sub_comm, cfg.info, &ncid); \
+    CHECK_ERR \
+}
+#define FILE_CLOSE {            \
+    err = driver.close(ncid);   \
+    CHECK_ERR                   \
+}
+#define ENDDEF {                \
+    err = driver.enddef(ncid);  \
+    CHECK_ERR                   \
+}
+#define INQ_PUT_SIZE(size) {                 \
+    err = driver.inq_put_size(ncid, &size);  \
+    CHECK_ERR                                \
+}
+#define INQ_FILE_INFO(info) {                \
+    err = driver.inq_file_info(ncid, &info); \
+    CHECK_ERR                                \
+}
+#define IPUT_VAR_DBL(adv) { \
+    err = driver.put_vara(ncid, *varid, MPI_DOUBLE, NULL, NULL, dbl_buf_ptr, nb); \
+    CHECK_VAR_ERR(*varid) \
+    dbl_buf_ptr += (adv); \
+    varid++; \
+}
+#define IPUT_VAR_INT(adv) { \
+    err = driver.put_vara(ncid, *varid, MPI_INT, NULL, NULL, int_buf_ptr, nb); \
+    CHECK_VAR_ERR(*varid) \
+    int_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VAR1_DBL(adv) { \
+    err = driver.put_vara(ncid, *varid, MPI_DOUBLE, start, NULL, dbl_buf_ptr, nb); \
+    CHECK_VAR_ERR(*varid) \
+    dbl_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VAR1_INT(adv) { \
+    err = driver.put_vara(ncid, *varid, MPI_INT, start, NULL, int_buf_ptr, nb); \
+    CHECK_VAR_ERR(*varid) \
+    int_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA_INT(adv) { \
+    err = driver.put_vara(ncid, *varid, MPI_INT, start, count, int_buf_ptr, nb); \
+    CHECK_VAR_ERR(*varid) \
+    int_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA_INT_NOADV(buf) { \
+    err = driver.put_vara(ncid, *varid, MPI_INT, start, count, buf, nb); \
+    CHECK_VAR_ERR(*varid) \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA_INT64_NOADV(buf) { \
+    err = driver.put_vara(ncid, *varid, MPI_LONG_LONG, start, count, buf, nb); \
+    CHECK_VAR_ERR(*varid) \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA_DBL(adv) { \
+    err = driver.put_vara(ncid, *varid, MPI_DOUBLE, start, count, dbl_buf_ptr, nb); \
+    CHECK_VAR_ERR(*varid) \
+    dbl_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA_CHR(adv) { \
+    err = driver.put_vara(ncid, *varid, MPI_CHAR, start, count, chr_buf_ptr, nb); \
+    CHECK_VAR_ERR(*varid) \
+    chr_buf_ptr += (adv); \
+    my_nreqs++; \
+    varid++; \
+}
+#define IPUT_VARA(varid, start, count, buf) { \
+    err = driver.put_vara(ncid, varid, REC_ITYPE, start, count, buf, nb); \
+    CHECK_VAR_ERR(varid) \
+    my_nreqs++; \
+    varid++; \
+}
+#define POST_VARA_DBL(decomp) {                                       \
+    err = driver.put_vara(ncid, *varid, MPI_DOUBLE, start_D[decomp],  \
+                          count_D[decomp], dbl_buf_ptr, nb);          \
+    CHECK_VAR_ERR(*varid)                                             \
+    dbl_buf_ptr += count_D[decomp][1] + gap;                          \
+    my_nreqs++;                                                       \
+    varid++;                                                          \
+    if (rec_no == 0) nvars_D[decomp]++;                               \
+}
+#define WAIT_ALL_REQS { \
+    err = driver.wait(ncid); \
+    CHECK_ERR \
+    nflushes++; \
+}
+#endif
+
+/*----< blob_G_case() >------------------------------------------------------*/
+int blob_G_case(e3sm_io_config &cfg,
+                e3sm_io_decom  &decom,
+                e3sm_io_driver &driver)
+{
+    char outfile[1040];
+    int i, err, sub_rank, global_rank, ncid=-1, nflushes=0, *varids;
+    int rec_no, gap=0, my_nreqs, num_decomp_vars;
+    int contig_nreqs[MAX_NUM_DECOMP], nvars_D[MAX_NUM_DECOMP];
+    double pre_timing, open_timing, post_timing, wait_timing, close_timing;
+    double def_timing, timing, total_timing;
+    MPI_Offset metadata_size, put_size, total_size, max_nreqs, total_nreqs;
+    MPI_Offset start[2], count[2];
+    MPI_Offset start_D[MAX_NUM_DECOMP][2], count_D[MAX_NUM_DECOMP][2];
+    MPI_Offset blob_start[MAX_NUM_DECOMP], blob_count[MAX_NUM_DECOMP];
+    MPI_Offset previous_size, sum_size, m_alloc=0, max_alloc;
+    MPI_Info info_used = MPI_INFO_NULL;
+    size_t j, chr_buflen, int_buflen, dbl_buflen;
+    double *dbl_buf=NULL, *dbl_buf_ptr; /* buffer for fixed double var */
+    int    *int_buf=NULL, *int_buf_ptr; /* buffer for int var */
+    char   *chr_buf=NULL, *chr_buf_ptr; /* buffer for char var */
+
+    int dec_varids[NVARS_DECOMP*MAX_NUM_DECOMP], *varid;
+    int fix_varids[11] = {8, 9, 10, 11, 12, 13, 14, 33, 35, 36, 37};
+    int rec_varids[41] = { 0,  1,  2,  3,  4,  5,  6,  7,
+                                              15, 16, 17, 18, 19,
+                          20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                          30, 31, 32,     34,             38, 39,
+                          40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+                          50, 51};
+
+    MPI_Barrier (cfg.io_comm); /*-----------------------------------------*/
+    total_timing = pre_timing = MPI_Wtime ();
+
+    open_timing  = 0.0;
+    def_timing   = 0.0;
+    post_timing  = 0.0;
+    wait_timing  = 0.0;
+    close_timing = 0.0;
+
+    if (cfg.api == hdf5) /* I/O amount from previous I/O */
+        INQ_PUT_SIZE(previous_size)
+    else
+        previous_size = 0;
+
+    MPI_Comm_rank(cfg.io_comm,  &global_rank);
+    MPI_Comm_rank(cfg.sub_comm, &sub_rank);
+
+    /* there are num_decomp_vars number of decomposition variables */
+    num_decomp_vars = decom.num_decomp * NVARS_DECOMP;
+
+    for (i=0; i<num_decomp_vars; i++) dec_varids[i] = i;
+    for (i=0; i<11; i++) fix_varids[i] += num_decomp_vars;
+    for (i=0; i<41; i++) rec_varids[i] += num_decomp_vars;
+
+    if (cfg.non_contig_buf) gap = 10;
+
+    /* allocate write buffer for small climate variables */
+    dbl_buflen = decom.dims[2][1] * 4
+               + decom.count[0] * 5
+               + decom.count[2] * 24
+               + decom.count[3]
+               + decom.count[4]
+               + decom.count[5] * 4
+               + 6                     /* 6 single-element variables */
+               + 45 * gap;
+
+    int_buflen = decom.count[0]
+               + decom.count[1] * 2
+               + decom.count[2]
+               + decom.count[3]
+               + decom.count[4]
+               + 6 * gap;
+
+    chr_buflen = 64 + gap;
+
+    /* allocate and initialize write buffer for large variables */
+#define FLUSH_ALL_RECORDS_AT_ONCE
+#ifdef FLUSH_ALL_RECORDS_AT_ONCE
+    dbl_buflen *= cfg.nrec;
+    int_buflen *= cfg.nrec;
+    chr_buflen *= cfg.nrec;
+#else
+    if (cfg.api == hdf5) {
+        printf("Error in %s:%d: %s() FLUSH_ALL_RECORDS_AT_ONCE must be enabled when using HDF5 blob I/O",
+               __FILE__, __LINE__, __func__);
+        err = -1;
+        goto err_out;
+    }
+#endif
+
+    dbl_buf = (double*) malloc(dbl_buflen * sizeof(double));
+    int_buf = (int*)    malloc(int_buflen * sizeof(int));
+    chr_buf = (char*)   malloc(chr_buflen * sizeof(char));
+
+    for (j=0; j<dbl_buflen; j++) dbl_buf[j] = global_rank;
+    for (j=0; j<int_buflen; j++) int_buf[j] = global_rank;
+    for (j=0; j<chr_buflen; j++) chr_buf[j] = 'a' + global_rank;
+
+    pre_timing = MPI_Wtime() - pre_timing;
+
+    MPI_Barrier(cfg.sub_comm); /*-----------------------------------------*/
+    timing = MPI_Wtime();
+
+    sprintf(outfile, "%s.%04d", cfg.out_path, cfg.subfile_ID);
+
+    /* set output subfile name */
+    if (cfg.verbose && sub_rank == 0)
+        printf("global_rank=%d sub_rank=%d outfile=%s\n",global_rank,sub_rank,outfile);
+
+    /* create the output file */
+    FILE_CREATE(outfile)
+
+    open_timing += MPI_Wtime() - timing;
+
+    MPI_Barrier(cfg.sub_comm); /*-----------------------------------------*/
+    timing = MPI_Wtime();
+
+    /* allocate space for all variable IDs */
+    varids = (int*) malloc((cfg.nvars + num_decomp_vars) * sizeof(int));
+
+    /* define dimensions, variables, and attributes */
+    err = def_G_case(cfg, decom, driver, ncid, varids);
+    CHECK_ERR
+
+    free(varids);
+
+    /* exit define mode and enter data mode */
+    ENDDEF
+
+    /* I/O amount so far */
+    INQ_PUT_SIZE(metadata_size)
+    metadata_size -= previous_size;
+
+    INQ_FILE_INFO(info_used)
+
+    def_timing += MPI_Wtime() - timing;
+
+    MPI_Barrier(cfg.sub_comm); /*-----------------------------------------*/
+    timing = MPI_Wtime();
+
+    my_nreqs = 0;
+
+    /* First, write decomposition variables */
+    varid = dec_varids;
+    for (i=0; i<decom.num_decomp; i++) {
+        nvars_D[i] = 0; /* number of variables using decomposition i */
+        start[0] = sub_rank;
+        count[0] = 1;
+        start[1] = 0;
+        count[1] = decom.contig_nreqs[i];
+
+        /* write to D*.nreqs, 1D array */
+        contig_nreqs[i] = decom.contig_nreqs[i];
+        IPUT_VARA_INT_NOADV(contig_nreqs+i)
+
+        /* write to D*.blob_start, 1D array */
+        blob_start[i] = decom.start[i];
+        IPUT_VARA_INT64_NOADV(blob_start+i)
+
+        /* write to D*.blob_count, 1D array */
+        blob_count[i] = decom.count[i];
+        IPUT_VARA_INT64_NOADV(blob_count+i);
+
+        /* write to D*.offsets, 2D array */
+        IPUT_VARA_INT_NOADV(decom.disps[i])
+
+        /* write to D*.lengths, 2D array */
+        IPUT_VARA_INT_NOADV(decom.blocklens[i])
+    }
+
+    /* Now, write climate variables */
+    dbl_buf_ptr = dbl_buf;
+    int_buf_ptr = int_buf;
+    chr_buf_ptr = chr_buf;
+
+    /* write all 11 fixed-size variables first */
+    varid = fix_varids;
+
+    /* int maxLevelEdgeTop(nEdges) */
+    start[0] = decom.start[1];
+    count[0] = decom.count[1];
+    IPUT_VARA_INT(count[0] + gap)
+    nvars_D[1]++;
+
+    /* double vertCoordMovementWeights(nVertLevels) */
+    if (sub_rank == 0)
+        IPUT_VAR_DBL(decom.dims[2][1] + gap)
+    else
+        varid++;
+
+    /* int edgeMask(nEdges, nVertLevels) */
+    start[0] = decom.start[3];
+    count[0] = decom.count[3];
+    IPUT_VARA_INT(count[0] + gap)
+    nvars_D[3]++;
+
+    /* int cellMask(nCells, nVertLevels) */
+    start[0] = decom.start[2];
+    count[0] = decom.count[2];
+    IPUT_VARA_INT(count[0] + gap)
+    nvars_D[2]++;
+
+    /* int vertexMask(nVertices, nVertLevels) */
+    start[0] = decom.start[4];
+    count[0] = decom.count[4];
+    IPUT_VARA_INT(count[0] + gap)
+    nvars_D[4]++;
+
+    /* double refZMid(nVertLevels) */
+    if (sub_rank == 0)
+        IPUT_VAR_DBL(decom.dims[2][1] + gap)
+    else
+        varid++;
+
+    /* double refLayerThickness(nVertLevels) */
+    if (sub_rank == 0)
+        IPUT_VAR_DBL(decom.dims[2][1] + gap)
+    else
+        varid++;
+
+    /* double refBottomDepth(nVertLevels) */
+    if (sub_rank == 0)
+        IPUT_VAR_DBL(decom.dims[2][1] + gap)
+    else
+        varid++;
+
+    /* double bottomDepth(nCells) */
+    start[0] = decom.start[0];
+    count[0] = decom.count[0];
+    IPUT_VARA_DBL(count[0] + gap)
+    nvars_D[0]++;
+
+    /* int maxLevelCell(nCells) */
+    start[0] = decom.start[0];
+    count[0] = decom.count[0];
+    IPUT_VARA_INT(count[0] + gap)
+    nvars_D[0]++;
+
+    /* int maxLevelEdgeBot(nEdges) */
+    start[0] = decom.start[1];
+    count[0] = decom.count[1];
+    IPUT_VARA_INT(count[0] + gap)
+    nvars_D[1]++;
+
+    /* Now write record variables */
+
+    for (i=0; i<decom.num_decomp; i++) {
+        start_D[i][0] = 0;
+        start_D[i][1] = decom.start[i];
+        count_D[i][0] = 1;
+        count_D[i][1] = decom.count[i];
+    }
+
+    for (rec_no=0; rec_no<cfg.nrec; rec_no++) {
+#ifndef FLUSH_ALL_RECORDS_AT_ONCE
+        timing = MPI_Wtime();
+        dbl_buf_ptr = dbl_buf
+                    + decom.dims[2][1] * 4
+                    + decom.count[0] + gap * 5;
+        int_buf_ptr = int_buf
+                    + decom.count[0]
+                    + decom.count[1] * 2
+                    + decom.count[3]
+                    + decom.count[2]
+                    + decom.count[4] + gap * 6;
+        chr_buf_ptr = chr_buf;
+#endif
+
+        for (i=0; i<decom.num_decomp; i++)
+            start_D[i][0] = rec_no;
+
+        varid = rec_varids;
+
+        /* write 41 record variables */
+
+        /* double salinitySurfaceRestoringTendency(Time, nCells) */
+        POST_VARA_DBL(0)
+        /* double vertTransportVelocityTop(Time, nCells, nVertLevelsP1) */
+        POST_VARA_DBL(5)
+        /* double vertGMBolusVelocityTop(Time, nCells, nVertLevelsP1) */
+        POST_VARA_DBL(5)
+        /* double vertAleTransportTop(Time, nCells, nVertLevelsP1) */
+        POST_VARA_DBL(5)
+        /* double tendSSH(Time, nCells) */
+        POST_VARA_DBL(0)
+        /* double layerThickness(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double normalVelocity(Time, nEdges, nVertLevels) */
+        POST_VARA_DBL(3)
+        /* double ssh(Time, nCells) */
+        POST_VARA_DBL(0)
+        /* char xtime(Time, StrLen) */
+        if (sub_rank == 0) {
+            start[0] = rec_no;
+            start[1] = 0;
+            count[0] = 1;
+            count[1] = 64;
+            IPUT_VARA_CHR(64 + gap)
+        }
+        else
+            varid++;
+        /* double kineticEnergyCell(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double relativeVorticityCell(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double relativeVorticity(Time, nVertices, nVertLevels) */
+        POST_VARA_DBL(4)
+        /* double divergence(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        if (sub_rank == 0) {
+            start[0] = rec_no;
+            count[0] = 1;
+            /* double areaCellGlobal(Time) */
+            IPUT_VAR1_DBL(1 + gap)
+            /* double areaEdgeGlobal(Time) */
+            IPUT_VAR1_DBL(1 + gap)
+            /* double areaTriangleGlobal(Time) */
+            IPUT_VAR1_DBL(1 + gap)
+            /* double volumeCellGlobal(Time) */
+            IPUT_VAR1_DBL(1 + gap)
+            /* double volumeEdgeGlobal(Time) */
+            IPUT_VAR1_DBL(1 + gap)
+            /* double CFLNumberGlobal(Time) */
+            IPUT_VAR1_DBL(1 + gap)
+        }
+        else
+            varid += 6;
+        /* double BruntVaisalaFreqTop(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double vertVelocityTop(Time, nCells, nVertLevelsP1) */
+        POST_VARA_DBL(5)
+        /* double velocityZonal(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double velocityMeridional(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double displacedDensity(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double potentialDensity(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double pressure(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double zMid(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double columnIntegratedSpeed(Time, nCells) */
+        POST_VARA_DBL(0)
+        /* double temperatureHorizontalAdvectionTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double salinityHorizontalAdvectionTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double temperatureVerticalAdvectionTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double salinityVerticalAdvectionTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double temperatureVertMixTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double salinityVertMixTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double temperatureSurfaceFluxTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double salinitySurfaceFluxTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double temperatureShortWaveTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double temperatureNonLocalTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double salinityNonLocalTendency(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double temperature(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+        /* double salinity(Time, nCells, nVertLevels) */
+        POST_VARA_DBL(2)
+
+#ifndef FLUSH_ALL_RECORDS_AT_ONCE
+        post_timing += MPI_Wtime() - timing;
+
+        MPI_Barrier(cfg.sub_comm); /*---------------------------------------*/
+        timing = MPI_Wtime();
+
+        /* flush once per time record */
+        WAIT_ALL_REQS
+
+        wait_timing += MPI_Wtime() - timing;
+
+        timing = MPI_Wtime();
+#endif
+    }
+#ifdef FLUSH_ALL_RECORDS_AT_ONCE
+    post_timing += MPI_Wtime() - timing;
+
+    MPI_Barrier(cfg.sub_comm); /*---------------------------------------*/
+    timing = MPI_Wtime();
+
+    /* flush once for all time records */
+    WAIT_ALL_REQS
+
+    wait_timing += MPI_Wtime() - timing;
+#endif
+    MPI_Barrier(cfg.sub_comm); /*---------------------------------------*/
+    timing = MPI_Wtime();
+
+    if (dbl_buf != NULL) free(dbl_buf);
+    if (chr_buf != NULL) free(chr_buf);
+    if (int_buf != NULL) free(int_buf);
+
+    if (cfg.api == pnetcdf) INQ_PUT_SIZE(total_size)
+
+    FILE_CLOSE
+
+    close_timing += MPI_Wtime() - timing;
+
+    if (cfg.api == hdf5) INQ_PUT_SIZE(total_size)
+
+    total_size -= previous_size;
+    put_size = total_size - metadata_size;
+
+    total_timing = MPI_Wtime() - total_timing;
+
+    /* check if there is any PnetCDF internal malloc residue */
+    if (cfg.api == pnetcdf) {
+        MPI_Offset malloc_size;
+        err = driver.inq_malloc_size(&malloc_size);
+        if (err == NC_NOERR) {
+            MPI_Reduce(&malloc_size, &sum_size, 1, MPI_OFFSET, MPI_SUM, 0, cfg.io_comm);
+            if (global_rank == 0 && sum_size > 0) {
+                printf("-----------------------------------------------------------\n");
+                printf("heap memory allocated by PnetCDF internally has %lld bytes yet to be freed\n",
+                        sum_size);
+            }
+        }
+        driver.inq_malloc_max_size(&m_alloc);
+    }
+
+    MPI_Offset off_tmp[3], sum_off[3];
+    off_tmp[0] = my_nreqs;
+    off_tmp[1] = put_size;
+    off_tmp[2] = total_size;
+    MPI_Reduce(off_tmp, sum_off, 3, MPI_OFFSET, MPI_SUM, 0, cfg.io_comm);
+    total_nreqs = sum_off[0];
+    put_size    = sum_off[1];
+    total_size  = sum_off[2];
+
+    MPI_Offset max_off[2];
+    off_tmp[0] = my_nreqs;
+    off_tmp[1] = m_alloc;
+    MPI_Reduce(off_tmp, max_off, 2, MPI_OFFSET, MPI_MAX, 0, cfg.io_comm);
+    max_nreqs = max_off[0];
+    max_alloc = max_off[1];
+
+    double dbl_tmp[7], max_dbl[7];
+    dbl_tmp[0] =   pre_timing;
+    dbl_tmp[1] =  open_timing;
+    dbl_tmp[2] =   def_timing;
+    dbl_tmp[3] =  post_timing;
+    dbl_tmp[4] =  wait_timing;
+    dbl_tmp[5] = close_timing;
+    dbl_tmp[6] = total_timing;
+    MPI_Reduce(dbl_tmp, max_dbl, 7, MPI_DOUBLE, MPI_MAX, 0, cfg.io_comm);
+      pre_timing = max_dbl[0];
+     open_timing = max_dbl[1];
+      def_timing = max_dbl[2];
+     post_timing = max_dbl[3];
+     wait_timing = max_dbl[4];
+    close_timing = max_dbl[5];
+    total_timing = max_dbl[6];
+
+    if (global_rank == 0) {
+        int nvars_noD = cfg.nvars;
+        for (i=0; i<decom.num_decomp; i++) nvars_noD -= nvars_D[i];
+        printf("History output file                = %s\n", outfile);
+        printf("No. decomposition variables        = %3d\n", num_decomp_vars);
+        printf("No. variables use no decomposition = %3d\n", nvars_noD);
+        printf("No. variables use decomposition D1 = %3d\n", nvars_D[0]);
+        printf("No. variables use decomposition D2 = %3d\n", nvars_D[1]);
+        printf("No. variables use decomposition D3 = %3d\n", nvars_D[2]);
+        printf("No. variables use decomposition D4 = %3d\n", nvars_D[3]);
+        printf("No. variables use decomposition D5 = %3d\n", nvars_D[4]);
+        printf("No. variables use decomposition D6 = %3d\n", nvars_D[5]);
+        printf("Total number of variables          = %3d\n", cfg.nvars + num_decomp_vars);
+        if (cfg.api == pnetcdf)
+            printf("MAX heap memory allocated by PnetCDF internally is %.2f MiB\n",
+                   (float)max_alloc / 1048576);
+        printf("Total write amount                 = %.2f MiB = %.2f GiB\n",
+               (double)total_size / 1048576, (double)total_size / 1073741824);
+        printf("Total no. noncontiguous requests   = %lld\n", total_nreqs);
+        printf("Max   no. noncontiguous requests   = %lld\n", max_nreqs);
+        if (cfg.api == pnetcdf)
+            printf("No. I/O flush calls                = %d\n", nflushes);
+        printf("Max Time of I/O preparing          = %.4f sec\n",   pre_timing);
+        printf("Max Time of file open/create       = %.4f sec\n",  open_timing);
+        printf("Max Time of define variables       = %.4f sec\n",   def_timing);
+        printf("Max Time of posting iput requests  = %.4f sec\n",  post_timing);
+        if (cfg.api == pnetcdf)
+            printf("Max Time of write flushing         = %.4f sec\n",  wait_timing);
+        printf("Max Time of close                  = %.4f sec\n", close_timing);
+        printf("Max Time of TOTAL                  = %.4f sec\n", total_timing);
+        printf("I/O bandwidth (open-to-close)      = %.4f MiB/sec\n",
+               (double)total_size / 1048576.0 / total_timing);
+        if (cfg.api == pnetcdf)
+            printf("I/O bandwidth (write-only)         = %.4f MiB/sec\n",
+                   (double)put_size / 1048576.0 / wait_timing);
+        if (cfg.verbose) print_info(&info_used);
+        printf("-----------------------------------------------------------\n");
+    }
+
+err_out:
+    if (err < 0 && ncid >= 0)
+#ifdef USE_PNETCDF_DIRECTLY
+        ncmpi_close(ncid);
+#else
+        driver.close(ncid);
+#endif
+
+    if (info_used != MPI_INFO_NULL) MPI_Info_free(&info_used);
+    if (!cfg.keep_outfile && sub_rank == 0) unlink(outfile);
+    fflush(stdout);
+
+    return err;
+}
+

--- a/src/drivers/Makefile.am
+++ b/src/drivers/Makefile.am
@@ -12,13 +12,20 @@ AM_CPPFLAGS += -I${top_srcdir}/src/cases
 noinst_LIBRARIES = libe3sm_io_drivers.a
 
 C_SRCS = e3sm_io_driver_pnc.cpp
-H_SRCS = e3sm_io_driver_pnc.hpp
+
+H_SRCS = e3sm_io_driver.hpp \
+         e3sm_io_driver_pnc.hpp
 
 if ENABLE_HDF5
 C_SRCS +=   e3sm_io_driver_hdf5.cpp \
-            e3sm_io_driver_hdf5_agg.cpp
+            e3sm_io_driver_hdf5_agg.cpp \
+            e3sm_io_driver_h5blob.cpp \
+            blob_ncmpio.c
+
 H_SRCS +=   e3sm_io_driver_hdf5.hpp \
-            e3sm_io_driver_hdf5_int.hpp
+            e3sm_io_driver_hdf5_int.hpp \
+            e3sm_io_driver_h5blob.hpp \
+            blob_ncmpio.h
 endif
 
 if ENABLE_ADIOS2

--- a/src/drivers/blob_ncmpio.c
+++ b/src/drivers/blob_ncmpio.c
@@ -1,0 +1,1103 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <mpi.h>
+
+#include <blob_ncmpio.h>
+
+#define NC_MAGIC_LEN 4
+
+#define X_SIZEOF_NC_TYPE X_SIZEOF_INT
+#define X_SIZEOF_NC_TAG  X_SIZEOF_INT
+
+/*
+ * "magic number" at beginning of file: 0x43444601 (big endian)
+ */
+static const char ncmagic5[] = {'C', 'D', 'F', 0x05};
+
+static const char nada[X_ALIGN] = {0, 0, 0, 0};
+
+static int
+ncmpii_xlen_nc_type(nc_type xtype, int *size)
+{
+    switch(xtype) {
+        case MPI_BYTE:
+        case MPI_CHAR:              *size = 1; return NC_NOERR;
+        case MPI_SHORT:
+        case MPI_UNSIGNED_SHORT:    *size = 2; return NC_NOERR;
+        case MPI_INT:
+        case MPI_UNSIGNED:
+        case MPI_FLOAT:              *size = 4; return NC_NOERR;
+        case MPI_DOUBLE:
+        case MPI_LONG_LONG:
+        case MPI_UNSIGNED_LONG_LONG: *size = 8; return NC_NOERR;
+        default: return 0;
+    }
+}
+
+/*----< hdr_len_NC_dim() >---------------------------------------------------*/
+static MPI_Offset
+hdr_len_NC_dim(const NC_dim *dimp, int sizeof_NON_NEG)
+{
+    /* netCDF file format:
+     *  ...
+     * dim        = name dim_length
+     * dim_length = NON_NEG
+     * NON_NEG    = <non-negative INT> |  // CDF-1 and CDF-2
+     *              <non-negative INT64>  // CDF-5
+     */
+    MPI_Offset sz;
+
+    assert(dimp != NULL);
+
+    sz  = sizeof_NON_NEG + _RNDUP(dimp->name_len, X_ALIGN); /* name */
+    sz += sizeof_NON_NEG;                                   /* dim_length */
+
+    return sz;
+}
+
+/*----< hdr_len_NC_dimarray() >----------------------------------------------*/
+static MPI_Offset
+hdr_len_NC_dimarray(const NC_dimarray *ncap, int sizeof_NON_NEG)
+{
+    /* netCDF file format:
+     *  ...
+     * dim_list     = ABSENT | NC_DIMENSION  nelems  [dim ...]
+     * ABSENT       = ZERO  ZERO |  // list is not present for CDF-1 and 2
+     *                ZERO  ZERO64  // for CDF-5
+     * ZERO         = \x00 \x00 \x00 \x00                      // 32-bit zero
+     * ZERO64       = \x00 \x00 \x00 \x00 \x00 \x00 \x00 \x00  // 64-bit zero
+     * NC_DIMENSION = \x00 \x00 \x00 \x0A         // tag for list of dimensions
+     * nelems       = NON_NEG       // number of elements in following sequence
+     * NON_NEG      = <non-negative INT> |        // CDF-1 and CDF-2
+     *                <non-negative INT64>        // CDF-5
+     */
+    int i;
+    MPI_Offset xlen;
+
+    xlen = X_SIZEOF_NC_TAG;           /* NC_DIMENSION */
+    xlen += sizeof_NON_NEG;           /* nelems */
+
+    if (ncap == NULL) /* ABSENT: no dimension is defined */
+        return xlen;
+
+    /* [dim ...] */
+    for (i=0; i<ncap->ndefined; i++)
+        xlen += hdr_len_NC_dim(ncap->value[i], sizeof_NON_NEG);
+
+    return xlen;
+}
+
+/*----< hdr_len_NC_attr() >--------------------------------------------------*/
+static MPI_Offset
+hdr_len_NC_attr(const NC_attr *attrp, int sizeof_NON_NEG)
+{
+    /* netCDF file format:
+     *  ...
+     * attr    = name  nc_type  nelems  [values ...]
+     * nc_type = NC_BYTE | NC_CHAR | NC_SHORT | ...
+     * nelems  = NON_NEG       // number of elements in following sequence
+     * values  = bytes | chars | shorts | ints | floats | doubles
+     * bytes   = [BYTE ...]  padding
+     * chars   = [CHAR ...]  padding
+     * shorts  = [SHORT ...]  padding
+     * ints    = [INT ...]
+     * floats  = [FLOAT ...]
+     * doubles = [DOUBLE ...]
+     * padding = <0, 1, 2, or 3 bytes to next 4-byte boundary>
+     * NON_NEG = <non-negative INT> |  // CDF-1 and CDF-2
+     *           <non-negative INT64>  // CDF-5
+     */
+    MPI_Offset sz;
+
+    assert(attrp != NULL);
+
+    sz  = sizeof_NON_NEG + _RNDUP(attrp->name_len, X_ALIGN); /* name */
+    sz += X_SIZEOF_NC_TYPE;                                  /* nc_type */
+    sz += sizeof_NON_NEG;                                    /* nelems */
+    sz += attrp->xsz;                                        /* [values ...] */
+
+    return sz;
+}
+
+/*----< hdr_len_NC_attrarray() >---------------------------------------------*/
+static MPI_Offset
+hdr_len_NC_attrarray(const NC_attrarray *ncap, int sizeof_NON_NEG)
+{
+    /* netCDF file format:
+     *  ...
+     * att_list     = ABSENT | NC_ATTRIBUTE  nelems  [attr ...]
+     * ABSENT       = ZERO  ZERO |  // list is not present for CDF-1 and 2
+     *                ZERO  ZERO64  // for CDF-5
+     * ZERO         = \x00 \x00 \x00 \x00                      // 32-bit zero
+     * ZERO64       = \x00 \x00 \x00 \x00 \x00 \x00 \x00 \x00  // 64-bit zero
+     * NC_ATTRIBUTE = \x00 \x00 \x00 \x0C         // tag for list of attributes
+     * nelems       = NON_NEG       // number of elements in following sequence
+     * NON_NEG      = <non-negative INT> |        // CDF-1 and CDF-2
+     *                <non-negative INT64>        // CDF-5
+     */
+    int i;
+    MPI_Offset xlen;
+
+    xlen = X_SIZEOF_NC_TAG;        /* NC_ATTRIBUTE */
+    xlen += sizeof_NON_NEG;        /* nelems */
+
+    if (ncap == NULL) /* ABSENT: no attribute is defined */
+        return xlen;
+
+    for (i=0; i<ncap->ndefined; i++) /* [attr ...] */
+        xlen += hdr_len_NC_attr(ncap->value[i], sizeof_NON_NEG);
+
+    return xlen;
+}
+
+/*----< hdr_len_NC_var() >---------------------------------------------------*/
+static MPI_Offset
+hdr_len_NC_var(const NC_var *varp,
+               int           sizeof_off_t,    /* OFFSET */
+               int           sizeof_NON_NEG)  /* NON_NEG */
+{
+    /* netCDF file format:
+     * netcdf_file = header data
+     * header      = magic numrecs dim_list gatt_list var_list
+     *  ...
+     * var         = name nelems [dimid ...] vatt_list nc_type vsize begin
+     * nelems      = NON_NEG
+     * dimid       = NON_NEG
+     * vatt_list   = att_list
+     * nc_type     = NC_BYTE | NC_CHAR | NC_SHORT | ...
+     * vsize       = NON_NEG
+     * begin       = OFFSET        // Variable start location.
+     * OFFSET      = <non-negative INT> |  // CDF-1
+     *               <non-negative INT64>  // CDF-2 and CDF-5
+     * NON_NEG     = <non-negative INT> |  // CDF-1 and CDF-2
+     *               <non-negative INT64>  // CDF-5
+     */
+    MPI_Offset sz;
+
+    assert(varp != NULL);
+
+    /* for CDF-1, sizeof_off_t == 4 && sizeof_NON_NEG == 4
+     * for CDF-2, sizeof_off_t == 8 && sizeof_NON_NEG == 4
+     * for CDF-5, sizeof_off_t == 8 && sizeof_NON_NEG == 8
+     */
+    sz  = sizeof_NON_NEG + _RNDUP(varp->name_len, X_ALIGN);   /* name */
+    sz += sizeof_NON_NEG;                                     /* nelems */
+    sz += sizeof_NON_NEG * varp->ndims;                       /* [dimid ...] */
+    sz += hdr_len_NC_attrarray(&varp->attrs, sizeof_NON_NEG); /* vatt_list */
+    sz += X_SIZEOF_NC_TYPE;                                   /* nc_type */
+    sz += sizeof_NON_NEG;                                     /* vsize */
+    sz += sizeof_off_t;                                       /* begin */
+
+    return sz;
+}
+
+/*----< hdr_len_NC_vararray() >----------------------------------------------*/
+static MPI_Offset
+hdr_len_NC_vararray(const NC_vararray *ncap,
+                    int                sizeof_NON_NEG, /* NON_NEG */
+                    int                sizeof_off_t)   /* OFFSET */
+{
+    /* netCDF file format:
+     * netcdf_file = header  data
+     * header      = magic  numrecs  dim_list  gatt_list  var_list
+     *  ...
+     * var_list    = ABSENT | NC_VARIABLE   nelems  [var ...]
+     * ABSENT      = ZERO  ZERO |  // list is not present for CDF-1 and 2
+     *               ZERO  ZERO64  // for CDF-5
+     * ZERO        = \x00 \x00 \x00 \x00                      // 32-bit zero
+     * ZERO64      = \x00 \x00 \x00 \x00 \x00 \x00 \x00 \x00  // 64-bit zero
+     * NC_VARIABLE = \x00 \x00 \x00 \x0B         // tag for list of variables
+     * nelems      = NON_NEG       // number of elements in following sequence
+     * NON_NEG     = <non-negative INT> |        // CDF-1 and CDF-2
+     *               <non-negative INT64>        // CDF-5
+     */
+    int i;
+    MPI_Offset xlen;
+
+    xlen = X_SIZEOF_NC_TAG;           /* NC_VARIABLE */
+    xlen += sizeof_NON_NEG;           /* nelems */
+
+    if (ncap == NULL) /* ABSENT: no variable is defined */
+        return xlen;
+
+    /* for CDF-1, sizeof_off_t == 4 && sizeof_NON_NEG == 4
+     * for CDF-2, sizeof_off_t == 8 && sizeof_NON_NEG == 4
+     * for CDF-5, sizeof_off_t == 8 && sizeof_NON_NEG == 8
+     */
+    for (i=0; i<ncap->ndefined; i++)  /* [var ...] */
+        xlen += hdr_len_NC_var(ncap->value[i], sizeof_off_t, sizeof_NON_NEG);
+
+    return xlen;
+}
+
+static MPI_Offset
+ncmpio_hdr_len_NC(const NC *ncp)
+{
+    /* netCDF file format:
+     * netcdf_file = header  data
+     * header      = magic  numrecs  dim_list  gatt_list  var_list
+     *  ...
+     * numrecs     = NON_NEG | STREAMING   // length of record dimension
+     * NON_NEG     = <non-negative INT> |  // CDF-1 and CDF-2
+     *               <non-negative INT64>  // CDF-5
+     */
+
+    int sizeof_NON_NEG, sizeof_off_t;
+    MPI_Offset xlen;
+
+    sizeof_NON_NEG = X_SIZEOF_INT64; /* 8-byte integer for all integers */
+    sizeof_off_t   = X_SIZEOF_INT64; /* 8-byte integer for var begin */
+
+    xlen  = NC_MAGIC_LEN;                                                    /* magic */
+    xlen += sizeof_NON_NEG;                                                  /* numrecs */
+    xlen += hdr_len_NC_dimarray(&ncp->dims,   sizeof_NON_NEG);               /* dim_list */
+    xlen += hdr_len_NC_attrarray(&ncp->attrs, sizeof_NON_NEG);               /* gatt_list */
+    xlen += hdr_len_NC_vararray(&ncp->vars,   sizeof_NON_NEG, sizeof_off_t); /* var_list */
+
+    return xlen; /* return the header size (not yet aligned) */
+}
+
+int blob_ncmpio_create_NC(NC *ncp)
+{
+    /* calculate the true header size (not-yet aligned) */
+    ncp->xsz = ncmpio_hdr_len_NC(ncp);
+
+    /* initialize unlimited_id as no unlimited dimension yet defined */
+    ncp->dims.unlimited_id = -1;
+
+    return 0;
+}
+
+static int
+ncmpix_putn_text(void **xpp, MPI_Offset nelems, const char *tp)
+{
+    (void) memcpy(*xpp, tp, (size_t)nelems);
+    *xpp = (void *)((char *)(*xpp) + nelems);
+    return NC_NOERR;
+}
+
+static int
+ncmpix_put_uint64(void **xpp, unsigned long long ip) {
+    (void) memcpy(*xpp, &ip, X_SIZEOF_UINT64);
+    *xpp  = (void *)((char *)(*xpp) + 8);
+    return NC_NOERR;
+}
+
+static int
+ncmpix_put_uint32(void **xpp, unsigned int ip) {
+    (void) memcpy(*xpp, &ip, X_SIZEOF_UINT);
+    *xpp  = (void *)((char *)(*xpp) + 4);
+    return NC_NOERR;
+}
+
+static int
+ncmpix_pad_putn_text(void **xpp, MPI_Offset nelems, const char *tp)
+{
+    MPI_Offset rndup = nelems % X_ALIGN;
+
+    if (rndup) rndup = X_ALIGN - rndup;
+
+    (void) memcpy(*xpp, tp, (size_t)nelems);
+    *xpp = (void *)((char *)(*xpp) + nelems);
+
+    if (rndup) {
+        (void) memcpy(*xpp, nada, (size_t)rndup);
+        *xpp = (void *)((char *)(*xpp) + rndup);
+    }
+    return NC_NOERR;
+}
+
+/*----< hdr_put_NC_name() >--------------------------------------------------*/
+static int
+hdr_put_NC_name(bufferinfo *pbp,
+                const char *name)
+{
+    /* netCDF file format:
+     *  ...
+     * name       = nelems  namestring
+     * nelems     = NON_NEG
+     * namestring = ID1 [IDN ...] padding
+     * ID1        = alphanumeric | '_'
+     * IDN        = alphanumeric | special1 | special2
+     * padding    = <0, 1, 2, or 3 bytes to next 4-byte boundary>
+     * NON_NEG    = <non-negative INT> |  // CDF-1 and CDF-2
+     *              <non-negative INT64>  // CDF-5
+     */
+    int err;
+    size_t nchars = strlen(name);
+
+    /* copy nelems */
+    err = ncmpix_put_uint64((void**)(&pbp->pos), (uint64)nchars);
+    if (err != NC_NOERR) return err;
+
+    /* copy namestring */
+    return ncmpix_pad_putn_text((void **)(&pbp->pos), (MPI_Offset)nchars, name);
+}
+
+/*----< hdr_put_NC_dim() >---------------------------------------------------*/
+static int
+hdr_put_NC_dim(bufferinfo   *pbp,
+               const NC_dim *dimp)
+{
+    /* netCDF file format:
+     *  ...
+     * dim        = name  dim_length
+     * dim_length = NON_NEG
+     * NON_NEG    = <non-negative INT> |  // CDF-1 and CDF-2
+     *              <non-negative INT64>  // CDF-5
+     */
+    int err;
+
+    /* copy name */
+    err = hdr_put_NC_name(pbp, dimp->name);
+    if (err != NC_NOERR) return err;
+
+    err = ncmpix_put_uint64((void**)(&pbp->pos), (uint64)dimp->size);
+
+    return err;
+}
+
+/*----< hdr_put_NC_dimarray() >----------------------------------------------*/
+static int
+hdr_put_NC_dimarray(bufferinfo        *pbp,
+                    const NC_dimarray *ncap)
+{
+    /* netCDF file format:
+     *  ...
+     * dim_list     = ABSENT | NC_DIMENSION  nelems  [dim ...]
+     * ABSENT       = ZERO  ZERO |  // list is not present for CDF-1 and 2
+     *                ZERO  ZERO64  // for CDF-5
+     * ZERO         = \x00 \x00 \x00 \x00                      // 32-bit zero
+     * ZERO64       = \x00 \x00 \x00 \x00 \x00 \x00 \x00 \x00  // 64-bit zero
+     * NC_DIMENSION = \x00 \x00 \x00 \x0A         // tag for list of dimensions
+     * nelems       = NON_NEG       // number of elements in following sequence
+     * NON_NEG      = <non-negative INT> |        // CDF-1 and CDF-2
+     *                <non-negative INT64>        // CDF-5
+     */
+    int i, status;
+
+    assert(pbp != NULL);
+
+    if (ncap == NULL || ncap->ndefined == 0) { /* ABSENT */
+        status = ncmpix_put_uint32((void**)(&pbp->pos), NC_UNSPECIFIED);
+        if (status != NC_NOERR) return status;
+
+        /* put a ZERO or ZERO64 depending on which CDF format */
+        status = ncmpix_put_uint64((void**)(&pbp->pos), 0);
+        if (status != NC_NOERR) return status;
+    }
+    else {
+        /* copy NC_DIMENSION */
+        status = ncmpix_put_uint32((void**)(&pbp->pos), NC_DIMENSION);
+        if (status != NC_NOERR) return status;
+
+        /* copy nelems */
+        status = ncmpix_put_uint64((void**)(&pbp->pos), (uint64)ncap->ndefined);
+        if (status != NC_NOERR) return status;
+
+        /* copy [dim ...] */
+        for (i=0; i<ncap->ndefined; i++) {
+            status = hdr_put_NC_dim(pbp, ncap->value[i]);
+            if (status != NC_NOERR) return status;
+        }
+    }
+
+    return NC_NOERR;
+}
+
+/*----< hdr_put_NC_attrV() >-------------------------------------------------*/
+static int
+hdr_put_NC_attrV(bufferinfo    *pbp,
+                 const NC_attr *attrp)
+{
+    /* netCDF file format:
+     *  ...
+     * attr    = name  nc_type  nelems  [values ...]
+     *  ...
+     * values  = bytes | chars | shorts | ints | floats | doubles
+     * bytes   = [BYTE ...]  padding
+     * chars   = [CHAR ...]  padding
+     * shorts  = [SHORT ...]  padding
+     * ints    = [INT ...]
+     * floats  = [FLOAT ...]
+     * doubles = [DOUBLE ...]
+     * padding = <0, 1, 2, or 3 bytes to next 4-byte boundary>
+     */
+    int xsz;
+    MPI_Offset padding, sz;
+
+    /* ncmpii_xlen_nc_type() returns the element size (unaligned) of
+     * attrp->xtype attrp->xsz is the aligned total size of attribute values
+     */
+    ncmpii_xlen_nc_type(attrp->xtype, &xsz);
+    sz = attrp->nelems * xsz;
+    padding = attrp->xsz - sz;
+
+    memcpy(pbp->pos, attrp->xvalue, (size_t)sz);
+    pbp->pos = (void *)((char *)pbp->pos + sz);
+
+    if (padding > 0) {
+        /* zero-padding is per buffer, not per element */
+        memset(pbp->pos, 0, (size_t)padding);
+        pbp->pos = (void *)((char *)pbp->pos + padding);
+    }
+
+    return NC_NOERR;
+}
+
+/*----< hdr_put_NC_attr() >--------------------------------------------------*/
+static int
+hdr_put_NC_attr(bufferinfo    *pbp,
+                const NC_attr *attrp)
+{
+    /* netCDF file format:
+     *  ...
+     * attr    = name  nc_type  nelems  [values ...]
+     * nc_type = NC_BYTE | NC_CHAR | NC_SHORT | ...
+     * nelems  = NON_NEG       // number of elements in following sequence
+     * NON_NEG = <non-negative INT> |  // CDF-1 and CDF-2
+     *           <non-negative INT64>  // CDF-5
+     */
+    int status;
+
+    /* copy name */
+    status = hdr_put_NC_name(pbp, attrp->name);
+    if (status != NC_NOERR) return status;
+
+    /* copy nc_type */
+    status = ncmpix_put_uint32((void**)(&pbp->pos), (uint)attrp->xtype);
+    if (status != NC_NOERR) return status;
+
+    /* copy nelems */
+    status = ncmpix_put_uint64((void**)(&pbp->pos), (uint64)attrp->nelems);
+    if (status != NC_NOERR) return status;
+
+    /* copy [values ...] */
+    status = hdr_put_NC_attrV(pbp, attrp);
+    if (status != NC_NOERR) return status;
+
+    return NC_NOERR;
+}
+
+/*----< hdr_put_NC_attrarray() >---------------------------------------------*/
+static int
+hdr_put_NC_attrarray(bufferinfo         *pbp,
+                     const NC_attrarray *ncap)
+{
+    /* netCDF file format:
+     *  ...
+     * att_list     = ABSENT | NC_ATTRIBUTE  nelems  [attr ...]
+     * ABSENT       = ZERO  ZERO |  // list is not present for CDF-1 and 2
+     *                ZERO  ZERO64  // for CDF-5
+     * ZERO         = \x00 \x00 \x00 \x00                      // 32-bit zero
+     * ZERO64       = \x00 \x00 \x00 \x00 \x00 \x00 \x00 \x00  // 64-bit zero
+     * NC_ATTRIBUTE = \x00 \x00 \x00 \x0C         // tag for list of attributes
+     * nelems       = NON_NEG       // number of elements in following sequence
+     * NON_NEG      = <non-negative INT> |        // CDF-1 and CDF-2
+     *                <non-negative INT64>        // CDF-5
+     */
+    int i, status;
+
+    assert(pbp != NULL);
+
+    if (ncap == NULL || ncap->ndefined == 0) { /* ABSENT */
+        status = ncmpix_put_uint32((void**)(&pbp->pos), NC_UNSPECIFIED);
+        if (status != NC_NOERR) return status;
+
+        /* put a ZERO or ZERO64 depending on which CDF format */
+        status = ncmpix_put_uint64((void**)(&pbp->pos), 0);
+        if (status != NC_NOERR) return status;
+    }
+    else {
+        /* copy NC_ATTRIBUTE */
+        status = ncmpix_put_uint32((void**)(&pbp->pos), NC_ATTRIBUTE);
+        if (status != NC_NOERR) return status;
+
+        /* copy nelems */
+        status = ncmpix_put_uint64((void**)(&pbp->pos), (uint64)ncap->ndefined);
+        if (status != NC_NOERR) return status;
+
+        /* copy [attr ...] */
+        for (i=0; i<ncap->ndefined; i++) {
+            status = hdr_put_NC_attr(pbp, ncap->value[i]);
+            if (status != NC_NOERR) return status;
+        }
+    }
+
+    return NC_NOERR;
+}
+
+/*----< hdr_put_NC_var() >---------------------------------------------------*/
+static int
+hdr_put_NC_var(bufferinfo   *pbp,
+               const NC_var *varp)
+{
+    /* netCDF file format:
+     * netcdf_file = header data
+     * header      = magic numrecs dim_list gatt_list var_list
+     *  ...
+     * var         = name nelems [dimid ...] vatt_list nc_type vsize begin
+     * nelems      = NON_NEG
+     * dimid       = NON_NEG
+     * vatt_list   = att_list
+     * nc_type     = NC_BYTE | NC_CHAR | NC_SHORT | ...
+     * vsize       = NON_NEG
+     * begin       = OFFSET        // Variable start location.
+     * OFFSET      = <non-negative INT> |  // CDF-1
+     *               <non-negative INT64>  // CDF-2 and CDF-5
+     * NON_NEG     = <non-negative INT> |  // CDF-1 and CDF-2
+     *               <non-negative INT64>  // CDF-5
+     */
+    int i, status;
+
+    /* copy name */
+    status = hdr_put_NC_name(pbp, varp->name);
+    if (status != NC_NOERR) return status;
+
+    /* copy nelems */
+    status = ncmpix_put_uint64((void**)(&pbp->pos), (uint64)varp->ndims);
+    if (status != NC_NOERR) return status;
+
+    /* copy [dimid ...] */
+    for (i=0; i<varp->ndims; i++) {
+        status = ncmpix_put_uint64((void**)(&pbp->pos), (uint64)varp->dimids[i]);
+        if (status != NC_NOERR) return status;
+    }
+
+    /* copy vatt_list */
+    status = hdr_put_NC_attrarray(pbp, &varp->attrs);
+    if (status != NC_NOERR) return status;
+
+    /* copy nc_type */
+    status = ncmpix_put_uint32((void**)(&pbp->pos), (uint)varp->xtype);
+    if (status != NC_NOERR) return status;
+
+    /* copy vsize */
+    status = ncmpix_put_uint64((void**)(&pbp->pos), (uint64)varp->len);
+    if (status != NC_NOERR) return status;
+
+    /* copy begin */
+    status = ncmpix_put_uint64((void**)(&pbp->pos), (uint64)varp->begin);
+    if (status != NC_NOERR) return status;
+
+    return NC_NOERR;
+}
+
+/*----< hdr_put_NC_vararray() >----------------------------------------------*/
+static int
+hdr_put_NC_vararray(bufferinfo        *pbp,
+                    const NC_vararray *ncap)
+{
+    /* netCDF file format:
+     * netcdf_file = header  data
+     * header      = magic  numrecs  dim_list  gatt_list  var_list
+     *  ...
+     * var_list    = ABSENT | NC_VARIABLE   nelems  [var ...]
+     * ABSENT      = ZERO  ZERO |  // list is not present for CDF-1 and 2
+     *               ZERO  ZERO64  // for CDF-5
+     * ZERO        = \x00 \x00 \x00 \x00                      // 32-bit zero
+     * ZERO64      = \x00 \x00 \x00 \x00 \x00 \x00 \x00 \x00  // 64-bit zero
+     * NC_VARIABLE = \x00 \x00 \x00 \x0B         // tag for list of variables
+     * nelems      = NON_NEG       // number of elements in following sequence
+     * NON_NEG     = <non-negative INT> |        // CDF-1 and CDF-2
+     *               <non-negative INT64>        // CDF-5
+     */
+    int i, status;
+
+    assert(pbp != NULL);
+
+    if (ncap == NULL || ncap->ndefined == 0) { /* ABSENT */
+        status = ncmpix_put_uint32((void**)(&pbp->pos), NC_UNSPECIFIED);
+        if (status != NC_NOERR) return status;
+
+        /* put a ZERO or ZERO64 depending on which CDF format */
+        status = ncmpix_put_uint64((void**)(&pbp->pos), 0);
+        if (status != NC_NOERR) return status;
+    }
+    else {
+        /* copy NC_VARIABLE */
+        status = ncmpix_put_uint32((void**)(&pbp->pos), NC_VARIABLE);
+        if (status != NC_NOERR) return status;
+
+        /* copy nelems */
+        status = ncmpix_put_uint64((void**)(&pbp->pos), (uint64)ncap->ndefined);
+        if (status != NC_NOERR) return status;
+
+        /* copy [var ...] */
+        for (i=0; i<ncap->ndefined; i++) {
+            status = hdr_put_NC_var(pbp, ncap->value[i]);
+            if (status != NC_NOERR) return status;
+        }
+    }
+
+    return NC_NOERR;
+}
+
+/*----< ncmpio_hdr_put_NC() >-------------------------------------------*/
+static int
+ncmpio_hdr_put_NC(NC *ncp, void *buf)
+{
+    int status;
+    bufferinfo putbuf;
+    MPI_Offset nrecs=0;
+
+    putbuf.offset        = 0;
+    putbuf.pos           = buf;
+    putbuf.base          = buf;
+    putbuf.size          = ncp->xsz;
+
+    /* netCDF file format:
+     * netcdf_file  = header  data
+     * header       = magic  numrecs  dim_list  gatt_list  var_list
+     */
+
+    /* copy "magic", 4 characters */
+    putbuf.version = 5;
+    status = ncmpix_putn_text((void **)(&putbuf.pos), sizeof(ncmagic5), ncmagic5);
+    if (status != NC_NOERR) return status;
+
+    /* copy numrecs, number of records */
+    nrecs = ncp->numrecs;
+    status = ncmpix_put_uint64((void**)(&putbuf.pos), (uint64)nrecs);
+    if (status != NC_NOERR) return status;
+
+    /* copy dim_list */
+    status = hdr_put_NC_dimarray(&putbuf, &ncp->dims);
+    if (status != NC_NOERR) return status;
+
+    /* copy gatt_list */
+    status = hdr_put_NC_attrarray(&putbuf, &ncp->attrs);
+    if (status != NC_NOERR) return status;
+
+    /* copy var_list */
+    status = hdr_put_NC_vararray(&putbuf, &ncp->vars);
+    if (status != NC_NOERR) return status;
+
+    return NC_NOERR;
+}
+
+int
+blob_ncmpio_pack_NC(NC      *ncp,
+                    size_t  *bufLen,
+                    void   **buf)
+{
+    int err=NC_NOERR, header_wlen;
+
+    *bufLen = 0;
+    *buf = NULL;
+
+    /* get the true header size (not header extent) */
+    ncp->xsz = ncmpio_hdr_len_NC(ncp);
+
+    /* Do not write padding area (between ncp->xsz and ncp->begin_var) */
+    header_wlen = (int) ncp->xsz;
+    *bufLen = _RNDUP(header_wlen, X_ALIGN);
+    *buf = NCI_Malloc(*bufLen);
+
+    /* pack the entire local header object to buf */
+    err = ncmpio_hdr_put_NC(ncp, *buf);
+    if (err != NC_NOERR) { /* a fatal error */
+        NCI_Free(*buf);
+        *buf = NULL;
+    }
+    return err;
+}
+
+static void
+ncmpio_free_NC_dimarray(NC_dimarray *ncap)
+{
+    int i;
+    if (ncap->ndefined == 0) return;
+
+    if (ncap->value != NULL) {
+        for (i=0; i<ncap->ndefined; i++) {
+            if (ncap->value[i] == NULL) break;
+            NCI_Free(ncap->value[i]->name);
+            NCI_Free(ncap->value[i]);
+        }
+        NCI_Free(ncap->value);
+        ncap->value = NULL;
+    }
+    ncap->ndefined = 0;
+}
+
+static void
+ncmpio_free_NC_attrarray(NC_attrarray *ncap)
+{
+    int i;
+
+    if (ncap->value != NULL) {
+        for (i=0; i<ncap->ndefined; i++) {
+            if (ncap->value[i] == NULL) continue;
+            if (ncap->value[i]->xvalue != NULL)
+                NCI_Free(ncap->value[i]->xvalue);
+            NCI_Free(ncap->value[i]->name);
+            NCI_Free(ncap->value[i]);
+        }
+        NCI_Free(ncap->value);
+        ncap->value = NULL;
+    }
+    ncap->ndefined = 0;
+}
+
+static void
+ncmpio_free_NC_var(NC_var *varp)
+{
+    if (varp == NULL) return;
+
+    ncmpio_free_NC_attrarray(&varp->attrs);
+    NCI_Free(varp->name);
+    if (varp->shape  != NULL) NCI_Free(varp->shape);
+    if (varp->dsizes != NULL) NCI_Free(varp->dsizes);
+    if (varp->dimids != NULL) NCI_Free(varp->dimids);
+
+    NCI_Free(varp);
+}
+
+static void
+ncmpio_free_NC_vararray(NC_vararray *ncap)
+{
+    int i;
+
+    if (ncap->ndefined == 0) return;
+
+    if (ncap->value != NULL) {
+        for (i=0; i<ncap->ndefined; i++) {
+            if (ncap->value[i] != NULL)
+                ncmpio_free_NC_var(ncap->value[i]);
+        }
+        NCI_Free(ncap->value);
+        ncap->value    = NULL;
+    }
+    ncap->ndefined = 0;
+}
+
+int blob_ncmpio_free_NC(NC *ncp) {
+
+    /* free up space occupied by the header metadata */
+    ncmpio_free_NC_dimarray(&ncp->dims);
+    ncmpio_free_NC_attrarray(&ncp->attrs);
+    ncmpio_free_NC_vararray(&ncp->vars);
+
+    return 0;
+}
+
+static int
+ncmpio_NC_var_shape64(NC_var            *varp,
+                      const NC_dimarray *dims)
+{
+    int i;
+    MPI_Offset product = 1;
+
+    if (varp->ndims == 0) goto out;
+
+    for (i=0; i<varp->ndims; i++)
+        varp->shape[i] = dims->value[varp->dimids[i]]->size;
+
+    product = 1;
+    if (varp->ndims == 1) {
+        if (varp->shape[0] == NC_UNLIMITED)
+            varp->dsizes[0] = 1;
+        else {
+            varp->dsizes[0] = varp->shape[0];
+            product = varp->shape[0];
+        }
+    }
+    else { /* varp->ndims > 1 */
+        varp->dsizes[varp->ndims-1] = varp->shape[varp->ndims-1];
+        product = varp->shape[varp->ndims-1];
+        for (i=varp->ndims-2; i>=0; i--) {
+            if (varp->shape[i] != NC_UNLIMITED)
+                product *= varp->shape[i];
+            varp->dsizes[i] = product;
+        }
+    }
+
+out:
+    varp->len = product * varp->xsz;
+    if (varp->len % 4 > 0)
+        varp->len += 4 - varp->len % 4; /* round up */
+
+    return NC_NOERR;
+}
+
+static NC_var*
+ncmpio_new_NC_var(const char *name, int ndims)
+{
+    NC_var *varp = (NC_var *) NCI_Calloc(1, sizeof(NC_var));
+    if (varp == NULL) return NULL;
+
+    if (ndims > 0) {
+        varp->shape  = (MPI_Offset*)NCI_Calloc(ndims, sizeof(MPI_Offset));
+        varp->dsizes = (MPI_Offset*)NCI_Calloc(ndims, sizeof(MPI_Offset));
+        varp->dimids = (int *)      NCI_Calloc(ndims, sizeof(int));
+    }
+
+    varp->name     = strdup(name);
+    varp->name_len = strlen(name); /* name has been NULL checked */
+    varp->ndims    = ndims;
+
+    return varp;
+}
+
+int blob_ncmpio_add_var(NC         *ncp,
+                        const char *name,
+                        nc_type     xtype,
+                        int         ndims,
+                        int        *dimids,
+                        int        *varidp)
+{
+    /* add a variable object in NC */
+    int err=NC_NOERR;
+    NC_var *varp=NULL;
+    varp = ncmpio_new_NC_var(name, ndims);
+    varp->xtype = xtype;
+    ncmpii_xlen_nc_type(xtype, &varp->xsz);
+
+    /* copy dimids[] */
+    if (ndims != 0 && dimids != NULL)
+        memcpy(varp->dimids, dimids, (size_t)ndims * sizeof(int));
+
+    /* set up array dimensional structures */
+    ncmpio_NC_var_shape64(varp, &ncp->dims);
+
+    /* allocate/expand ncp->vars.value array */
+    if (ncp->vars.ndefined % NC_ARRAY_GROWBY == 0)
+        ncp->vars.value = (NC_var **) NCI_Realloc(ncp->vars.value,
+                          ((size_t)ncp->vars.ndefined + NC_ARRAY_GROWBY) *
+                          sizeof(NC_var*));
+
+    varp->varid = ncp->vars.ndefined; /* varid */
+
+    /* Add a new handle to the end of an array of handles */
+    ncp->vars.value[ncp->vars.ndefined] = varp;
+
+    ncp->vars.ndefined++;
+
+    if (varidp != NULL) *varidp = varp->varid;
+
+    return err;
+}
+
+int blob_ncmpio_add_dim(NC         *ncp,
+                        const char *name,
+                        MPI_Offset  size,
+                        int        *dimidp)
+{
+    int err=NC_NOERR, dimid;
+    NC_dim *dimp=NULL;
+
+    /* create a new dimension object (dimp->name points to nname) */
+    dimp = (NC_dim*) NCI_Malloc(sizeof(NC_dim));
+
+    dimp->size     = size;
+    dimp->name     = strdup(name);
+    dimp->name_len = strlen(dimp->name);
+
+    /* allocate/expand ncp->dims.value array */
+    if (ncp->dims.ndefined % NC_ARRAY_GROWBY == 0)
+        ncp->dims.value = (NC_dim **) NCI_Realloc(ncp->dims.value,
+                          ((size_t)ncp->dims.ndefined + NC_ARRAY_GROWBY) *
+                          sizeof(NC_dim*));
+
+    dimid = ncp->dims.ndefined;
+
+    /* Add a new dim handle to the end of handle array */
+    ncp->dims.value[dimid] = dimp;
+
+    if (size == NC_UNLIMITED) ncp->dims.unlimited_id = dimid;
+
+    ncp->dims.ndefined++;
+
+    if (dimidp != NULL) *dimidp = dimid;
+
+    return err;
+}
+
+static MPI_Offset
+x_len_NC_attrV(nc_type    xtype,
+               MPI_Offset nelems)
+{
+    switch(xtype) {
+        case MPI_BYTE:
+        case MPI_CHAR:  return _RNDUP(nelems, 4);
+        case MPI_SHORT:
+        case MPI_UNSIGNED_SHORT: return ((nelems + nelems%2) * 2);
+        case MPI_INT:
+        case MPI_UNSIGNED:
+        case MPI_FLOAT:  return (nelems * 4);
+        case MPI_DOUBLE:
+        case MPI_LONG_LONG:
+        case MPI_UNSIGNED_LONG_LONG: return (nelems * 8);
+        default: fprintf(stderr, "Error: bad type(%d) in %s\n",xtype,__func__);
+    }
+    return 0;
+}
+
+static int
+ncmpio_new_NC_attr(const char  *name,
+                        nc_type      xtype,
+                        MPI_Offset   nelems,
+                        NC_attr    **attrp)
+{
+    *attrp = (NC_attr*) NCI_Malloc(sizeof(NC_attr));
+
+    (*attrp)->xtype    = xtype;
+    (*attrp)->xsz      = 0;
+    (*attrp)->nelems   = nelems;
+    (*attrp)->xvalue   = NULL;
+    (*attrp)->name     = strdup(name);
+    (*attrp)->name_len = strlen(name);
+
+    if (nelems > 0) {
+        /* obtain 4-byte aligned size of space to store the values */
+        MPI_Offset xsz = x_len_NC_attrV(xtype, nelems);
+        (*attrp)->xsz    = xsz;
+        (*attrp)->xvalue = NCI_Malloc((size_t)xsz);
+    }
+    return NC_NOERR;
+}
+
+static int
+incr_NC_attrarray(NC_attrarray *ncap, NC_attr *new_attr)
+{
+    if (ncap->ndefined % NC_ARRAY_GROWBY == 0)
+        ncap->value = (NC_attr **) NCI_Realloc(ncap->value,
+                      ((size_t)ncap->ndefined + NC_ARRAY_GROWBY) *
+                      sizeof(NC_attr*));
+
+    ncap->value[ncap->ndefined++] = new_attr;
+
+    return NC_NOERR;
+}
+
+static int
+ncmpio_NC_findattr(const NC_attrarray *ncap,
+                   const char         *name) /* normalized string */
+{
+    int i; 
+    size_t nchars;
+
+    if (ncap->ndefined == 0) return -1; /* none created yet */
+
+    nchars = strlen(name);
+    for (i=0; i<ncap->ndefined; i++) {
+        if (ncap->value[i]->name_len == nchars && 
+            strcmp(ncap->value[i]->name, name) == 0)
+            return i;
+    }
+    return -1; /* the name has never been used */
+}
+
+int blob_ncmpio_put_att(NC         *ncp,
+                        int         varid,
+                        const char *name,
+                        nc_type     xtype,
+                        MPI_Offset  nelems,
+                        const void *buf)
+{
+    /* E3SM always uses the same itype and xtype for attributes */
+
+    int indx=0, err=NC_NOERR;
+    NC_attrarray *ncap=NULL;
+    NC_attr *attrp=NULL;
+
+    /* obtain NC_attrarray object pointer, ncap */
+    if (varid == NC_GLOBAL) ncap = &ncp->attrs;
+    else                    ncap = &ncp->vars.value[varid]->attrs;
+
+    /* check whether attribute already exists */
+    indx = ncmpio_NC_findattr(ncap, name);
+    if (indx >= 0) {
+        if (varid == NC_GLOBAL)
+            printf("NC_GLOBAL attribute name %s in used\n", name);
+        else
+            printf("var %s attribute name %s in used\n",
+                   ncp->vars.value[varid]->name, name);
+        return -1;
+    }
+
+    err = ncmpio_new_NC_attr(name, xtype, nelems, &attrp);
+    if (err != NC_NOERR) return err;
+
+    err = incr_NC_attrarray(ncap, attrp);
+    if (err != NC_NOERR) return err;
+
+    if (nelems != 0 && buf != NULL) { /* non-zero length attribute */
+        void *xp = attrp->xvalue;
+        if (xtype == MPI_CHAR || xtype == MPI_BYTE)
+            memcpy(xp, buf, nelems);
+        else if (xtype == MPI_SHORT || xtype == MPI_UNSIGNED_SHORT)
+            memcpy(xp, buf, nelems*sizeof(short));
+        else if (xtype == MPI_INT || xtype == MPI_UNSIGNED)
+            memcpy(xp, buf, nelems*sizeof(int));
+        else if (xtype == MPI_FLOAT)
+            memcpy(xp, buf, nelems*sizeof(float));
+        else if (xtype == MPI_DOUBLE)
+            memcpy(xp, buf, nelems*sizeof(double));
+        else if (xtype == MPI_LONG_LONG)
+            memcpy(xp, buf, nelems*sizeof(long long));
+        else if (xtype == MPI_UNSIGNED_LONG_LONG)
+            memcpy(xp, buf, nelems*sizeof(unsigned long long));
+        else err = -1;
+    }
+
+    return err;
+}
+
+int blob_ncmpio_get_att(NC         *ncp,
+                        int         varid,
+                        const char *name,
+                        void       *buf)
+{
+    int indx=0, err=NC_NOERR;
+    NC_attrarray *ncap=NULL;
+    NC_attr *attrp=NULL;
+    nc_type xtype;
+
+    if (buf == NULL) return -1;
+
+    if (varid == NC_GLOBAL) ncap = &ncp->attrs;
+    else                    ncap = &ncp->vars.value[varid]->attrs;
+
+    indx = ncmpio_NC_findattr(ncap, name);
+    if (indx == -1) return -1;
+
+    attrp = ncap->value[indx];
+
+    if (attrp->nelems == 0) return NC_NOERR;
+
+    xtype = attrp->xtype;
+
+    if (xtype == MPI_CHAR || xtype == MPI_BYTE)
+        memcpy(buf, attrp->xvalue, attrp->nelems);
+    else if (xtype == MPI_SHORT || xtype == MPI_UNSIGNED_SHORT)
+        memcpy(buf, attrp->xvalue, attrp->nelems*sizeof(short));
+    else if (xtype == MPI_INT || xtype == MPI_UNSIGNED)
+        memcpy(buf, attrp->xvalue, attrp->nelems*sizeof(int));
+    else if (xtype == MPI_FLOAT)
+        memcpy(buf, attrp->xvalue, attrp->nelems*sizeof(float));
+    else if (xtype == MPI_DOUBLE)
+        memcpy(buf, attrp->xvalue, attrp->nelems*sizeof(double));
+    else if (xtype == MPI_LONG_LONG)
+        memcpy(buf, attrp->xvalue, attrp->nelems*sizeof(long long));
+    else if (xtype == MPI_UNSIGNED_LONG_LONG)
+        memcpy(buf, attrp->xvalue, attrp->nelems*sizeof(unsigned long long));
+    else err = -1;
+
+    return err;
+}
+

--- a/src/drivers/blob_ncmpio.h
+++ b/src/drivers/blob_ncmpio.h
@@ -1,0 +1,269 @@
+/*
+ *  Copyright (C) 2003, Northwestern University and Argonne National Laboratory
+ *  See COPYRIGHT notice in top-level directory.
+ */
+
+#ifndef _NC_H
+#define _NC_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>     /* size_t */
+
+#include <mpi.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+typedef MPI_Datatype nc_type;
+#define NC_NOERR 0
+#define NC_UNLIMITED 0L
+#define NC_GLOBAL -1
+
+#define NCI_Malloc malloc
+#define NCI_Calloc calloc
+#define NCI_Realloc realloc
+#define NCI_Free free
+
+#define X_ALIGN 4
+#define _RNDUP(x, unit)      ((((x) + (unit) - 1) / (unit)) * (unit))
+
+#define X_SIZEOF_BYTE           1
+#define X_SIZEOF_CHAR           1
+#define X_SIZEOF_SHORT          2
+#define X_SIZEOF_INT            4       /* xdr_int */
+#define X_SIZEOF_FLOAT          4
+#define X_SIZEOF_DOUBLE         8
+
+/* additional data types in CDF-5 */
+#define X_SIZEOF_UBYTE          1
+#define X_SIZEOF_USHORT         2
+#define X_SIZEOF_UINT           4
+#define X_SIZEOF_LONGLONG       8
+#define X_SIZEOF_ULONGLONG      8
+#define X_SIZEOF_INT64          8
+#define X_SIZEOF_UINT64         8
+
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifndef HAVE_SCHAR
+typedef signed char schar;
+#endif
+#ifndef HAVE_UCHAR
+typedef unsigned char uchar;
+#endif
+#ifndef HAVE_USHORT
+typedef unsigned short int ushort;
+#endif
+#ifndef HAVE_UINT
+typedef unsigned int uint;
+#endif
+#ifndef HAVE_LONGLONG
+typedef long long longlong;
+#endif
+#ifndef HAVE_ULONGLONG
+typedef unsigned long long ulonglong;
+#endif
+#ifndef HAVE_INT64
+typedef long long int64;
+#endif
+#ifndef HAVE_UINT64
+typedef unsigned long long uint64;
+#endif
+
+#define FILE_ALIGNMENT_DEFAULT 512
+#define FILE_ALIGNMENT_LB      4
+
+/* XXX: this seems really low.  do we end up spending a ton of time mallocing?
+ * could we reduce that by increasing this to something 21st century? */
+#ifndef NC_ARRAY_GROWBY
+#define NC_ARRAY_GROWBY 64
+#endif
+
+#define MIN_NC_XSZ 32
+
+typedef enum {
+    NC_UNSPECIFIED =  0,  /* ABSENT */
+    NC_DIMENSION   = 10,  /* \x00 \x00 \x00 \x0A */
+    NC_VARIABLE    = 11,  /* \x00 \x00 \x00 \x0B */
+    NC_ATTRIBUTE   = 12   /* \x00 \x00 \x00 \x0C */
+} NC_tag;
+
+/* netcdf file format:
+     netcdf_file  = header  data
+     header       = magic  numrecs  dim_list  gatt_list  var_list
+     magic        = 'C'  'D'  'F'  VERSION
+     VERSION      = \x01 | \x02 | \x05
+     numrecs      = NON_NEG | STREAMING
+     dim_list     = ABSENT | NC_DIMENSION  nelems  [dim ...]
+     gatt_list    = att_list
+     att_list     = ABSENT | NC_ATTRIBUTE  nelems  [attr ...]
+     var_list     = ABSENT | NC_VARIABLE   nelems  [var ...]
+     ABSENT       = ZERO  ZERO                  // Means list is not present
+     ZERO         = \x00 \x00 \x00 \x00         // 32-bit zero
+
+  Minimum happens when nothing is defined, i.e.
+     magic              -- 4 bytes
+     numrecs            -- 4 bytes for CDF-1 and CDF-2, 8 bytes for CDF-5
+     dim_list = ABSENT  -- 8 bytes
+     gatt_list = ABSENT -- 8 bytes
+     var_list = ABSENT  -- 8 bytes
+*/
+
+typedef struct NC NC; /* forward reference */
+
+/*
+ * NC dimension structure
+ */
+typedef struct {
+    MPI_Offset  size;
+    size_t      name_len; /* strlen(name), for faster string compare */
+    char       *name;
+} NC_dim;
+
+/* The dimension ID returned from ncmpi_def_dim() is a pointer to type "int"
+ * which means the total number of defined dimension allowed in a file
+ * is up to 2^31-1. Thus, the member ndefined below should be of type int.
+ * In fact, the value of ndefined should be between 0 and NC_MAX_DIMS.
+ *
+ * We use name ndefined for number of defined dimensions, instead of "nelems"
+ * used in the CDF format specifications because the number can only be of
+ * data type int (signed 4-byte integer). Other "nelems" in the format
+ * specifications can be of type 8-byte integers.
+ */
+typedef struct NC_dimarray {
+    int            ndefined;      /* number of defined dimensions */
+    int            unlimited_id;  /* -1 for not defined, otherwise >= 0 */
+    NC_dim       **value;
+} NC_dimarray;
+
+/*
+ * NC attribute
+ */
+typedef struct {
+    MPI_Offset nelems;   /* number of attribute elements */
+    MPI_Offset xsz;      /* amount of space at xvalue (4-byte aligned) */
+    nc_type    xtype;    /* external NC data type of the attribute */
+    size_t     name_len; /* strlen(name) for faster string compare */
+    char      *name;     /* name of the attributes */
+    void      *xvalue;   /* the actual data, in external representation */
+} NC_attr;
+
+/* Number of attributes is limited by 2^31-1 because the argument ngattsp in
+ * API ncmpi_inq()/nc_inq() is a signed 4-byte integer. Similarly for argument
+ * ngattsp in API ncmpi_inq_natts()/nc_inq_natts(). In fact, the value of
+ * ndefined should be between 0 and NC_MAX_ATTRS.
+ *
+ * We use name ndefined for number of defined attributes, instead of "nelems"
+ * used in the CDF format specifications, because the number can only be of
+ * data type int (signed 4-byte integer). Other "nelems" in the format
+ * specifications can be of type 8-byte integers.
+ */
+typedef struct NC_attrarray {
+    int            ndefined;  /* number of defined attributes */
+    NC_attr      **value;
+} NC_attrarray;
+
+/*
+ * NC variable: description and data
+ */
+typedef struct {
+    int           varid;   /* variable ID */
+    int           xsz;     /* byte size of 1 array element */
+    nc_type       xtype;   /* variable's external NC data type */
+    int           no_fill; /* whether fill mode is disabled */
+    size_t        name_len;/* strlen(name) for faster string compare */
+    char         *name;    /* name of the variable */
+    int           ndims;   /* number of dimensions */
+    int          *dimids;  /* [ndims] array of dimension IDs */
+    MPI_Offset   *shape;   /* [ndims] dim->size of each dim
+                              shape[0] == NC_UNLIMITED if record variable */
+    MPI_Offset   *dsizes;  /* [ndims] the right to left product of shape */
+    MPI_Offset    begin;   /* starting file offset of this variable */
+    MPI_Offset    len;     /* this is the "vsize" defined in header format, the
+                              total size in bytes of the array variable.
+                              For record variable, this is the record size */
+    NC_attrarray  attrs;   /* attribute array */
+} NC_var;
+
+/*
+ * Number of variables is limited by 2^31-1 because the argument nvarsp in
+ * API ncmpi_inq()/nc_inq() is a signed 4-byte integer and argument varid in
+ * API ncmpi_def_var()/nc_def_var() is also a signed 4-byte int. In fact,
+ * the value of ndefined should be between 0 and NC_MAX_VARS.
+ *
+ * We use name ndefined for number of defined variables, instead of "nelems"
+ * used in the CDF format specifications, because the number can only be of
+ * data type int (signed 4-byte integer). Other "nelems" in the format
+ * specifications can be of type 8-byte integers.
+ */
+/* note: we only allow less than 2^31-1 variables defined in a file */
+typedef struct NC_vararray {
+    int            ndefined;    /* number of defined variables */
+    int            num_rec_vars;/* number of defined record variables */
+    NC_var       **value;
+} NC_vararray;
+
+#define IS_RECVAR(vp) \
+        ((vp)->shape != NULL ? (*(vp)->shape == NC_UNLIMITED) : 0 )
+
+
+struct NC {
+    int           ncid;         /* file ID */
+    int           format;       /* 1, 2, or 5 corresponding to CDF-1, 2, or 5 */
+    MPI_Offset    xsz;         /* size of this file header, <= var[0].begin */
+    MPI_Offset    begin_var;   /* file offset of the first fixed-size variable,
+                                  if no fixed-sized variable, it is the offset
+                                  of first record variable. This value is also
+                                  the size of file header extent. */
+    MPI_Offset    begin_rec;   /* file offset of the first 'record' */
+
+    MPI_Offset    recsize;   /* length of 'record': sum of single record sizes
+                                of all the record variables */
+    MPI_Offset    numrecs;   /* number of 'records' allocated */
+    MPI_Offset    put_size;  /* amount of writes committed so far in bytes */
+    MPI_Offset    get_size;  /* amount of reads  committed so far in bytes */
+
+    MPI_Comm      comm;           /* MPI communicator */
+
+    NC_dimarray   dims;     /* dimensions defined */
+    NC_attrarray  attrs;    /* global attributes defined */
+    NC_vararray   vars;     /* variables defined */
+
+    char         *path;     /* file name */
+    struct NC    *old;      /* contains the previous NC during redef. */
+};
+
+
+/* Begin defined in ncmpio_header_get.c -------------------------------------*/
+typedef struct bufferinfo {
+    MPI_Offset  get_size; /* amount of file read n bytes so far */
+    MPI_Offset  offset;   /* current read/write offset in the file */
+    int         size;     /* allocated size of the buffer */
+    int         version;  /* 1, 2, and 5 for CDF-1, 2, and 5 respectively */
+    int         safe_mode;/* 0: disabled, 1: enabled */
+    char       *base;     /* beginning of read/write buffer */
+    char       *pos;      /* current position in buffer */
+    char       *end;      /* end position of buffer */
+} bufferinfo;
+
+extern int blob_ncmpio_create_NC(NC *ncp);
+extern int blob_ncmpio_free_NC(NC *ncp);
+extern int blob_ncmpio_add_var(NC *ncp, const char *name, nc_type xtype,
+                               int ndims, int *dimids, int *varidp);
+extern int blob_ncmpio_add_dim(NC *ncp, const char *name, MPI_Offset size,
+                               int *dimidp);
+extern int blob_ncmpio_put_att(NC *ncp, int varid, const char *name,
+                               nc_type xtype, MPI_Offset nelems,
+                               const void *buf);
+extern int blob_ncmpio_get_att(NC *ncp, int varid, const char *name, void *buf);
+extern int blob_ncmpio_pack_NC(NC *ncp, size_t *buf_len, void **buf);
+
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* _NC_H */

--- a/src/drivers/e3sm_io_driver_h5blob.cpp
+++ b/src/drivers/e3sm_io_driver_h5blob.cpp
@@ -1,0 +1,643 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <cstring>
+#include <sys/stat.h>
+#include <assert.h>
+
+#include <hdf5.h>
+
+#include <e3sm_io.h>
+#include <e3sm_io_err.h>
+#include <e3sm_io_driver_hdf5_int.hpp>
+#include <e3sm_io_driver_h5blob.hpp>
+
+e3sm_io_driver_h5blob::e3sm_io_driver_h5blob (e3sm_io_config *cfg) : e3sm_io_driver (cfg) {
+    this->cfg = cfg;
+    this->put_amount = 0;  /* write amount per driver, not per file */
+    this->get_amount = 0;
+}
+
+e3sm_io_driver_h5blob::~e3sm_io_driver_h5blob () { }
+
+int e3sm_io_driver_h5blob::create(std::string path,
+                                  MPI_Comm comm,
+                                  MPI_Info info,
+                                  int *fid)
+{
+    int i, err=0, nvars;
+    herr_t herr;
+    hid_t faplid;
+    h5blob_file *fp;
+    NC *ncp;
+
+    fp = new h5blob_file(*this);
+
+    err = MPI_Comm_dup(comm, &fp->comm);
+    CHECK_MPIERR
+
+    faplid = H5Pcreate (H5P_FILE_ACCESS);
+    CHECK_HID (faplid)
+    herr = H5Pset_fapl_mpio(faplid, fp->comm, info);
+    CHECK_HERR
+    herr = H5Pset_all_coll_metadata_ops(faplid, true);
+    CHECK_HERR
+    herr = H5Pset_coll_metadata_write(faplid, true);
+    CHECK_HERR
+
+    fp->id = H5Fcreate(path.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, faplid);
+    CHECK_HID (fp->id)
+
+    *fid = this->files.size ();
+
+    /* Use NetCDF header struct to store all metadata */
+    ncp = (NC*) NCI_Calloc(1, sizeof(NC));
+
+    fp->header = ncp;
+    fp->num_puts = 0;
+
+    /* allocate write buffer pointer array, one for each variable */
+    nvars = cfg->nvars + MAX_NUM_DECOMP * NVARS_DECOMP;
+    fp->vars = (var_buf*) malloc(nvars * sizeof(var_buf));
+    for (i=0; i<nvars; i++) {
+        fp->vars[i].nalloc = 0;
+        fp->vars[i].nrecs = 0;
+        fp->vars[i].buf = NULL;
+        fp->vars[i].len = NULL;
+    }
+    fp->total_len = 0;
+
+    this->files.push_back (fp);
+
+err_out:
+    if (faplid >= 0) { H5Pclose (faplid); }
+
+    return err;
+}
+
+int e3sm_io_driver_h5blob::open(std::string path,
+                                MPI_Comm comm,
+                                MPI_Info info,
+                                int *fid)
+{
+    throw "HDF5 blob I/O does not support file open yet";
+    return -1;
+}
+
+int e3sm_io_driver_h5blob::close (int fid)
+{
+    char *buf_ptr;
+    int i, j, err=0, rank, nvars;
+    herr_t herr;
+    hid_t dcpl_id, fspace, mspace, dxpl_id, header_blob, data_blob;
+    hsize_t dim_len, off, len, one=1;
+    h5blob_file *fp = this->files[fid];
+    NC *ncp;
+    size_t header_len;
+    void *buf, *header_buf;
+    MPI_Offset start, count, sum;
+
+    /* prepare to write the header */
+    ncp = fp->header;
+    nvars = ncp->vars.ndefined;
+
+    MPI_Comm_rank(fp->comm, &rank);
+
+/*
+printf("%s: nvars=%d num_puts=%d total_len=%lld header=%lld\n", __FILE__,ncp->vars.ndefined, fp->num_puts, fp->total_len, fp->header->xsz);
+for (i=0; i<fp->num_puts; i++) printf("var[%d]=%s nrecs=%d buf len =%ld\n",i,ncp->vars.value[i]->name,fp->vars[i].nrecs,fp->vars[i].len[0]);
+*/
+    /* create a new dataset to store data blobs of all processes */
+
+    /* Sum the data blob sizes across all processes */
+    count = fp->total_len;
+    err = MPI_Allreduce(&count, &sum, 1, MPI_OFFSET, MPI_SUM, fp->comm);
+    CHECK_MPIERR
+
+    /* Find write starting offset in data blob dataset for each process */
+    start = 0;
+    err = MPI_Exscan(&count, &start, 1, MPI_OFFSET, MPI_SUM, fp->comm);
+    CHECK_MPIERR
+
+    if (cfg->verbose) printf("%2d; start=%lld count=%lld\n",rank,start,count);
+
+    /* pack header into a contiguous buffer */
+    err = blob_ncmpio_pack_NC(ncp, &header_len, &header_buf);
+
+    /* free up space occupied by the header metadata */
+    blob_ncmpio_free_NC(ncp);
+
+    /* set create property list */
+    dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
+    CHECK_HID(dcpl_id)
+
+    H5Pset_fill_value(dcpl_id, 0, NULL);
+    H5Pset_fill_time(dcpl_id, H5D_FILL_TIME_NEVER);
+    H5Pset_alloc_time(dcpl_id, H5D_ALLOC_TIME_DEFAULT);
+
+    /* create a new dataset to store header blob */
+    dim_len = header_len;
+    fspace = H5Screate_simple(1, &dim_len, NULL);
+    CHECK_HID(fspace);
+
+    /* create a HDF5 blob dataset to store header */
+    header_blob = H5Dcreate2(fp->id, "header_blob", H5T_NATIVE_UCHAR, fspace,
+                             H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
+    CHECK_HID(header_blob)
+    herr = H5Sclose(fspace);
+    CHECK_HERR
+
+    /* create a HDF5 dataset to store data blob */
+    dim_len = sum;
+    fspace = H5Screate_simple(1, &dim_len, NULL);
+    CHECK_HID(fspace);
+
+    /* create a HDF5 blob dataset to store climate data */
+    data_blob = H5Dcreate2(fp->id, "data_blob", H5T_NATIVE_UCHAR, fspace,
+                           H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
+    CHECK_HID(data_blob)
+
+    herr = H5Pclose(dcpl_id);
+    CHECK_HERR
+
+    /* done with creating new datasets */
+
+    /* Each process packs its write data into a contiguous buffer */
+    buf = (void*) malloc(fp->total_len);
+    buf_ptr = (char*) buf;
+    for (i=0; i<nvars; i++) {
+        if (fp->vars[i].nalloc == 0) continue; /* not written by this proc */
+        memcpy(buf_ptr, fp->vars[i].buf[0], fp->vars[i].len[0]);
+        free(fp->vars[i].buf[0]);
+        buf_ptr += fp->vars[i].len[0];
+        for (j=1; j<fp->vars[i].nrecs; j++) {
+            memcpy(buf_ptr, fp->vars[i].buf[j], fp->vars[i].len[j]);
+            free(fp->vars[i].buf[j]);
+            buf_ptr += fp->vars[i].len[j];
+        }
+        free(fp->vars[i].buf);
+        free(fp->vars[i].len);
+    }
+    assert(buf_ptr - (char*)buf == (long)fp->total_len);
+    free(fp->vars);
+
+    /* set collectie write mode for writing data blob */
+    dxpl_id = H5Pcreate(H5P_DATASET_XFER);
+    CHECK_HID(dxpl_id)
+    herr = H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE);
+    CHECK_HERR
+
+    /* Setup hyperslab file space for each process */
+    off = start;
+    len = count;
+    herr = H5Sselect_hyperslab(fspace, H5S_SELECT_SET, &off, NULL, &one, &len);
+    CHECK_HERR
+
+    /* set local memory space, a contiguous buffer of size fp->total_len */
+    dim_len = fp->total_len;
+    mspace = H5Screate_simple(1, &dim_len, NULL);
+    CHECK_HID(mspace)
+
+    /* all processes write to the data blob dataset collectively */
+    herr = H5Dwrite(data_blob, H5T_NATIVE_UCHAR, mspace, fspace, dxpl_id, buf);
+    CHECK_HERR
+
+    /* this process writes fp->total_len amount in bytes */
+    this->put_amount += fp->total_len;
+
+    herr = H5Pclose(dxpl_id);
+    CHECK_HERR
+    herr = H5Sclose(mspace);
+    CHECK_HERR
+
+    herr = H5Sclose(fspace);
+    CHECK_HERR
+
+    free(buf);
+
+    /* close data_blob dataset */
+    herr = H5Dclose(data_blob);
+    CHECK_HERR
+
+    /* set independent write mode, as only root writes header blob */
+    dxpl_id = H5Pcreate(H5P_DATASET_XFER);
+    CHECK_HID(dxpl_id)
+    herr = H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_INDEPENDENT);
+    CHECK_HERR
+
+    /* root writes to the header blob dataset entirely */
+    if (rank == 0) {
+        herr = H5Dwrite(header_blob, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL,
+                        dxpl_id, header_buf);
+        CHECK_HERR
+
+        /* root process writes header_len amount in bytes */
+        this->put_amount += header_len;
+    }
+
+    herr = H5Pclose(dxpl_id);
+    CHECK_HERR
+
+    /* close header blob dataset */
+    herr = H5Dclose(header_blob);
+    CHECK_HERR
+
+    free(header_buf);
+
+    herr = H5Fclose(fp->id);
+    CHECK_HERR
+
+    free(fp->header);
+    MPI_Comm_free(&fp->comm);
+
+    delete fp;
+
+err_out:
+    return err;
+}
+
+int e3sm_io_driver_h5blob::inq_file_info (int fid, MPI_Info *info) {
+    int err = 0;
+    herr_t herr;
+    h5blob_file *fp = this->files[fid];
+    hid_t pid;
+
+
+    pid = H5Fget_access_plist (fp->id);
+    CHECK_HID (pid);
+    herr = H5Pget_fapl_mpio (pid, NULL, info);
+    CHECK_HERR
+
+err_out:
+    if (pid != -1) H5Pclose (pid);
+    return err;
+}
+
+int e3sm_io_driver_h5blob::inq_file_size (std::string path, MPI_Offset *size) {
+    int err = 0;
+    struct stat file_stat;
+
+    err = stat (path.c_str (), &file_stat);
+    CHECK_ERR
+
+    *size = (MPI_Offset) (file_stat.st_size);
+
+err_out:
+    return err;
+}
+
+int e3sm_io_driver_h5blob::inq_put_size (int fid, MPI_Offset *size) {
+    *size = this->put_amount;
+    return 0;
+}
+
+int e3sm_io_driver_h5blob::inq_get_size (int fid, MPI_Offset *size) {
+    *size = this->get_amount;
+    return 0;
+}
+
+int e3sm_io_driver_h5blob::inq_malloc_size (MPI_Offset *size) {
+    *size = 0;
+    return 0;
+}
+
+int e3sm_io_driver_h5blob::inq_malloc_max_size (MPI_Offset *size) {
+    *size = 0;
+    return 0;
+}
+
+int e3sm_io_driver_h5blob::inq_rec_size (int fid, MPI_Offset *size) {
+
+    *size = (MPI_Offset) (this->files[fid]->header->recsize);
+
+    return 0;
+}
+
+int e3sm_io_driver_h5blob::def_var(int          fid,
+                                   std::string  name,
+                                   nc_type      xtype,
+                                   int          ndims,
+                                   int         *dimids,
+                                   int         *varidp)
+{
+    /* add a variable object in NC */
+    return blob_ncmpio_add_var(this->files[fid]->header, name.c_str(), xtype,
+                               ndims, dimids, varidp);
+}
+
+int e3sm_io_driver_h5blob::def_local_var (
+    int fid, std::string name, MPI_Datatype type, int ndim, MPI_Offset *dsize, int *did) {
+    int err = 0;
+
+    ERR_OUT ("HDF5 blob I/O does not support local variables")
+
+err_out:
+    return err;
+}
+
+int e3sm_io_driver_h5blob::inq_var (int fid, std::string name, int *did) {
+    int err = 0;
+
+    ERR_OUT ("HDF5 blob I/O does not implement inq_var yet")
+
+err_out:
+    return err;
+}
+
+int e3sm_io_driver_h5blob::inq_var_name (int fid, int varid, char *name) {
+    NC *ncp = this->files[fid]->header;
+    NC_var *varp = ncp->vars.value[varid];
+
+    if (name != NULL) strcpy(name, varp->name);
+
+    return 0;
+}
+
+int e3sm_io_driver_h5blob::inq_var_off (int fid, int vid, MPI_Offset *off) {
+    throw "Function not supported";
+    return -1;
+}
+
+int e3sm_io_driver_h5blob::def_dim(int          fid,
+                                   std::string  name,
+                                   MPI_Offset   size,
+                                   int         *dimidp)
+{
+    return blob_ncmpio_add_dim(this->files[fid]->header, name.c_str(), size,
+                               dimidp);
+}
+
+int e3sm_io_driver_h5blob::inq_dim(int fid, std::string name, int *dimid) {
+    int i;
+    size_t nchars;
+    NC_dimarray *ncdap = &this->files[fid]->header->dims;
+
+    if (ncdap->ndefined == 0) return -1; /* none defined yet */
+
+    /* note that the number of dimensions allowed is < 2^32 */
+    nchars = strlen(name.c_str());
+    for (i=0; i<ncdap->ndefined; i++) {
+        if (ncdap->value[i]->name_len == nchars &&
+            strcmp(ncdap->value[i]->name, name.c_str()) == 0) {
+            /* found the matched name */
+            if (dimid != NULL) *dimid = i;
+            return NC_NOERR; /* found it */
+        }
+    }
+    return -1;
+}
+
+int e3sm_io_driver_h5blob::inq_dimlen (int fid, int dimid, MPI_Offset *size) {
+    NC *ncp = this->files[fid]->header;
+    NC_dim *dimp = ncp->dims.value[dimid];
+
+    if (size != NULL) {
+        if (dimp->size == NC_UNLIMITED)
+            *size = ncp->numrecs;
+        else
+            *size = dimp->size;
+    }
+    return 0;
+}
+
+int e3sm_io_driver_h5blob::enddef (int fid) { return 0; }
+int e3sm_io_driver_h5blob::redef (int fid) { return 0; }
+int e3sm_io_driver_h5blob::wait (int fid) {
+    int err = 0;
+    herr_t herr;
+    h5blob_file *fp = this->files[fid];
+
+    herr = H5Fflush (fp->id, H5F_SCOPE_GLOBAL);
+    CHECK_HERR
+
+err_out:
+    return err;
+}
+
+int e3sm_io_driver_h5blob::put_att(int          fid,
+                                   int          varid,
+                                   std::string  name,
+                                   nc_type      xtype,
+                                   MPI_Offset   nelems,
+                                   const void  *buf)
+{
+    return blob_ncmpio_put_att(this->files[fid]->header, varid, name.c_str(),
+                               xtype, nelems, buf);
+}
+
+int e3sm_io_driver_h5blob::get_att(int          fid,
+                                   int          varid,
+                                   std::string  name,
+                                   void        *buf)
+{
+    return blob_ncmpio_get_att(this->files[fid]->header, varid, name.c_str(),
+                               buf);
+}
+
+int e3sm_io_driver_h5blob::put_varl (
+    int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode) {
+    int err = 0;
+
+    ERR_OUT ("HDF5 does not support local variables")
+
+err_out:
+    return err;
+}
+
+int e3sm_io_driver_h5blob::put_vara(int fid,
+                                    int varid,
+                                    MPI_Datatype itype,
+                                    MPI_Offset *start,
+                                    MPI_Offset *count,
+                                    void *buf,
+                                    e3sm_io_op_mode mode)
+{
+    int i, xsz;
+    MPI_Datatype xtype;
+    MPI_Offset nelems, len;
+    NC *ncp = this->files[fid]->header;
+    NC_var *varp = ncp->vars.value[varid];
+    var_buf *vbuf = this->files[fid]->vars + varid;
+
+    this->files[fid]->num_puts++;
+
+    xtype = varp->xtype;
+    MPI_Type_size(xtype, &xsz);
+
+    nelems = 1;
+    if (varp->ndims > 0 && start == NULL) { /* var API */
+        if (varp->shape[0] != NC_UNLIMITED) nelems *= varp->shape[0];
+        for (i=1; i<varp->ndims; i++)
+            nelems *= varp->shape[i];
+
+/*
+if (varp->ndims==1) printf("%s var %s varid %d: ndims=%d shape[0]=%lld nelems=%lld\n",__func__,varp->name,varid,varp->ndims,varp->shape[0],nelems);
+if (varp->ndims==2) printf("%s var %s varid %d: ndims=%d shape[0]=%lld %lld nelems=%lld\n",__func__,varp->name,varid,varp->ndims,varp->shape[0],varp->shape[1],nelems);
+if (varp->ndims==3) printf("%s var %s varid %d: ndims=%d shape[0]=%lld %lld %lld nelems=%lld\n",__func__,varp->name,varid,varp->ndims,varp->shape[0],varp->shape[1],varp->shape[2],nelems);
+*/
+    }
+    else if (varp->ndims > 0 && count != NULL) {
+        if (varp->shape[0] != NC_UNLIMITED) nelems *= count[0];
+        for (i=1; i<varp->ndims; i++)
+            nelems *= count[i];
+/*
+if (varp->ndims==1) printf("%s var %s varid %d: ndims=%d count[0]=%lld nelems=%lld\n",__func__,varp->name,varid,varp->ndims,count[0],nelems);
+if (varp->ndims==2) printf("%s var %s varid %d: ndims=%d count[0]=%lld %lld nelems=%lld\n",__func__,varp->name,varid,varp->ndims,count[0],count[1],nelems);
+if (varp->ndims==3) printf("%s var %s varid %d: ndims=%d count[0]=%lld %lld %lld nelems=%lld\n",__func__,varp->name,varid,varp->ndims,count[0],count[1],count[2],nelems);
+*/
+    }
+
+    len = nelems * xsz;
+
+    if (itype != xtype) {
+        /* type cast when external and internal data type sizes are different */
+        if (itype == MPI_DOUBLE && xtype == MPI_FLOAT) {
+            double *dbl_buf = (double*)buf;
+            float *flt_buf = (float*) malloc(nelems * sizeof(float));
+            for (i=0; i<nelems; i++)
+                flt_buf[i] = (float) dbl_buf[i];
+            buf = flt_buf;
+        }
+        else {
+            printf("var %s itype xtype mismatched\n",varp->name);
+            return -1;
+        }
+    }
+    else { /* type matched, allocate buffer and copy over */
+        void *tmp = (void*) malloc(len);
+        memcpy(tmp, buf, len);
+        buf = tmp;
+    }
+
+    if (IS_RECVAR(varp) && count != NULL && count[0] > 1)
+        throw "Error: writing 2 or more records is not supported yet";
+
+    this->files[fid]->total_len += len;
+
+    if (IS_RECVAR(varp)) {
+        assert(start != NULL);
+        if (start[0] > vbuf->nalloc + 64)
+            throw "Error: non-sequential write to records is not supported yet";
+        if (start[0] == vbuf->nalloc) {
+            vbuf->nalloc += 64;
+            vbuf->buf = (void**)  realloc(vbuf->buf, vbuf->nalloc * sizeof(void*));
+            vbuf->len = (size_t*) realloc(vbuf->len, vbuf->nalloc * sizeof(size_t));
+            for (i=0; i<64; i++)
+                vbuf->len[vbuf->nalloc - 64 + i] = 0;
+        }
+
+        vbuf->nrecs = (start[0]+1 > vbuf->nrecs) ? start[0]+1 : vbuf->nrecs;
+
+        vbuf->buf[start[0]] = buf;
+        vbuf->len[start[0]] = len;
+
+        MPI_Offset new_numrecs = start[0];
+        new_numrecs += (count == NULL) ? 1 : count[0];
+        if (ncp->numrecs < new_numrecs)
+            ncp->numrecs = new_numrecs;
+// printf("%s RECORD var %s\n", __FILE__,ncp->vars.value[varid]->name);
+    }
+    else { /* fixed-size variable */
+        vbuf->nrecs = 0;
+        if (vbuf->nalloc == 0) {
+            vbuf->nalloc = 1;
+            vbuf->buf = (void**)  realloc(vbuf->buf, sizeof(void*));
+            vbuf->len = (size_t*) realloc(vbuf->len, sizeof(size_t));
+        }
+        vbuf->buf[0] = buf;
+        vbuf->len[0] = len;
+// printf("%s FIXED var %s\n", __FILE__,ncp->vars.value[varid]->name);
+    }
+
+    return 0;
+}
+
+int e3sm_io_driver_h5blob::put_vars (int fid,
+                                   int vid,
+                                   MPI_Datatype type,
+                                   MPI_Offset *start,
+                                   MPI_Offset *count,
+                                   MPI_Offset *stride,
+                                   void *buf,
+                                   e3sm_io_op_mode mode) {
+    throw "HDF5 blob I/O does not support put_vars yet";
+    return -1;
+}
+
+int e3sm_io_driver_h5blob::put_varn (int fid,
+                                   int vid,
+                                   MPI_Datatype type,
+                                   int nreq,
+                                   MPI_Offset **starts,
+                                   MPI_Offset **counts,
+                                   void *buf,
+                                   e3sm_io_op_mode mode) {
+    throw "HDF5 blob I/O does not support put_varn yet";
+    return -1;
+}
+
+int e3sm_io_driver_h5blob::put_vard (int fid,
+                                   int vid,
+                                   MPI_Datatype type,
+                                   MPI_Offset nelem,
+                                   MPI_Datatype ftype,
+                                   void *buf,
+                                   e3sm_io_op_mode mode) {
+    throw "HDF5 blob I/O does not support put_vard yet";
+    return -1;
+}
+
+int e3sm_io_driver_h5blob::get_vara (int fid,
+                                   int vid,
+                                   MPI_Datatype type,
+                                   MPI_Offset *start,
+                                   MPI_Offset *count,
+                                   void *buf,
+                                   e3sm_io_op_mode mode) {
+    throw "HDF5 blob I/O does not support get_vara yet";
+    return -1;
+}
+
+int e3sm_io_driver_h5blob::get_vars (int fid,
+                                   int vid,
+                                   MPI_Datatype type,
+                                   MPI_Offset *start,
+                                   MPI_Offset *count,
+                                   MPI_Offset *stride,
+                                   void *buf,
+                                   e3sm_io_op_mode mode) {
+    throw "HDF5 blob I/O does not support get_vars yet";
+    return -1;
+}
+
+int e3sm_io_driver_h5blob::get_varn (int fid,
+                                   int vid,
+                                   MPI_Datatype type,
+                                   int nreq,
+                                   MPI_Offset **starts,
+                                   MPI_Offset **counts,
+                                   void *buf,
+                                   e3sm_io_op_mode mode) {
+    throw "HDF5 blob I/O does not support get_varn yet";
+    return -1;
+}
+
+int e3sm_io_driver_h5blob::get_vard (int fid,
+                                   int vid,
+                                   MPI_Datatype type,
+                                   MPI_Offset nelem,
+                                   MPI_Datatype ftype,
+                                   void *buf,
+                                   e3sm_io_op_mode mode) {
+    throw "HDF5 blob I/O does not support get_vard yet";
+    return -1;
+}

--- a/src/drivers/e3sm_io_driver_h5blob.hpp
+++ b/src/drivers/e3sm_io_driver_h5blob.hpp
@@ -1,0 +1,139 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include <hdf5.h>
+#include <mpi.h>
+
+#include <e3sm_io.h>
+#include <e3sm_io_driver.hpp>
+#include <blob_ncmpio.h>
+
+class e3sm_io_driver_h5blob : public e3sm_io_driver {
+    typedef struct {
+        int      nalloc;
+        int      nrecs;
+        void   **buf;  /* [nrecs] */
+        size_t  *len;  /* [nrecs] */
+    } var_buf;
+
+    class h5blob_file {
+        public:
+            e3sm_io_driver_h5blob &driver;
+            h5blob_file (e3sm_io_driver_h5blob &x) : driver (x) {};
+
+            hid_t id;   /* HDF5 file ID */
+            NC *header; /* metadata in NetCDF format */
+            var_buf *vars;
+            size_t total_len;
+            int num_puts;
+            MPI_Comm comm;
+    };
+
+    std::vector<h5blob_file *> files;
+
+    e3sm_io_config *cfg;
+    MPI_Offset put_amount;  /* write amount by far for all files */
+    MPI_Offset get_amount;  /* read  amount by far for all files */
+
+   public:
+    e3sm_io_driver_h5blob (e3sm_io_config *cfg);
+    ~e3sm_io_driver_h5blob ();
+    int create (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
+    int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
+    int close (int fid);
+    int inq_file_info (int fid, MPI_Info *info);
+    int inq_file_size (std::string path, MPI_Offset *size);
+    int inq_put_size (int fid, MPI_Offset *size);
+    int inq_get_size (int fid, MPI_Offset *size);
+    int inq_malloc_size (MPI_Offset *size);
+    int inq_malloc_max_size (MPI_Offset *size);
+    int inq_rec_size (int fid, MPI_Offset *size);
+    int def_var (int fid, std::string name, MPI_Datatype type, int ndim, int *dimids, int *did);
+    int def_local_var (
+        int fid, std::string name, MPI_Datatype type, int ndim, MPI_Offset *dsize, int *did);
+    int inq_var (int fid, std::string name, int *did);
+    int inq_var_name(int ncid, int varid, char *name);
+    int inq_var_off (int fid, int vid, MPI_Offset *off);
+    int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);
+    int inq_dim (int fid, std::string name, int *dimid);
+    int inq_dimlen (int fid, int dimid, MPI_Offset *size);
+    int enddef (int fid);
+    int redef (int fid);
+    int wait (int fid);
+    int put_att (int fid, int vid, std::string name, MPI_Datatype type, MPI_Offset size, const void *buf);
+    int get_att (int fid, int vid, std::string name, void *buf);
+    int put_varl (int fid, int vid, MPI_Datatype type, void *buf, e3sm_io_op_mode mode);
+    int put_vara (int fid,
+                  int vid,
+                  MPI_Datatype type,
+                  MPI_Offset *start,
+                  MPI_Offset *count,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int put_vars (int fid,
+                  int vid,
+                  MPI_Datatype type,
+                  MPI_Offset *start,
+                  MPI_Offset *count,
+                  MPI_Offset *stride,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int put_varn (int fid,
+                  int vid,
+                  MPI_Datatype type,
+                  int nreq,
+                  MPI_Offset **starts,
+                  MPI_Offset **counts,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int put_vard (int fid,
+                  int vid,
+                  MPI_Datatype type,
+                  MPI_Offset nelem,
+                  MPI_Datatype ftype,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int get_vara (int fid,
+                  int vid,
+                  MPI_Datatype type,
+                  MPI_Offset *start,
+                  MPI_Offset *count,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int get_vars (int fid,
+                  int vid,
+                  MPI_Datatype type,
+                  MPI_Offset *start,
+                  MPI_Offset *count,
+                  MPI_Offset *stride,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int get_varn (int fid,
+                  int vid,
+                  MPI_Datatype type,
+                  int nreq,
+                  MPI_Offset **starts,
+                  MPI_Offset **counts,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int get_vard (int fid,
+                  int vid,
+                  MPI_Datatype type,
+                  MPI_Offset nelem,
+                  MPI_Datatype ftype,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+
+};
+

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -68,6 +68,7 @@ err_out:
 void print_info (MPI_Info *info_used) {
     int i, nkeys;
 
+    if (*info_used == MPI_INFO_NULL) return;
     MPI_Info_get_nkeys (*info_used, &nkeys);
     printf ("MPI File Info: nkeys = %d\n", nkeys);
     for (i = 0; i < nkeys; i++) {
@@ -103,7 +104,7 @@ static void usage (char *argv0) {
 "                 (folder) path\n"
 "       [-a api]  I/O library name to perform write operation\n"
 "           pnetcdf:   PnetCDF library (default)\n"
-"           hdf5_ra:   HDF5 library with request rearranger on top of it\n"
+"           hdf5:      HDF5 library\n"
 "           hdf5_log:  HDF5 library with Log-based VOL\n"
 "           hdf5_md:   HDF5 library with multi-dataset APIs\n"
 "           adios:     ADIOS2 library using BP3 format\n"
@@ -179,8 +180,8 @@ int main (int argc, char **argv) {
                 if (strcmp (optarg, "pnetcdf") == 0)
                     cfg.api = pnetcdf;
 #ifdef ENABLE_HDF5
-                else if (strcmp (optarg, "hdf5_ra") == 0)
-                    cfg.api = hdf5_ra;
+                else if (strcmp (optarg, "hdf5") == 0)
+                    cfg.api = hdf5;
                 else if (strcmp (optarg, "hdf5_md") == 0)
 #ifdef HDF5_HAVE_DWRITE_MULTI
                     cfg.api = hdf5_md;
@@ -270,7 +271,7 @@ int main (int argc, char **argv) {
 
     /* neither command-line option -i or -o is used */
     if (!cfg.wr && !cfg.rd)
-        ERR_OUT("Error: neither command-line option -i or -o is used")
+        ERR_OUT("Error: neither command-line option -i nor -o is used")
 
     /* check yet to support APIs and I/O strategies */
     if (cfg.api == undef_api) cfg.api = pnetcdf;
@@ -282,13 +283,11 @@ int main (int argc, char **argv) {
             ERR_OUT ("PnetCDF with log I/O strategy is not supported yet")
     }
 
-    if (cfg.api == hdf5_ra) {
+    if (cfg.api == hdf5) {
         if (cfg.strategy == undef_io)
             cfg.strategy = canonical;
         else if (cfg.strategy == log)
             ERR_OUT ("HDF5 rearranger with log I/O strategy is not supported yet")
-        else if (cfg.strategy == blob)
-            ERR_OUT ("HDF5 rearranger with blob I/O strategy is not supported yet")
     }
 
     if (cfg.api == hdf5_md) {

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -48,7 +48,7 @@ typedef float itype; /* internal data type of buffer in memory */
 
 typedef enum e3sm_io_api {
     pnetcdf,
-    hdf5_ra,
+    hdf5,
     hdf5_md,
     hdf5_log,
     adios,


### PR DESCRIPTION
Add an option to performance blob I/O using HDF5 library.
The implementation uses the per-process based blob I/O strategy, in which
each process writes only one blob at file close time. All writes to all variables
by a process will first be cached in memory and packed into a contiguous
buffer to be flushed out in a single write call. There is one additional write
for the header data blob, which is written by the root process only.

Note this strategy is different from the one used on PnetCDF blob strategy
which is a per-record based.

The per-process based blob I/O does not allow flush before file close, such
as flushing writes of one time step after another. Such operation will require
to move data already in the file to upper location to make space for new data,
in order to maintain the one-blob-per-process data layout in the file.

The per-record based blob I/O does not incur such penalty.
