### PR TITLE
Changes to make the output file of ADIOS blob test readable by adios2pio-nm.exe

### DIFF
--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -126,7 +126,7 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
                 CHECK_ERR
 
                 // NetCDF type enum
-                ibuf = 5;
+                ibuf = (int)mpitype2nctype (type);
                 err  = driver.put_att (fid, var->data, "__pio__/nctype", MPI_INT, 1, &ibuf);
                 CHECK_ERR
 

--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -71,7 +71,7 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
     std::vector<const char*> dnames_array (ndim);
 
     var->type    = type;
-    var->decomid = decomid;
+    var->decomid = decomid + 512;
     var->ndim = 0;
 
     for(i = 0; i < ndim; i++){
@@ -112,8 +112,7 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
             // Scorpio attributes are only written by rank 0
             if (cfg.rank == 0) {
                 // Decomposition map
-                ibuf = var->decomp_id + 512;
-                sprintf(cbuf, "%d", ibuf);
+                sprintf(cbuf, "%d", var->decomid);
                 err  = driver.put_att (fid, var->data, "__pio__/decomp", MPI_CHAR, strlen(cbuf), &cbuf);
                 CHECK_ERR
 

--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -69,9 +69,10 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
     int ibuf;
     int ret;
     std::vector<const char*> dnames_array (ndim);
+    int piodecomid_inv[] = {0, 1, 4};
 
     var->type    = type;
-    var->decomid = decomid + 512;
+    var->decomid = piodecomid_inv[decomid] + 512;
     var->ndim = 0;
 
     for(i = 0; i < ndim; i++){
@@ -219,6 +220,7 @@ inline int e3sm_io_scorpio_write_var (e3sm_io_driver &driver,
                                   void *buf,
                                   e3sm_io_op_mode mode) {
     int err, nerrs = 0;
+    int decomid;
 
     // Attach start and count before the data for small, non-scalar variables
     if (var.ndim){
@@ -233,7 +235,11 @@ inline int e3sm_io_scorpio_write_var (e3sm_io_driver &driver,
         err = driver.put_varl (fid, var.frame_id, MPI_INT, &frameid, nbe);
         CHECK_ERR
 
-        err = driver.put_varl (fid, var.decomp_id, MPI_INT, &(var.decomid), nbe);
+        decomid = var.decomid;
+        if (var.fillval_id < 0) {
+            decomid *= -1;
+        }
+        err = driver.put_varl (fid, var.decomp_id, MPI_INT, &(decomid), nbe);
         CHECK_ERR
 
         if (var.fillval_id >= 0) {

--- a/src/cases/header_io_F_case_scorpio.cpp
+++ b/src/cases/header_io_F_case_scorpio.cpp
@@ -6155,36 +6155,46 @@ int def_F_case_h1_scorpio (e3sm_io_driver &driver,
     char name[128];
 
     /* global attributes: */
-    iattr = 4;
-    err   = e3sm_io_scorpio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR, "ne", MPI_INT, 1, &iattr);
+    // TODO: retrieve real attribute content
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/Conventions", 6, "CF-1.7");
     CHECK_ERR
-    err = e3sm_io_scorpio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR, "np", MPI_INT, 1, &iattr);
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/case", 33, "ADIOS_FC5AV1C-H01A_ne120_oRRS18v3");
     CHECK_ERR
-    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "Conventions", 6, "CF-1.0");
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/contact", 35, "e3sm-data-support@listserv.llnl.gov");
     CHECK_ERR
-    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "source", 3, "CAM");
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/git_version", 10, "025f820fce");
     CHECK_ERR
-    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "case", 20, "FC5AV1C-H01B_ne4_ne4");
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/history", 28, "created on 06/10/21 11:59:48");
     CHECK_ERR
-    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "title", 5, "UNSET");
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/hostname", 8, "cori-knl");
     CHECK_ERR
-    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "logname", 6, "wkliao");
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/initial_file", 99, "/global/cfs/cdirs/e3sm/inputdata/atm/cam/inic/homme/cami_mam3_Linoz_0000-01-ne120np4_L72_c160318.nc");
     CHECK_ERR
-    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "host", 10, "compute001");
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/institution", 660, "LLNL (Lawrence Livermore National Laboratory, Livermore, CA 94550, USA); ANL (Argonne National Laboratory, Argonne, IL 60439, USA); BNL (Brookhaven National Laboratory, Upton, NY 11973, USA); LANL (Los Alamos National Laboratory, Los Alamos, NM 87545, USA); LBNL (Lawrence Berkeley National Laboratory, Berkeley, CA 94720, USA); ORNL (Oak Ridge National Laboratory, Oak Ridge, TN 37831, USA); PNNL (Pacific Northwest National Laboratory, Richland, WA 99352, USA); SNL (Sandia National Laboratories, Albuquerque, NM 87185, USA). Mailing address: LLNL Climate Program, c/o David C. Bader, Principal Investigator, L-103, 7000 East Avenue, Livermore, CA 94550, USA");
     CHECK_ERR
