### PR TITLE
Bug fix in HDF5 driver

### DIFF
--- a/src/drivers/Makefile.am
+++ b/src/drivers/Makefile.am
@@ -20,16 +20,13 @@ H_SRCS = e3sm_io_driver.hpp \
 if ENABLE_HDF5
 C_SRCS +=   e3sm_io_driver_hdf5.cpp \
             e3sm_io_driver_h5blob.cpp \
+            e3sm_io_driver_hdf5_agg.cpp \
             blob_ncmpio.c
 
 H_SRCS +=   e3sm_io_driver_hdf5.hpp \
             e3sm_io_driver_h5blob.hpp \
+            e3sm_io_driver_hdf5_int.hpp \ 
             blob_ncmpio.h
-
-if HDF5_HAVE_DWRITE_MULTI
-C_SRCS +=   e3sm_io_driver_hdf5_agg.cpp
-H_SRCS +=   e3sm_io_driver_hdf5_int.hpp
-endif
 endif
 
 if ENABLE_ADIOS2

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -87,6 +87,10 @@ e3sm_io_driver_hdf5::e3sm_io_driver_hdf5 (e3sm_io_config *cfg) : e3sm_io_driver 
         throw "The HDF5 used does not support multi-dataset write";
 #endif
     }
+#ifdef E3SM_IO_DEBUG
+    else if (cfg->api == hdf5_ra) {  
+    }
+#endif
 
     if ((cfg->chunksize != 0) && (cfg->filter != none)) {
         throw "Fitler requries chunking in HDF5";

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -492,10 +492,10 @@ int e3sm_io_driver_hdf5::wait (int fid) {
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
 
-#ifdef HDF5_HAVE_DWRITE_MULTI
+// #ifdef HDF5_HAVE_DWRITE_MULTI
     err = fp->flush_multidatasets ();
     CHECK_ERR
-#endif
+// #endif
 
     herr = H5Fflush (fp->id, H5F_SCOPE_GLOBAL);
     CHECK_HERR
@@ -722,14 +722,14 @@ int e3sm_io_driver_hdf5::put_vara (int fid,
         herr = H5Dwrite (did, h5_itype, msid, dsid, dxplid, buf);
         CHECK_HERR
     }
-#ifdef HDF5_HAVE_DWRITE_MULTI
+// #ifdef HDF5_HAVE_DWRITE_MULTI
     else {  // Otherwier, queue request in driver
         herr = fp->register_multidataset (buf, did, dsid, msid, h5_itype, 1);
         CHECK_HERR
         // Prevent freeing of dsid and msid, they will be freed after flush
         dsid = msid = -1;
     }
-#endif
+// #endif
 
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5_WR)
 
@@ -857,14 +857,14 @@ int e3sm_io_driver_hdf5::put_vars (int fid,
         herr = H5Dwrite (did, h5_itype, msid, dsid, dxplid, buf);
         CHECK_HERR
     }
-#ifdef HDF5_HAVE_DWRITE_MULTI
+// #ifdef HDF5_HAVE_DWRITE_MULTI
     else {  // Otherwier, queue request in driver
         herr = fp->register_multidataset (buf, did, dsid, msid, h5_itype, 1);
         CHECK_HERR
         // Prevent freeing of dsid and msid, they will be freed after flush
         dsid = msid = -1;
     }
-#endif
+// #endif
 
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5_WR)
 
@@ -894,11 +894,11 @@ int e3sm_io_driver_hdf5::put_varn (int fid,
                                    MPI_Offset **counts,
                                    void *buf,
                                    e3sm_io_op_mode mode) {
-#ifdef HDF5_HAVE_DWRITE_MULTI
+// #ifdef HDF5_HAVE_DWRITE_MULTI
     if (this->merge_varn)
         return this->put_varn_merge (fid, vid, itype, nreq, starts, counts, buf, mode);
     else
-#endif
+// #endif
         return this->put_varn_expand (fid, vid, itype, nreq, starts, counts, buf, mode);
 }
 int e3sm_io_driver_hdf5::put_varn_expand (int fid,
@@ -1055,14 +1055,14 @@ int e3sm_io_driver_hdf5::put_varn_expand (int fid,
                     herr = H5Dwrite (did, mtype, msid, dsid, dxplid, bufp);
                     CHECK_HERR
                 }
-#ifdef HDF5_HAVE_DWRITE_MULTI
+// #ifdef HDF5_HAVE_DWRITE_MULTI
                 else {  // Otherwier, queue request in driver
                     herr = fp->register_multidataset (bufp, did, dsid, msid, mtype, 1);
                     CHECK_HERR
                     // Prevent freeing of dsid and msid, they will be freed after flush
                     dsid = msid = -1;
                 }
-#endif
+// #endif
                 E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5_WR)
 
                 bufp += rsize;
