### PR TITLE
Fix to make G case scorpio output file readable by adios2pio-nm.exe

### DIFF
--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -69,10 +69,9 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
     int ibuf;
     int ret;
     std::vector<const char*> dnames_array (ndim);
-    int piodecomid_inv[] = {0, 1, 4};
 
     var->type    = type;
-    var->decomid = piodecomid_inv[decomid] + 512;
+    var->decomid = decomid + 512;
     var->ndim = 0;
 
     for(i = 0; i < ndim; i++){

--- a/src/cases/header_io_F_case_scorpio.cpp
+++ b/src/cases/header_io_F_case_scorpio.cpp
@@ -35,7 +35,7 @@
 
 #define INQ_VID(F, N, T, S, B, V) driver.inq_var (F, N, V);
 
-#define DEF_VAR(F, N, T, ND, D, V) e3sm_io_scorpio_define_var (driver, cfg, dnames, decom, decomids[i], F, N, T, ND, D, V);
+#define DEF_VAR(F, N, T, ND, D, V) e3sm_io_scorpio_define_var (driver, cfg, dnames, decom, (decomids[i] >=0 ? piodecomid_inv[decomids[i]] : -1), F, N, T, ND, D, V);
 
 static char attbuf[4096];
 
@@ -102,6 +102,7 @@ int def_F_case_h0_scorpio (e3sm_io_driver &driver,
     int dim_ncol, dim_time, dim_nbnd, dim_chars, dim_lev, dim_ilev;
     float fillv = 1.e+36f, missv = 1.e+36f;
     std::map<int, std::string> dnames;
+    int piodecomid_inv[] = {0, 1, 4};
     char name[128];
 
     /* global attributes: */
@@ -6152,6 +6153,7 @@ int def_F_case_h1_scorpio (e3sm_io_driver &driver,
     int i, j, k, err, nerrs = 0, dimids[3], iattr, mdims = 1;
     int dim_ncol, dim_time, dim_nbnd, dim_chars, dim_lev, dim_ilev;
     std::map<int, std::string> dnames;
+    int piodecomid_inv[] = {0, 1, 4};
     char name[128];
 
     /* global attributes: */

--- a/src/cases/header_io_G_case_scorpio.cpp
+++ b/src/cases/header_io_G_case_scorpio.cpp
@@ -35,15 +35,17 @@
         err = e3sm_io_scorpio_define_dim (driver, ncid, name, num, dnames, dimid); \
         CHECK_ERR                                                                  \
     }
-#define DEF_VAR(name, type, ndims, dimids)                                                      \
-    {                                                                                           \
-        varid++;                                                                                \
-        err = e3sm_io_scorpio_define_var (driver, cfg, dnames, decom, decomids[varid - varids], \
-                                          ncid, name, type, ndims, dimids, varid);              \
-        if (err != 0) {                                                                         \
-            printf ("Error in %s line %d: def_var %s\n", __FILE__, __LINE__, name);             \
-            goto err_out;                                                                       \
-        }                                                                                       \
+#define DEF_VAR(name, type, ndims, dimids)                                                         \
+    {                                                                                              \
+        varid++;                                                                                   \
+        err = e3sm_io_scorpio_define_var (                                                         \
+            driver, cfg, dnames, decom,                                                            \
+            (decomids[varid - varids] >= 0 ? piodecomid_inv[decomids[varid - varids]] : -1), ncid, \
+            name, type, ndims, dimids, varid);                                                     \
+        if (err != 0) {                                                                            \
+            printf ("Error in %s line %d: def_var %s\n", __FILE__, __LINE__, name);                \
+            goto err_out;                                                                          \
+        }                                                                                          \
     }
 #define PUT_GATTR_TXT(name, buf)                                                                   \
     {                                                                                              \
@@ -912,7 +914,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     int dim_nVertLevels, dim_nVertLevelsP1, dimids_D[MAX_NUM_DECOMP][3];
     int fix_D[MAX_NUM_DECOMP][3], rec_D[MAX_NUM_DECOMP][3];
     std::map<int, std::string> dnames;
-
+    int piodecomid_inv[] = {0, 1, 2, 3, 4, 5};
     char name[64];
 
     err = add_gattrs_scorpio (cfg, decom, driver, ncid);

--- a/src/cases/header_io_G_case_scorpio.cpp
+++ b/src/cases/header_io_G_case_scorpio.cpp
@@ -91,7 +91,7 @@
     }
 #define PUT_ATTR_DECOMP(D, ndims, dimids)                                                        \
     {                                                                                            \
-        if (cfg.strategy == blob) {                                                              \
+        if ((cfg.strategy == blob) && false) {                                                              \
             err = e3sm_io_scorpio_put_att (driver, ncid, *varid, "decomposition_ID", MPI_INT, 1, \
                                            &D);                                                  \
             CHECK_VAR_ERR (*varid)                                                               \
@@ -1034,7 +1034,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (one, 2, dimids_D[0])
 
     /* double vertTransportVelocityTop(Time, nCells, nVertLevelsP1) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("vertTransportVelocityTop", MPI_DOUBLE, ndims, rec_D[5])
     PUT_ATTR_TXT ("units", "m s^{-1}")
     PUT_ATTR_TXT ("long_name",
@@ -1045,7 +1045,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (six, 3, dimids_D[5])
 
     /* double vertGMBolusVelocityTop(Time, nCells, nVertLevelsP1) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("vertGMBolusVelocityTop", MPI_DOUBLE, ndims, rec_D[5])
     PUT_ATTR_TXT ("units", "m s^{-1}")
     PUT_ATTR_TXT ("long_name",
@@ -1056,7 +1056,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (six, 3, dimids_D[5])
 
     /* double vertAleTransportTop(Time, nCells, nVertLevelsP1) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("vertAleTransportTop", MPI_DOUBLE, ndims, rec_D[5])
     PUT_ATTR_TXT ("units", "m s^{-1}")
     PUT_ATTR_TXT ("long_name",
@@ -1070,14 +1070,14 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (one, 2, dimids_D[0])
 
     /* double layerThickness(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("layerThickness", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "m")
     PUT_ATTR_TXT ("long_name", "layer thickness")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double normalVelocity(Time, nEdges, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("normalVelocity", MPI_DOUBLE, ndims, rec_D[3])
     PUT_ATTR_TXT ("units", "m s^{-1}")
     PUT_ATTR_TXT ("long_name", "horizonal velocity, normal component to an edge")
@@ -1104,7 +1104,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
                   "multiple vertical levels.")
 
     /* int edgeMask(nEdges, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 1 : 2;
+    ndims = ((cfg.strategy == blob) && false) ? 1 : 2;
     DEF_VAR ("edgeMask", MPI_INT, ndims, fix_D[3])
     PUT_ATTR_TXT ("units", "unitless")
     PUT_ATTR_TXT ("long_name",
@@ -1112,7 +1112,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (four, 2, dimids_D[3] + 1)
 
     /* int cellMask(nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 1 : 2;
+    ndims = ((cfg.strategy == blob) && false) ? 1 : 2;
     DEF_VAR ("cellMask", MPI_INT, ndims, fix_D[2])
     PUT_ATTR_TXT ("units", "unitless")
     PUT_ATTR_TXT ("long_name",
@@ -1120,7 +1120,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (three, 2, dimids_D[2] + 1)
 
     /* int vertexMask(nVertices, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 1 : 2;
+    ndims = ((cfg.strategy == blob) && false) ? 1 : 2;
     DEF_VAR ("vertexMask", MPI_INT, ndims, fix_D[4])
     PUT_ATTR_TXT ("units", "unitless")
     PUT_ATTR_TXT ("long_name",
@@ -1147,14 +1147,14 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_TXT ("long_name", "model time, with format \'YYYY-MM-DD_HH:MM:SS\'")
 
     /* double kineticEnergyCell(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("kineticEnergyCell", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "m^2 s^{-2}")
     PUT_ATTR_TXT ("long_name", "kinetic energy of horizontal velocity on cells")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double relativeVorticityCell(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("relativeVorticityCell", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "s^{-1}")
     PUT_ATTR_TXT ("long_name",
@@ -1162,14 +1162,14 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double relativeVorticity(Time, nVertices, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("relativeVorticity", MPI_DOUBLE, ndims, rec_D[4])
     PUT_ATTR_TXT ("units", "s^{-1}")
     PUT_ATTR_TXT ("long_name", "curl of horizontal velocity, defined at vertices")
     PUT_ATTR_DECOMP (five, 3, dimids_D[4])
 
     /* double divergence(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("divergence", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "s^{-1}")
     PUT_ATTR_TXT ("long_name", "divergence of horizontal velocity")
@@ -1216,7 +1216,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_TXT ("long_name", "maximum CFL number over the full domain")
 
     /* double BruntVaisalaFreqTop(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("BruntVaisalaFreqTop", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "s^{-2}")
     PUT_ATTR_TXT ("long_name",
@@ -1225,7 +1225,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double vertVelocityTop(Time, nCells, nVertLevelsP1) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("vertVelocityTop", MPI_DOUBLE, ndims, rec_D[5])
     PUT_ATTR_TXT ("units", "m s^{-1}")
     PUT_ATTR_TXT ("long_name",
@@ -1233,21 +1233,21 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (six, 3, dimids_D[5])
 
     /* double velocityZonal(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("velocityZonal", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "m s^{-1}")
     PUT_ATTR_TXT ("long_name", "component of horizontal velocity in the eastward direction")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double velocityMeridional(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("velocityMeridional", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "m s^{-1}")
     PUT_ATTR_TXT ("long_name", "component of horizontal velocity in the northward direction")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double displacedDensity(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("displacedDensity", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "kg m^{-3}")
     PUT_ATTR_TXT ("long_name",
@@ -1256,7 +1256,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double potentialDensity(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("potentialDensity", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "kg m^{-3}")
     PUT_ATTR_TXT (
@@ -1265,7 +1265,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double pressure(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("pressure", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "N m^{-2}")
     PUT_ATTR_TXT ("long_name", "pressure used in the momentum equation")
@@ -1279,7 +1279,7 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
         "Reference depth of ocean for each vertical level. Used in \'z-level\' type runs.")
 
     /* double zMid(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("zMid", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "m")
     PUT_ATTR_TXT ("long_name", "z-coordinate of the mid-depth of the layer")
@@ -1315,91 +1315,91 @@ int def_G_case_scorpio (e3sm_io_config &cfg,
     PUT_ATTR_DECOMP (one, 2, dimids_D[0])
 
     /* double temperatureHorizontalAdvectionTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("temperatureHorizontalAdvectionTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "potential temperature tendency due to horizontal advection")
     PUT_ATTR_TXT ("units", "degrees Celsius per second")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double salinityHorizontalAdvectionTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("salinityHorizontalAdvectionTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "salinity tendency due to horizontal advection")
     PUT_ATTR_TXT ("units", "PSU per second")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double temperatureVerticalAdvectionTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("temperatureVerticalAdvectionTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "potential temperature tendency due to vertical advection")
     PUT_ATTR_TXT ("units", "degrees Celsius per second")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double salinityVerticalAdvectionTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("salinityVerticalAdvectionTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "salinity tendency due to vertical advection")
     PUT_ATTR_TXT ("units", "PSU per second")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double temperatureVertMixTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("temperatureVertMixTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "potential temperature tendency due to vertical mixing")
     PUT_ATTR_TXT ("units", "degrees Celsius per second")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double salinityVertMixTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("salinityVertMixTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "salinity tendency due to vertical mixing")
     PUT_ATTR_TXT ("units", "PSU per second")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double temperatureSurfaceFluxTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("temperatureSurfaceFluxTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "potential temperature tendency due to surface fluxes")
     PUT_ATTR_TXT ("units", "degrees Celsius per second")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double salinitySurfaceFluxTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("salinitySurfaceFluxTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "salinity tendency due to surface fluxes")
     PUT_ATTR_TXT ("units", "PSU per second")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double temperatureShortWaveTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("temperatureShortWaveTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("units", "degrees Celsius per second")
     PUT_ATTR_TXT ("long_name", "potential temperature tendency due to penetrating shortwave")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double temperatureNonLocalTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("temperatureNonLocalTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "potential temperature tendency due to kpp non-local flux")
     PUT_ATTR_TXT ("units", "degrees Celsius per second")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double salinityNonLocalTendency(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("salinityNonLocalTendency", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "salinity tendency due to kpp non-local flux")
     PUT_ATTR_TXT ("units", "PSU per second")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double temperature(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("temperature", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "potential temperature")
     PUT_ATTR_TXT ("units", "degrees Celsius")
     PUT_ATTR_DECOMP (three, 3, dimids_D[2])
 
     /* double salinity(Time, nCells, nVertLevels) */
-    ndims = (cfg.strategy == blob) ? 2 : 3;
+    ndims = ((cfg.strategy == blob) && false) ? 2 : 3;
     DEF_VAR ("salinity", MPI_DOUBLE, ndims, rec_D[2])
     PUT_ATTR_TXT ("long_name", "salinity")
     PUT_ATTR_TXT ("units", "grams salt per kilogram seawater")

--- a/src/cases/var_io_F_case_scorpio.cpp
+++ b/src/cases/var_io_F_case_scorpio.cpp
@@ -431,7 +431,7 @@ int run_varn_F_case_scorpio (e3sm_io_config &cfg,
     int i, j, k, err=0, rank, ncid, *nvars_D=cfg.nvars_D;
     e3sm_io_scorpio_var *varids;
     int scorpiovars[6];
-    int rec_no=0, gap = 0, my_nreqs, *int_buf=NULL, *int_buf_ptr, xnreqs[3];
+    int rec_no = -1, gap = 0, my_nreqs, *int_buf=NULL, *int_buf_ptr, xnreqs[3];
     size_t ii, dbl_buflen, rec_buflen, nelems[3];
     itype *rec_buf  = NULL, *rec_buf_ptr;
     double *dbl_buf = NULL, *dbl_buf_ptr;

--- a/src/cases/var_io_G_case_scorpio.cpp
+++ b/src/cases/var_io_G_case_scorpio.cpp
@@ -251,7 +251,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
     int i, j, k, err, rank, ncid;
     e3sm_io_scorpio_var *varids;
     int scorpiovars[7];
-    int rec_no=0, my_nreqs, *nvars_D=cfg.nvars_D;
+    int rec_no = -1, my_nreqs, *nvars_D=cfg.nvars_D;
     size_t ii, rec_buflen, nelems[6];
     double *D1_fix_dbl_buf, *D1_rec_dbl_buf, *D3_rec_dbl_buf, *D4_rec_dbl_buf;
     double *D5_rec_dbl_buf, *D6_rec_dbl_buf, *rec_buf_ptr;


### PR DESCRIPTION
frame_id must be -1 for non-record variables.
Remove special treatment on variables for PnetCDF blob method copied into G case scorpio.