### PR TITLE
Changes required to compile on summit with OpenMPI

### DIFF
--- a/src/cases/e3sm_io_case_F.cpp
+++ b/src/cases/e3sm_io_case_F.cpp
@@ -9,9 +9,10 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
-
+//
 #include <assert.h>
-
+#include <stdlib.h>
+//
 #include <e3sm_io.h>
 #include <e3sm_io_err.h>
 #include <e3sm_io_case.hpp>

--- a/src/cases/e3sm_io_case_G.cpp
+++ b/src/cases/e3sm_io_case_G.cpp
@@ -9,9 +9,10 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
-
+//
 #include <assert.h>
-
+#include <stdlib.h>
+//
 #include <e3sm_io.h>
 #include <e3sm_io_err.h>
 #include <e3sm_io_case.hpp>

--- a/src/drivers/blob_ncmpio.c
+++ b/src/drivers/blob_ncmpio.c
@@ -34,7 +34,7 @@ static const char ncmagic5[] = {'C', 'D', 'F', 0x05};
 static const char nada[X_ALIGN] = {0, 0, 0, 0};
 
 static int
-ncmpii_xlen_nc_type(nc_type xtype, int *size)
+ncmpii_xlen_nc_type(MPI_Datatype xtype, int *size)
 {
     switch(xtype) {
         case MPI_BYTE:
@@ -859,7 +859,7 @@ ncmpio_new_NC_var(const char *name, int ndims)
 
 int blob_ncmpio_add_var(NC         *ncp,
                         const char *name,
-                        nc_type     xtype,
+                        MPI_Datatype     xtype,
                         int         ndims,
                         int        *dimids,
                         int        *varidp)
@@ -932,7 +932,7 @@ int blob_ncmpio_add_dim(NC         *ncp,
 }
 
 static MPI_Offset
-x_len_NC_attrV(nc_type    xtype,
+x_len_NC_attrV(MPI_Datatype    xtype,
                MPI_Offset nelems)
 {
     switch(xtype) {
@@ -953,7 +953,7 @@ x_len_NC_attrV(nc_type    xtype,
 
 static int
 ncmpio_new_NC_attr(const char  *name,
-                        nc_type      xtype,
+                        MPI_Datatype      xtype,
                         MPI_Offset   nelems,
                         NC_attr    **attrp)
 {
@@ -1009,7 +1009,7 @@ ncmpio_NC_findattr(const NC_attrarray *ncap,
 int blob_ncmpio_put_att(NC         *ncp,
                         int         varid,
                         const char *name,
-                        nc_type     xtype,
+                        MPI_Datatype     xtype,
                         MPI_Offset  nelems,
                         const void *buf)
 {
@@ -1070,7 +1070,7 @@ int blob_ncmpio_get_att(NC         *ncp,
     int indx=0, err=NC_NOERR;
     NC_attrarray *ncap=NULL;
     NC_attr *attrp=NULL;
-    nc_type xtype;
+    MPI_Datatype xtype;
 
     if (buf == NULL) return -1;
 

--- a/src/drivers/blob_ncmpio.c
+++ b/src/drivers/blob_ncmpio.c
@@ -936,19 +936,20 @@ static MPI_Offset
 x_len_NC_attrV(MPI_Datatype    xtype,
                MPI_Offset nelems)
 {
-    switch(xtype) {
-        case MPI_BYTE:
-        case MPI_CHAR:  return _RNDUP(nelems, 4);
-        case MPI_SHORT:
-        case MPI_UNSIGNED_SHORT: return ((nelems + nelems%2) * 2);
-        case MPI_INT:
-        case MPI_UNSIGNED:
-        case MPI_FLOAT:  return (nelems * 4);
-        case MPI_DOUBLE:
-        case MPI_LONG_LONG:
-        case MPI_UNSIGNED_LONG_LONG: return (nelems * 8);
-        default: fprintf(stderr, "Error: bad type(%d) in %s\n",xtype,__func__);
+    if ((xtype == MPI_BYTE) || (xtype == MPI_CHAR)) {
+        return _RNDUP(nelems, 4);
     }
+    else if ((xtype == MPI_SHORT) || (xtype == MPI_UNSIGNED_SHORT)) {
+        return ((nelems + nelems%2) * 2);
+    }
+    else if ((xtype == MPI_INT) || (xtype == MPI_UNSIGNED) || (xtype == MPI_FLOAT)) {
+        return (nelems * 4);
+    }
+    else if ((xtype == MPI_DOUBLE) || (xtype == MPI_LONG_LONG) || (xtype == MPI_UNSIGNED_LONG_LONG)) {
+        return (nelems * 8);
+    }
+
+    fprintf(stderr, "Error: bad type(%d) in %s\n",xtype,__func__);
     return 0;
 }
 

--- a/src/drivers/blob_ncmpio.c
+++ b/src/drivers/blob_ncmpio.c
@@ -36,19 +36,20 @@ static const char nada[X_ALIGN] = {0, 0, 0, 0};
 static int
 ncmpii_xlen_nc_type(MPI_Datatype xtype, int *size)
 {
-    switch(xtype) {
-        case MPI_BYTE:
-        case MPI_CHAR:              *size = 1; return NC_NOERR;
-        case MPI_SHORT:
-        case MPI_UNSIGNED_SHORT:    *size = 2; return NC_NOERR;
-        case MPI_INT:
-        case MPI_UNSIGNED:
-        case MPI_FLOAT:              *size = 4; return NC_NOERR;
-        case MPI_DOUBLE:
-        case MPI_LONG_LONG:
-        case MPI_UNSIGNED_LONG_LONG: *size = 8; return NC_NOERR;
-        default: return 0;
+    if ((xtype == MPI_BYTE) || (xtype == MPI_CHAR)) {
+        *size = 1; return NC_NOERR;
     }
+    else if ((xtype == MPI_SHORT) || (xtype == MPI_UNSIGNED_SHORT)) {
+        *size = 2; return NC_NOERR;
+    }
+    else if ((xtype == MPI_INT) || (xtype == MPI_UNSIGNED) || (xtype == MPI_FLOAT)) {
+        *size = 4; return NC_NOERR;
+    }
+    else if ((xtype == MPI_DOUBLE) || (xtype == MPI_LONG_LONG) || (xtype == MPI_UNSIGNED_LONG_LONG)) {
+        *size = 8; return NC_NOERR;
+    }
+
+    return 0;
 }
 
 /*----< hdr_len_NC_dim() >---------------------------------------------------*/

--- a/src/drivers/blob_ncmpio.h
+++ b/src/drivers/blob_ncmpio.h
@@ -23,7 +23,6 @@
 extern "C" {
 #endif
 
-typedef MPI_Datatype nc_type;
 #define NC_NOERR 0
 #define NC_UNLIMITED 0L
 #define NC_GLOBAL -1
@@ -132,7 +131,7 @@ typedef struct NC_dimarray {
 typedef struct {
     MPI_Offset nelems;   /* number of attribute elements */
     MPI_Offset xsz;      /* amount of space at xvalue (4-byte aligned) */
-    nc_type    xtype;    /* external NC data type of the attribute */
+    MPI_Datatype    xtype;    /* external NC data type of the attribute */
     size_t     name_len; /* strlen(name) for faster string compare */
     char      *name;     /* name of the attributes */
     void      *xvalue;   /* the actual data, in external representation */
@@ -149,7 +148,7 @@ typedef struct {
 typedef struct {
     int           varid;   /* variable ID */
     int           xsz;     /* byte size of 1 array element */
-    nc_type       xtype;   /* variable's external NC data type */
+    MPI_Datatype       xtype;   /* variable's external NC data type */
     int           no_fill; /* whether fill mode is disabled */
     size_t        name_len;/* strlen(name) for faster string compare */
     char         *name;    /* name of the variable */
@@ -198,12 +197,12 @@ typedef struct {
 
 extern int blob_ncmpio_create_NC(NC *ncp);
 extern int blob_ncmpio_free_NC(NC *ncp);
-extern int blob_ncmpio_add_var(NC *ncp, const char *name, nc_type xtype,
+extern int blob_ncmpio_add_var(NC *ncp, const char *name, MPI_Datatype xtype,
                                int ndims, int *dimids, int *varidp);
 extern int blob_ncmpio_add_dim(NC *ncp, const char *name, MPI_Offset size,
                                int *dimidp);
 extern int blob_ncmpio_put_att(NC *ncp, int varid, const char *name,
-                               nc_type xtype, MPI_Offset nelems,
+                               MPI_Datatype xtype, MPI_Offset nelems,
                                const void *buf);
 extern int blob_ncmpio_get_att(NC *ncp, int varid, const char *name, void *buf);
 extern int blob_ncmpio_pack_NC(NC *ncp, size_t *buf_len, void **buf);

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -19,26 +19,31 @@
 
 #include <e3sm_io_driver.hpp>
 
-inline adios2_type mpi_type_to_adios2_type (MPI_Datatype mpitype) {
-    switch (mpitype) {
-        case MPI_INT:
-            return adios2_type_int32_t;
-        case MPI_FLOAT:
-            return adios2_type_float;
-        case MPI_DOUBLE:
-            return adios2_type_double;
-        case MPI_LONG_LONG:
-            return adios2_type_int64_t;
-        case MPI_CHAR:
-            return adios2_type_int8_t;
-        case MPI_WCHAR:
-            return adios2_type_string;
-        case MPI_BYTE:
-            return adios2_type_uint8_t;
-        default:
-            printf ("Error at line %d in %s: Unknown type %d\n", __LINE__, __FILE__, mpitype);
-            DEBUG_ABORT
+inline adios2_type mpi_type_to_adios2_type (MPI_Datatype type) {
+    if (type == MPI_DOUBLE){
+        return adios2_type_double;
     }
+    else if (type == MPI_FLOAT){
+        return adios2_type_float;
+    }
+    else if (type == MPI_INT){
+        return adios2_type_int32_t;
+    }
+    else if (type == MPI_LONG_LONG){
+        return adios2_type_int64_t;
+    }
+    else if (type == MPI_CHAR){
+        return adios2_type_int8_t;
+    }
+    else if (type == MPI_WCHAR){
+        return adios2_type_string;
+    }
+    else if (type == MPI_BYTE){
+        return adios2_type_uint8_t;
+    }
+
+    printf ("Error at line %d in %s: Unknown type %d\n", __LINE__, __FILE__, type);
+    DEBUG_ABORT
 
     return adios2_type_unknown;
 }

--- a/src/drivers/e3sm_io_driver_h5blob.cpp
+++ b/src/drivers/e3sm_io_driver_h5blob.cpp
@@ -337,7 +337,7 @@ int e3sm_io_driver_h5blob::inq_rec_size (int fid, MPI_Offset *size) {
 
 int e3sm_io_driver_h5blob::def_var(int          fid,
                                    std::string  name,
-                                   nc_type      xtype,
+                                   MPI_Datatype      xtype,
                                    int          ndims,
                                    int         *dimids,
                                    int         *varidp)
@@ -427,7 +427,7 @@ int e3sm_io_driver_h5blob::wait (int fid) { return 0; }
 int e3sm_io_driver_h5blob::put_att(int          fid,
                                    int          varid,
                                    std::string  name,
-                                   nc_type      xtype,
+                                   MPI_Datatype      xtype,
                                    MPI_Offset   nelems,
                                    const void  *buf)
 {

--- a/src/drivers/e3sm_io_driver_h5blob.cpp
+++ b/src/drivers/e3sm_io_driver_h5blob.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include <cstring>
+#include <cstdlib>
 #include <sys/stat.h>
 #include <assert.h>
 

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -11,6 +11,7 @@
 #endif
 //
 #include <cstring>
+#include <cstdlib>
 //
 #include <sys/stat.h>
 //

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -50,7 +50,7 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
 #endif
         std::vector<H5D_rw_multi_t> multi_datasets;
 
-        std::vector<std::vector<e3sm_io_driver_hdf5::Index_order>> dataset_segments;
+        std::vector<std::vector<e3sm_io_driver_hdf5::Index_order> > dataset_segments;
 
         std::vector<hid_t> memspace_recycle;
         std::vector<hid_t> dataspace_recycle;

--- a/src/drivers/e3sm_io_driver_hdf5_agg.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_agg.cpp
@@ -11,6 +11,7 @@
 #endif
 //
 #include <cstring>
+#include <cstdlib>
 //
 #include <sys/stat.h>
 //

--- a/src/drivers/e3sm_io_driver_hdf5_int.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5_int.hpp
@@ -59,21 +59,24 @@ static inline hid_t nc_type_to_hdf5_type (nc_type nctype) {
     return -1;
 }
 
-static inline hid_t mpi_type_to_hdf5_type (MPI_Datatype mpitype) {
-    switch (mpitype) {
-        case MPI_INT:
-            return H5T_NATIVE_INT;
-        case MPI_FLOAT:
-            return H5T_NATIVE_FLOAT;
-        case MPI_DOUBLE:
-            return H5T_NATIVE_DOUBLE;
-        case MPI_CHAR:
-            return H5T_NATIVE_CHAR;
-        case MPI_BYTE:
-            return H5T_NATIVE_UINT8;
-        default:
-            printf ("Error at line %d in %s: Unknown type %d\n", __LINE__, __FILE__, mpitype);
-            DEBUG_ABORT
+static inline hid_t mpi_type_to_hdf5_type (MPI_Datatype type) {
+    if (type == MPI_DOUBLE){
+        return H5T_NATIVE_DOUBLE;
+    }
+    else if (type == MPI_FLOAT){
+        return H5T_NATIVE_FLOAT;
+    }
+    else if (type == MPI_INT){
+        return H5T_NATIVE_INT;
+    }
+    else if (type == MPI_LONG_LONG){
+        return H5T_NATIVE_INT64;
+    }
+    else if (type == MPI_CHAR){
+        return H5T_NATIVE_CHAR;
+    }
+    else if (type == MPI_BYTE){
+        return H5T_NATIVE_UINT8;
     }
 
     return -1;

--- a/src/drivers/e3sm_io_driver_pnc.hpp
+++ b/src/drivers/e3sm_io_driver_pnc.hpp
@@ -19,22 +19,26 @@
 #include <e3sm_io_driver.hpp>
 
 inline nc_type mpitype2nctype (MPI_Datatype type) {
-    switch (type) {
-        case MPI_DOUBLE:
-            return NC_DOUBLE;
-        case MPI_FLOAT:
-            return NC_FLOAT;
-        case MPI_INT:
-            return NC_INT;
-        case MPI_LONG_LONG:
-            return NC_INT64;
-        case MPI_CHAR:
-            return NC_CHAR;
-        case MPI_BYTE:
-            return NC_BYTE;
-        default:
-            throw "Unsupported datatype";
+    if (type == MPI_DOUBLE){
+        return NC_DOUBLE;
     }
+    else if (type == MPI_FLOAT){
+        return NC_FLOAT;
+    }
+    else if (type == MPI_INT){
+        return NC_INT;
+    }
+    else if (type == MPI_LONG_LONG){
+        return NC_INT64;
+    }
+    else if (type == MPI_CHAR){
+        return NC_CHAR;
+    }
+    else if (type == MPI_BYTE){
+        return NC_BYTE;
+    }
+
+    throw "Unsupported datatype";
 }
 
 class e3sm_io_driver_pnc : public e3sm_io_driver {


### PR DESCRIPTION
Replace switches with if on MPI type
Separate nc_type (int) with MPI type (can be struct)
Include missing headers
Add a space to nested c++ templates. 