@@ -1194,14 +1194,14 @@ int e3sm_io_driver_hdf5::get_vara (int fid,
         herr = H5Dread (did, h5_itype, msid, dsid, dxplid, buf);
         CHECK_HERR
     }
-#ifdef HDF5_HAVE_DWRITE_MULTI
+// #ifdef HDF5_HAVE_DWRITE_MULTI
     else {  // Otherwier, queue request in driver
         herr = fp->register_multidataset (buf, did, dsid, msid, h5_itype, 0);
         CHECK_HERR
         // Prevent freeing of dsid and msid, they will be freed after flush
         dsid = msid = -1;
     }
-#endif
+// #endif
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5_RD)
 
     tid     = H5Dget_type (did);
@@ -1308,14 +1308,14 @@ int e3sm_io_driver_hdf5::get_vars (int fid,
         herr = H5Dread (did, h5_itype, msid, dsid, dxplid, buf);
         CHECK_HERR
     }
-#ifdef HDF5_HAVE_DWRITE_MULTI
+// #ifdef HDF5_HAVE_DWRITE_MULTI
     else {  // Otherwier, queue request in driver
         herr = fp->register_multidataset (buf, did, dsid, msid, h5_itype, 0);
         CHECK_HERR
         // Prevent freeing of dsid and msid, they will be freed after flush
         dsid = msid = -1;
     }
-#endif
+// #endif
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5_RD)
 
     tid     = H5Dget_type (did);
@@ -1345,11 +1345,11 @@ int e3sm_io_driver_hdf5::get_varn (int fid,
                                    MPI_Offset **counts,
                                    void *buf,
                                    e3sm_io_op_mode mode) {
-#ifdef HDF5_HAVE_DWRITE_MULTI
+// #ifdef HDF5_HAVE_DWRITE_MULTI
     if (this->merge_varn)
         return this->get_varn_merge (fid, vid, itype, nreq, starts, counts, buf, mode);
     else
-#endif
+// #endif
         return this->get_varn_expand (fid, vid, itype, nreq, starts, counts, buf, mode);
 }
 int e3sm_io_driver_hdf5::get_varn_expand (int fid,
@@ -1484,14 +1484,14 @@ int e3sm_io_driver_hdf5::get_varn_expand (int fid,
                     herr = H5Dread (did, mtype, msid, dsid, dxplid, bufp);
                     CHECK_HERR
                 }
-#ifdef HDF5_HAVE_DWRITE_MULTI
+// #ifdef HDF5_HAVE_DWRITE_MULTI
                 else {  // Otherwier, queue request in driver
                     herr = fp->register_multidataset (bufp, did, dsid, msid, mtype, 0);
                     CHECK_HERR
                     // Prevent freeing of dsid and msid, they will be freed after flush
                     dsid = msid = -1;
                 }
-#endif
+// #endif
                 E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5_RD)
 
                 bufp += rsize;

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -31,6 +31,9 @@ e3sm_io_driver_hdf5::e3sm_io_driver_hdf5 (e3sm_io_config *cfg) : e3sm_io_driver 
     int err = 0;
     herr_t herr = 0;
     int i;
+#ifdef ENABLE_LOGVOL
+        char *env;
+#endif
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
 