-    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "Version", 6, "$Name$");
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/institution_id", 12, "E3SM-Project");
     CHECK_ERR
-    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "revision_Id", 4, "$Id$");
+    k = 120;
+    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/ne", MPI_INT, 1, &k);
     CHECK_ERR
-    err = PUT_ATT_TEXT (
-        ncid, E3SM_IO_GLOBAL_ATTR, "initial_file", 86,
-        "/home/climate1/acme/inputdata/atm/cam/inic/homme/cami_mam3_Linoz_ne4np4_L72_c160909.nc");
+    k = 21600;
+    err = driver.put_att (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/np", MPI_INT, 1, &k);
     CHECK_ERR
-    err = PUT_ATT_TEXT (
-        ncid, E3SM_IO_GLOBAL_ATTR, "topography_file", 79,
-        "/home/climate1/acme/inputdata/atm/cam/topo/USGS-gtopo30_ne4np4_16x.c20160612.nc");
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/product", 12, "model-output");
     CHECK_ERR
-    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "time_period_freq", 6, "hour_2");
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/realm", 5, "atmos");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/source", 21, "E3SM Atmosphere Model");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/source_id", 10, "025f820fce");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/time_period_freq", 5, "day_5");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/title", 28, "EAM History file information");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/topography_file", 96, "/global/cfs/cdirs/e3sm/inputdata/atm/cam/topo/USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc");
+    CHECK_ERR
+    err = PUT_ATT_TEXT (ncid, E3SM_IO_GLOBAL_ATTR, "pio_global/username", 4, "dqwu");
     CHECK_ERR
 
     // PIO attributes

--- a/src/cases/header_io_F_case_scorpio.cpp
+++ b/src/cases/header_io_F_case_scorpio.cpp
@@ -204,13 +204,18 @@ int def_F_case_h0_scorpio (e3sm_io_driver &driver,
     /* define pio decom map variables */
     for (j = 0; j < 5; j++) {
         int piodecomid[] = {0, 1, 1, 1, 2};
+        int piodims[5];
 
         sprintf (name, "/__pio__/decomp/%d", (j + 512));
         err = driver.def_local_var (ncid, name, MPI_LONG_LONG, 1, decom.raw_nreqs + piodecomid[j],
                                     scorpiovars + j);
         CHECK_ERR
+
+        for (i = 0; i < decom.ndims[piodecomid[j]]; i++){
+            piodims[i] = (int)decom.dims[piodecomid[j]][i];
+        }
         err = driver.put_att (ncid, scorpiovars[j], "dimlen", MPI_INT, decom.ndims[piodecomid[j]],
-                              decom.dims + piodecomid[j]);
+                              piodims);
         CHECK_ERR
         err = driver.put_att (ncid, scorpiovars[j], "ndims", MPI_INT, 1, decom.ndims + piodecomid[j]);
         CHECK_ERR
@@ -6204,16 +6209,23 @@ int def_F_case_h1_scorpio (e3sm_io_driver &driver,
     /* define pio decom map variables */
     for (j = 0; j < 5; j++) {
         int piodecomid[] = {0, 1, 1, 1, 2};
-        k                = 6;
+        int piodims[5];
+        
         sprintf (name, "/__pio__/decomp/%d", (j + 512));
         err = driver.def_local_var (ncid, name, MPI_LONG_LONG, 1, decom.raw_nreqs + piodecomid[j],
                                     scorpiovars + j);
         CHECK_ERR
+
+        for (i = 0; i < decom.ndims[piodecomid[j]]; i++){
+            piodims[i] = (int)decom.dims[piodecomid[j]][i];
+        }
         err = driver.put_att (ncid, scorpiovars[j], "dimlen", MPI_INT, decom.ndims[piodecomid[j]],
-                              decom.dims + piodecomid[j]);
+                              piodims);
         CHECK_ERR
+
         err = driver.put_att (ncid, scorpiovars[j], "ndims", MPI_INT, 1, decom.ndims + piodecomid[j]);
         CHECK_ERR
+
         err = driver.put_att (ncid, scorpiovars[j], "piotype", MPI_INT, 1, &k);
         CHECK_ERR
     }

--- a/src/cases/header_io_G_case_scorpio.cpp
+++ b/src/cases/header_io_G_case_scorpio.cpp
@@ -984,14 +984,20 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     /* define scorpio decom map variables */
     for (j = 0; j < 6; j++) {
         int piodecomid[] = {0, 1, 2, 3, 4, 5};
+        int piodims[5];
 
         sprintf (name, "/__pio__/decomp/%d", (j + 512));
         err = driver.def_local_var (ncid, name, MPI_LONG_LONG, 1, decom.raw_nreqs + piodecomid[j],
                                     scorpiovars + j);
         CHECK_ERR
+
+        for (i = 0; i < decom.ndims[piodecomid[j]]; i++){
+            piodims[i] = (int)decom.dims[piodecomid[j]][i];
+        }
         err = driver.put_att (ncid, scorpiovars[j], "dimlen", MPI_INT, decom.ndims[piodecomid[j]],
-                              decom.dims + piodecomid[j]);
+                              piodims);
         CHECK_ERR
+
         err =
             driver.put_att (ncid, scorpiovars[j], "ndims", MPI_INT, 1, decom.ndims + piodecomid[j]);
         CHECK_ERR

--- a/src/cases/header_io_G_case_scorpio.cpp
+++ b/src/cases/header_io_G_case_scorpio.cpp
@@ -45,24 +45,26 @@
             goto err_out;                                                                       \
         }                                                                                       \
     }
