### PR TITLE
Fix valgrind warnings

### DIFF
--- a/src/cases/e3sm_io_case.hpp
+++ b/src/cases/e3sm_io_case.hpp
@@ -24,8 +24,8 @@ class e3sm_io_case_F : public e3sm_io_case {
    protected:
     double *dbl_buf_h0 = NULL, *dbl_buf_h1 = NULL;
     itype *rec_buf_h0 = NULL, *rec_buf_h1 = NULL;
-    char txt_buf[2][16];
-    int int_buf[2][10];
+    char *txt_buf = NULL;
+    int *int_buf = NULL;
 
    public:
     e3sm_io_case_F ();

--- a/src/cases/e3sm_io_case_F.cpp
+++ b/src/cases/e3sm_io_case_F.cpp
@@ -70,8 +70,8 @@ int e3sm_io_case_F::wr_test(e3sm_io_config &cfg,
             err = run_vard_F_case(cfg, decom, driver,
                                   this->dbl_buf_h0,
                                   this->rec_buf_h0,
-                                  this->txt_buf[0],
-                                  this->int_buf[0]);
+                                  this->txt_buf,
+                                  this->int_buf);
             CHECK_ERR
         }
 
@@ -81,8 +81,8 @@ int e3sm_io_case_F::wr_test(e3sm_io_config &cfg,
             err = run_vard_F_case (cfg, decom, driver,
                                   this->dbl_buf_h0,
                                   this->rec_buf_h0,
-                                  this->txt_buf[0],
-                                  this->int_buf[0]);
+                                  this->txt_buf,
+                                  this->int_buf);
             CHECK_ERR
         }
     } else { /* using PnetCDF/HDF5 varn APIs to write/read */
@@ -128,8 +128,8 @@ int e3sm_io_case_F::rd_test (e3sm_io_config &cfg, e3sm_io_decom &decom, e3sm_io_
             err = run_varn_F_case_rd(cfg, decom, driver,
                                      &(this->dbl_buf_h0),
                                      &(this->rec_buf_h0),
-                                     this->txt_buf[0],
-                                     this->int_buf[0]);
+                                     this->txt_buf,
+                                     this->int_buf);
             CHECK_ERR
         }
         if (cfg.hx == 0 || cfg.hx == -1) {
@@ -139,8 +139,8 @@ int e3sm_io_case_F::rd_test (e3sm_io_config &cfg, e3sm_io_decom &decom, e3sm_io_
             err = run_varn_F_case_rd(cfg, decom, driver,
                                      &(this->dbl_buf_h0),
                                      &(this->rec_buf_h0),
-                                     this->txt_buf[0],
-                                     this->int_buf[0]);
+                                     this->txt_buf,
+                                     this->int_buf);
             CHECK_ERR
         }
     }

--- a/src/cases/e3sm_io_case_F_scorpio.cpp
+++ b/src/cases/e3sm_io_case_F_scorpio.cpp
@@ -37,8 +37,8 @@ int e3sm_io_case_F_scorpio::wr_test(e3sm_io_config &cfg,
             err = run_varn_F_case_scorpio(cfg, decom, driver,
                                           this->dbl_buf_h0,
                                           this->rec_buf_h0,
-                                          this->txt_buf[0],
-                                          this->int_buf[0]);
+                                          this->txt_buf,
+                                          this->int_buf);
             CHECK_ERR
         }
 
@@ -48,8 +48,8 @@ int e3sm_io_case_F_scorpio::wr_test(e3sm_io_config &cfg,
             err = run_varn_F_case_scorpio(cfg, decom, driver,
                                           this->dbl_buf_h0,
                                           this->rec_buf_h0,
-                                          this->txt_buf[0],
-                                          this->int_buf[0]);
+                                          this->txt_buf,
+                                          this->int_buf);
             CHECK_ERR
         }
     }

--- a/src/cases/header_def_F_case_scorpio.cpp
+++ b/src/cases/header_def_F_case_scorpio.cpp
@@ -3434,6 +3434,7 @@ int def_F_case_h1_scorpio (e3sm_io_driver &driver,
             driver.put_att (ncid, scorpiovars[j], "ndims", MPI_INT, 1, decom.ndims + piodecomid[j]);
         CHECK_ERR
 
+        k = 6;
         err = driver.put_att (ncid, scorpiovars[j], "piotype", MPI_INT, 1, &k);
         CHECK_ERR
     }