@@ -921,6 +924,9 @@ int e3sm_io_driver_hdf5::put_varn_expand (int fid,
     hsize_t start[E3SM_IO_DRIVER_MAX_RANK], block[E3SM_IO_DRIVER_MAX_RANK];
     hsize_t dims[E3SM_IO_DRIVER_MAX_RANK], mdims[E3SM_IO_DRIVER_MAX_RANK];
     hid_t tid = -1;
+#ifdef ENABLE_LOGVOL
+    hsize_t **hstarts = NULL, **hcounts;
+#endif
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
 
@@ -1370,6 +1376,9 @@ int e3sm_io_driver_hdf5::get_varn_expand (int fid,
     hid_t tid = -1;
     MPI_Offset getsize;
     MPI_Offset **count;
+#ifdef ENABLE_LOGVOL
+    hsize_t **hstarts = NULL, **hcounts;
+#endif
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
 

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -59,12 +59,12 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
 
         hdf5_file (e3sm_io_driver_hdf5 &x) : driver (x) {};
 
-#ifdef HDF5_HAVE_DWRITE_MULTI
+// #ifdef HDF5_HAVE_DWRITE_MULTI
         herr_t register_multidataset (
             void *buf, hid_t did, hid_t dsid, hid_t msid, hid_t mtype, int write);
         herr_t pull_multidatasets ();
         int flush_multidatasets ();
-#endif
+// #endif
     };
 
     std::vector<hdf5_file *> files;

--- a/src/drivers/e3sm_io_driver_hdf5_agg.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_agg.cpp
@@ -243,6 +243,7 @@ int e3sm_io_driver_hdf5::hdf5_file::flush_multidatasets () {
         CHECK_HERR
 
         if (!rank) {
+            uint32_t local_no_collective_cause, global_no_collective_cause;
             H5Pget_mpio_no_collective_cause (this->driver.dxplid_coll, &local_no_collective_cause,
                                              &global_no_collective_cause);
             print_no_collective_cause (local_no_collective_cause, global_no_collective_cause);
@@ -305,6 +306,7 @@ herr_t e3sm_io_driver_hdf5::hdf5_file::pull_multidatasets () {
                  driver.dxplid_coll, multi_datasets[i].u.rbuf);
 
         if (!rank) {
+            uint32_t local_no_collective_cause, global_no_collective_cause;
             H5Pget_mpio_no_collective_cause (this->driver.dxplid_coll, &local_no_collective_cause,
                                              &global_no_collective_cause);
             print_no_collective_cause (local_no_collective_cause, global_no_collective_cause);

--- a/src/drivers/e3sm_io_driver_hdf5_agg.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_agg.cpp
@@ -360,6 +360,8 @@ herr_t e3sm_io_driver_hdf5::hdf5_file::pull_multidatasets () {
     return 0;
 }
 
+// TODO: Fix bug of not extending the datasets when needed
+// This function was not in use for now
 int e3sm_io_driver_hdf5::put_varn_merge (int fid,
                                          int vid,
                                          MPI_Datatype type,
@@ -537,6 +539,8 @@ err_out:
     return err;
 }
 
+// TODO: Fix bug of not extending the datasets when needed
+// This function was not in use for now
 int e3sm_io_driver_hdf5::get_varn_merge (int fid,
                                          int vid,
                                          MPI_Datatype type,

--- a/src/drivers/e3sm_io_driver_hdf5_agg.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_agg.cpp
@@ -525,7 +525,7 @@ int e3sm_io_driver_hdf5::put_varn_merge (int fid,
     tid     = H5Dget_type (did);
     putsize = H5Tget_size (tid);
     for (count = counts; count < counts + nreq; count++) {
-        for (i = 0; i < ndim; i++) { putsize *= *count[i]; }
+        for (i = 0; i < ndim; i++) { putsize *= (*count)[i]; }
     }
     fp->putsize += putsize;
 
@@ -656,7 +656,7 @@ int e3sm_io_driver_hdf5::get_varn_merge (int fid,
     tid     = H5Dget_type (did);
     getsize = H5Tget_size (tid);
     for (count = counts; count < counts + nreq; count++) {
-        for (i = 0; i < ndim; i++) { getsize *= *count[i]; }
+        for (i = 0; i < ndim; i++) { getsize *= (*count)[i]; }
     }
     fp->getsize += getsize;
 

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -188,6 +188,11 @@ int main (int argc, char **argv) {
                     cfg.api = hdf5_log;
                 else if (strcmp (optarg, "adios") == 0)
                     cfg.api = adios;
+#ifdef E3SM_IO_DEBUG
+                /* For debug purpose only */
+                else if (strcmp (optarg, "hdf5_ra") == 0)
+                    cfg.api = hdf5_ra;
+#endif
                 else
                     ERR_OUT ("Unknown API")
                 break;
@@ -290,6 +295,18 @@ int main (int argc, char **argv) {
         else if (cfg.strategy == blob)
             ERR_OUT ("HDF5 multi-dataset with blob I/O strategy is not supported yet")
     }
+
+#ifdef E3SM_IO_DEBUG
+    /* For debug purpose only */
+    if (cfg.api == hdf5_ra) {
+        if (cfg.strategy == undef_io)
+            cfg.strategy = canonical;
+        else if (cfg.strategy == log)
+            ERR_OUT ("HDF5 multi-dataset with log I/O strategy is not supported yet")
+        else if (cfg.strategy == blob)
+            ERR_OUT ("HDF5 multi-dataset with blob I/O strategy is not supported yet")
+    }
+#endif
 
     if (cfg.api == hdf5_log) {
 #ifndef ENABLE_LOGVOL

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -72,6 +72,7 @@ typedef enum e3sm_io_api {
     pnetcdf,
     hdf5,
     hdf5_md,
+    hdf5_ra,
     hdf5_log,
     adios,
     undef_api

--- a/src/e3sm_io_core.cpp
+++ b/src/e3sm_io_core.cpp
@@ -156,6 +156,9 @@ done_check:
             ERR_OUT ("HDF5 support was not enabled in this build")
 #endif
             break;
+#ifdef E3SM_IO_DEBUG
+        case hdf5_ra:
+#endif
         case hdf5_md:
         case hdf5_log:
 #ifdef ENABLE_HDF5


### PR DESCRIPTION
Solve compile error related to undefined variables when using HDF5 without multi-dataset support.
When building for debug, allow hdf5_ra API option for debugging purpose.
Fix early free of data spaces in non-blocking I/O.