### PR TITLE
Fix bug in scorpio wrapper decom_id:

### DIFF
--- a/src/cases/header_io_F_case_scorpio.cpp
+++ b/src/cases/header_io_F_case_scorpio.cpp
@@ -35,7 +35,7 @@
 
 #define INQ_VID(F, N, T, S, B, V) driver.inq_var (F, N, V);
 
-#define DEF_VAR(F, N, T, ND, D, V) e3sm_io_scorpio_define_var (driver, cfg, dnames, decom, (decomids[i] >=0 ? piodecomid_inv[decomids[i]] : -1), F, N, T, ND, D, V);
+#define DEF_VAR(F, N, T, ND, D, V) e3sm_io_scorpio_define_var (driver, cfg, dnames, decom, decomids[i], (decomids[i] >=0 ? piodecomid_inv[decomids[i]] : -1), F, N, T, ND, D, V);
 
 static char attbuf[4096];
 

--- a/src/cases/header_io_G_case_scorpio.cpp
+++ b/src/cases/header_io_G_case_scorpio.cpp
@@ -39,7 +39,7 @@
     {                                                                                              \
         varid++;                                                                                   \
         err = e3sm_io_scorpio_define_var (                                                         \
-            driver, cfg, dnames, decom,                                                            \
+            driver, cfg, dnames, decom, decomids[i],                                               \
             (decomids[varid - varids] >= 0 ? piodecomid_inv[decomids[varid - varids]] : -1), ncid, \
             name, type, ndims, dimids, varid);                                                     \
         if (err != 0) {                                                                            \
@@ -91,7 +91,7 @@
     }
 #define PUT_ATTR_DECOMP(D, ndims, dimids)                                                        \
     {                                                                                            \
-        if ((cfg.strategy == blob) && false) {                                                              \
+        if ((cfg.strategy == blob) && false) {                                                   \
             err = e3sm_io_scorpio_put_att (driver, ncid, *varid, "decomposition_ID", MPI_INT, 1, \
                                            &D);                                                  \
             CHECK_VAR_ERR (*varid)                                                               \


### PR DESCRIPTION
E3SM decom_id and scorpio decom_id differs.
Use scorpio decom_id only in the output file content.
For E3SM operations, use E3SM decom_id