### PR TITLE
Fix a bug in scorpio test cases when some process have nothing to write

### DIFF
--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -141,8 +141,8 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
             err = driver.inq_dimlen (fid, dimids[i], &(dsize[j]));
             CHECK_ERR
 
-            // Skip time dim
-            if (dsize[j] > 0) { j++; }
+            // Time dim is always 0, but block size should be 1
+            if (dsize[j] == 0) { dsize[j] = 1; }
         }
 
         // flatten into 1 dim only apply to non-scalar variables
@@ -151,13 +151,9 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
             var->ndim = ndim;
             for (i = 0; i < ndim; i++) { 
                 var->bsize[i] = dsize[ndim - i - 1]; 
-                // Time dim is always 0, but block size should be 1
-                if (var->bsize[i] == 0){
-                    var->bsize[i] = 1;
-                }
             }
             // Convert into byte array
-            for (i = 0; i < j; i++) { vsize *= dsize[i]; }
+            for (i = 0; i < ndim; i++) { vsize *= dsize[i]; }
             err = e3sm_io_xlen_nc_type(xtype, &esize);
             CHECK_MPIERR
             vsize *= esize;

--- a/src/cases/var_io_G_case_scorpio.cpp
+++ b/src/cases/var_io_G_case_scorpio.cpp
@@ -376,7 +376,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
 
     /* allocate and initialize write buffer for 7 fixed-size variables */
     /* int (nCells): maxLevelCell */
-    if (nelems[0] > 0) {
+    if (nelems[0] + 64 > 0) {
         if (D1_fix_int_bufp != NULL) {
             D1_fix_int_buf = D1_fix_int_bufp;
         } else {
@@ -387,7 +387,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         D1_fix_int_buf = NULL;
 
     /* int (nEdges): maxLevelEdgeTop and maxLevelEdgeBot */
-    if (nelems[1] > 0) {
+    if (nelems[1] + 64 > 0) {
         if (D2_fix_int_bufp != NULL) {
             D2_fix_int_buf = D2_fix_int_bufp;
         } else {
@@ -398,7 +398,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         D2_fix_int_buf = NULL;
 
     /* int (nCells, nVertLevels): cellMask */
-    if (nelems[2] > 0) {
+    if (nelems[2] + 64 > 0) {
         if (D3_fix_int_bufp != NULL) {
             D3_fix_int_buf = D3_fix_int_bufp;
         } else {
@@ -409,7 +409,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         D3_fix_int_buf = NULL;
 
     /* int (nEdges, nVertLevels): edgeMask */
-    if (nelems[3] > 0) {
+    if (nelems[3] + 64 > 0) {
         if (D4_fix_int_bufp != NULL) {
             D4_fix_int_buf = D4_fix_int_bufp;
         } else {
@@ -420,7 +420,7 @@ int run_varn_G_case_scorpio (e3sm_io_config &cfg,
         D4_fix_int_buf = NULL;
 
     /* int (nVertices, nVertLevels): vertexMask */
-    if (nelems[4] > 0) {
+    if (nelems[4] + 64 > 0) {
         if (D5_fix_int_bufp != NULL) {
             D5_fix_int_buf = D5_fix_int_bufp;
         } else {

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -378,7 +378,9 @@ int e3sm_io_driver_adios2::def_local_var (
     for (i = 0; i < ndim; i++) {
         dims[i] = (size_t)dsize[i];
         // Unlimited dimension is simulated by timesteps
-        if (dims[i] == NC_UNLIMITED) { dims[i] = 1; }
+        if (dims[i] == -1) { 
+            dims[i] = 1; 
+        }
     }
 
     if (dtype == adios2_type_string) {


### PR DESCRIPTION
use -1 in place of NC_UNLIMITED as the value 0 collide with processes that has no data to write.
The count along with the record dimension should be 1.