### PR TITLE
Convert data type in ADIOS driver variable operations

### DIFF
--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -225,10 +225,16 @@ inline int e3sm_io_scorpio_write_var (e3sm_io_driver &driver,
         memcpy((char*)buf + var.ndim * sizeof(int64_t), var.bsize, var.ndim * sizeof(int64_t));
     }
 
+    // Small variables are stored as byte array
+    if ((var.frame_id < 0) && var.ndim){
+        itype = MPI_BYTE;
+    }
+
     err = driver.put_varl (fid, var.data, itype, buf, nbe);
     CHECK_ERR
 
     if (var.frame_id >= 0) {
+
         err = driver.put_varl (fid, var.frame_id, MPI_INT, &frameid, nbe);
         CHECK_ERR
 

--- a/src/cases/var_io_G_case_scorpio.cpp
+++ b/src/cases/var_io_G_case_scorpio.cpp
@@ -599,7 +599,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
     
     // Nproc only written by rank 0
     if (rank == 0) {
-        err = driver.put_varl (ncid, scorpiovars[6], MPI_LONG_LONG, &(cfg.np), nb);
+        err = driver.put_varl (ncid, scorpiovars[6], MPI_INT, &(cfg.np), nb);
         CHECK_ERR
     }
 


### PR DESCRIPTION
Convert between float and double if memory type doesn't match variable type on put and get.