--- a/src/cases/var_io_G_case_scorpio.cpp
+++ b/src/cases/var_io_G_case_scorpio.cpp
@@ -284,7 +284,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
     MPI_Offset start[2]      = {0, 0};
     MPI_Offset count[2]      = {1, 1};
     double *dummy_double_buf = NULL;
-    char dummy_char_buf[64];
+    char dummy_char_buf[64 + 64];
     int xnreqs[6]; /* number of requests after combination */
     MPI_Offset previous_size;
     std::vector<int> decomids;
@@ -305,7 +305,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
     /* number of variable elements from 6 decompositions */
     my_nreqs = 0;
     for (i = 0; i < 6; i++) {
-        for (nelems[i] = 0, k = 0; k < xnreqs[i]; k++) nelems[i] += decom.blocklens[i][k];
+        nelems[i] = decom.raw_nreqs[i];
     }
 
     if (cfg.verbose && rank == 0)
@@ -438,7 +438,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D1_fix_dbl_bufp != NULL) {
             D1_fix_dbl_buf = D1_fix_dbl_bufp;
         } else {
-            D1_fix_dbl_buf = (double *)malloc (nelems[0] * sizeof (double) + 64);
+            D1_fix_dbl_buf = (double *)malloc (nelems[0] * sizeof (double));
             for (ii = 0; ii < nelems[0]; ii++) D1_fix_dbl_buf[ii] = rank + ii;
         }
     } else
@@ -461,7 +461,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D3_rec_dbl_bufp != NULL) {
             D3_rec_dbl_buf = D3_rec_dbl_bufp;
         } else {
-            D3_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double) + 64);
+            D3_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double));
             for (ii = 0; ii < rec_buflen; ii++) D3_rec_dbl_buf[ii] = rank + ii;
         }
     } else
@@ -472,7 +472,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D4_rec_dbl_bufp != NULL) {
             D4_rec_dbl_buf = D4_rec_dbl_bufp;
         } else {
-            D4_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double) + 64);
+            D4_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double));
             for (ii = 0; ii < rec_buflen; ii++) D4_rec_dbl_buf[ii] = rank + ii;
         }
     } else
@@ -483,7 +483,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D5_rec_dbl_bufp != NULL) {
             D5_rec_dbl_buf = D5_rec_dbl_bufp;
         } else {
-            D5_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double) + 64);
+            D5_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double));
             for (ii = 0; ii < rec_buflen; ii++) D5_rec_dbl_buf[ii] = rank + ii;
         }
     } else
@@ -494,16 +494,16 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         if (D6_rec_dbl_bufp != NULL) {
             D6_rec_dbl_buf = D6_rec_dbl_bufp;
         } else {
-            D6_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double) + 64);
+            D6_rec_dbl_buf = (double *)malloc (rec_buflen * sizeof (double));
             for (ii = 0; ii < rec_buflen; ii++) D6_rec_dbl_buf[ii] = rank + ii;
         }
     } else
         D6_rec_dbl_buf = NULL;
 
     /* initialize write buffer for 11 small variables */
-    dummy_double_buf = (double *)malloc (decom.dims[2][1] * sizeof (double));
-    for (i = 0; i < decom.dims[2][1]; i++) dummy_double_buf[i] = rank + i;
-    for (i = 0; i < 64; i++) dummy_char_buf[i] = 'a' + rank + i;
+    dummy_double_buf = (double *)malloc ((decom.dims[2][1] + 8) * sizeof (double));
+    for (i = 0; i < decom.dims[2][1] + 8; i++) dummy_double_buf[i] = rank + i;
+    for (i = 0; i < 64 + 64; i++) dummy_char_buf[i] = 'a' + rank + i;
 
     varids = (e3sm_io_scorpio_var *)malloc (cfg.nvars * sizeof (e3sm_io_scorpio_var));
     decomids.resize (cfg.nvars);


### PR DESCRIPTION
Data buffer size of scorpio test differs from canonical test.
Fix an uninitialized variable.