-#define PUT_GATTR_TXT(name, buf)                                                          \
-    {                                                                                     \
-        err = e3sm_io_scorpio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR, name, MPI_CHAR, \
-                                       strlen (buf), (void *)(buf));                      \
-        CHECK_ERR                                                                         \
-    }
-#define PUT_GATTR_INT(name, val)                                                                   \
+#define PUT_GATTR_TXT(name, buf)                                                                   \
     {                                                                                              \
-        int buf = val;                                                                             \
-        err = e3sm_io_scorpio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR, name, MPI_INT, 1, &buf); \
+        err = e3sm_io_scorpio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR,                          \
+                                       "pio_global/" + std::string (name), MPI_CHAR, strlen (buf), \
+                                       (void *)(buf));                                             \
         CHECK_ERR                                                                                  \
     }
-#define PUT_GATTR_DBL(name, val)                                                               \
-    {                                                                                          \
-        double buf = val;                                                                      \
-        err = e3sm_io_scorpio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR, name, MPI_DOUBLE, 1, \
-                                       &buf);                                                  \
-        CHECK_ERR                                                                              \
+#define PUT_GATTR_INT(name, val)                                                                  \
+    {                                                                                             \
+        int buf = val;                                                                            \
+        err     = e3sm_io_scorpio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR,                     \
+                                       "pio_global/" + std::string (name), MPI_INT, 1, &buf); \
+        CHECK_ERR                                                                                 \
+    }
+#define PUT_GATTR_DBL(name, val)                                                                        \
+    {                                                                                                   \
+        double buf = val;                                                                               \
+        err        = e3sm_io_scorpio_put_att (driver, ncid, E3SM_IO_GLOBAL_ATTR,                        \
+                                       "pio_global/" + std::string (name), MPI_DOUBLE, 1, &buf); \
+        CHECK_ERR                                                                                       \
     }
 #define PUT_ATTR_TXT(name, buf)                                                            \
     {                                                                                      \
@@ -111,6 +113,13 @@ static int add_gattrs_scorpio (e3sm_io_config &cfg,
     CHECK_ERR
 
     /* 742 global attributes: */
+    // TODO: retrieve real attribute content
+    PUT_GATTR_TXT ("initial_file",
+                   "/global/cfs/cdirs/e3sm/inputdata/atm/cam/inic/homme/"
+                   "cami_mam3_Linoz_0000-01-ne120np4_L72_c160318.nc")
+    PUT_GATTR_INT ("ne", 120)
+    PUT_GATTR_INT ("np", 21600)
+    PUT_GATTR_TXT ("time_period_freq", "day_5")
     PUT_GATTR_TXT ("title", "MPAS-Ocean output file information")
     PUT_GATTR_TXT ("source", "MPAS Ocean")
     PUT_GATTR_TXT ("source_id", "a79fafdb76")
@@ -123,6 +132,9 @@ static int add_gattrs_scorpio (e3sm_io_config &cfg,
     PUT_GATTR_TXT ("history", "created on 06/04/21 12:46:19")
     PUT_GATTR_TXT ("Conventions", "CF-1.7")
     PUT_GATTR_TXT ("institution_id", "E3SM-Project")
+    PUT_GATTR_TXT ("topography_file",
+                   "/global/cfs/cdirs/e3sm/inputdata/atm/cam/topo/"
+                   "USGS-gtopo30_ne120np4_16xdel2-PFC-consistentSGH.nc")
     PUT_GATTR_TXT (
         "institution",
         "LLNL (Lawrence Livermore National Laboratory, Livermore, CA 94550, USA); ANL (Argonne "
@@ -991,7 +1003,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
                                     scorpiovars + j);
         CHECK_ERR
 
-        for (i = 0; i < decom.ndims[piodecomid[j]]; i++){
+        for (i = 0; i < decom.ndims[piodecomid[j]]; i++) {
             piodims[i] = (int)decom.dims[piodecomid[j]][i];
         }
         err = driver.put_att (ncid, scorpiovars[j], "dimlen", MPI_INT, decom.ndims[piodecomid[j]],


### PR DESCRIPTION
Fill real value in all __pio__ attributes.
Fill real value in all decom_id/* variables.
Inverse decomp_id for all variables without an associated fillval_id variable.
Add new global attributes found in the output files.