### PR TITLE
Bug fix in scorpio wrapper and adios2 driver

### DIFF
--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -64,7 +64,7 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
                                    int *dimids,
                                    e3sm_io_scorpio_var *var) {
     int err, nerrs = 0;
-    int i, j;
+    int i;
     char cbuf[64];
     int ibuf;
     std::vector<const char*> dnames_array (ndim);
@@ -137,12 +137,12 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
         MPI_Offset vsize = 1;
         int esize;
 
-        for (i = j = 0; i < ndim; i++) {
-            err = driver.inq_dimlen (fid, dimids[i], &(dsize[j]));
+        for (i = 0; i < ndim; i++) {
+            err = driver.inq_dimlen (fid, dimids[i], &(dsize[i]));
             CHECK_ERR
 
             // Time dim is always 0, but block size should be 1
-            if (dsize[j] == 0) { dsize[j] = 1; }
+            if (dsize[i] == 0) { dsize[i] = 1; }
         }
 
         // flatten into 1 dim only apply to non-scalar variables

--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -158,7 +158,7 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
             CHECK_MPIERR
             vsize *= esize;
             vsize += 8 * 2 * ndim; // Include start and count array
-            err = driver.def_local_var (fid, name, NC_BYTE, 1, &vsize, &(var->data));
+            err = driver.def_local_var (fid, name, NC_UBYTE, 1, &vsize, &(var->data));
             CHECK_ERR
         }
         else{

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -544,6 +544,7 @@ int e3sm_io_driver_adios2::enddef (int fid) {
             for (i = 0; i < fp->ddids.size (); i++) {
                 adios2_put (fp->ep, fp->ddids[i], &(fp->dsizes[i]), adios2_mode_sync);
             }
+            this->amount_WR += fp->ddids.size() * 8;
         }
         E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_ADIOS2_PUT_VAR)
     }
@@ -643,7 +644,10 @@ int e3sm_io_driver_adios2::put_att (
         CHECK_APTR (aid)
     }
 
-    if (fp->rank == 0) {
+    // ADIOS2 write attributes in each subfile
+    // Instead of finding the exact process writing the attribute 
+    // we count them in the first num_group processes
+    if (fp->rank < cfg->num_group) {
         esize = adios2_type_size (atype);
         this->amount_WR += size * esize;
     }

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -53,9 +53,9 @@ inline adios2_type
 e3sm_io_type_nc2adios(nc_type xtype)
 {
     switch(xtype) {
-        case NC_BYTE:   return adios2_type_int8_t;
-        case NC_UBYTE:
-        case NC_CHAR:   return adios2_type_uint8_t;
+        case NC_BYTE:
+        case NC_CHAR:   return adios2_type_int8_t;
+        case NC_UBYTE:  return adios2_type_uint8_t;  
         case NC_INT:    return adios2_type_int32_t;
         case NC_FLOAT : return adios2_type_float;
         case NC_DOUBLE: return adios2_type_double;

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -53,7 +53,7 @@ inline adios2_type
 e3sm_io_type_nc2adios(nc_type xtype)
 {
     switch(xtype) {
-        case NC_BYTE:
+        case NC_BYTE:   return adios2_type_int8_t;
         case NC_UBYTE:
         case NC_CHAR:   return adios2_type_uint8_t;
         case NC_INT:    return adios2_type_int32_t;


### PR DESCRIPTION
make output file readable by adios2pio-nm
fix type translation bug from nctype to scorpio type
fix miscalculate small variable size
adios2 driver putsize count attributes in all subfiles.