### PR TITLE
Use raw major order for start and count in small variables:

### DIFF
--- a/src/cases/e3sm_io_case_scorpio.hpp
+++ b/src/cases/e3sm_io_case_scorpio.hpp
@@ -159,7 +159,7 @@ inline int e3sm_io_scorpio_define_var (e3sm_io_driver &driver,
             // Record block size to be written into the data later
             var->ndim = ndim;
             for (i = 0; i < ndim; i++) { 
-                var->bsize[i] = dsize[ndim - i - 1]; 
+                var->bsize[i] = dsize[i]; 
             }
             // Convert into byte array
             for (i = 0; i < ndim; i++) { vsize *= dsize[i]; }


### PR DESCRIPTION
Do not reverse start and count order.
It caused adios2pio-nm to take the last dimension for record (first) dimension and create more records then needed.