### PR TITLE
Bug fixes in HDF5 driver

### DIFF
--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -1002,7 +1002,7 @@ int e3sm_io_driver_hdf5::put_varn_expand (int fid,
             hstarts[i] = hstarts[i - 1] + ndim;
             hcounts[i] = hcounts[i - 1] + ndim;
         }
-        for (i = 1; i < nreq; i++) {
+        for (i = 0; i < nreq; i++) {
             for (j = 0; j < ndim; j++) {
                 hstarts[i][j] = (hsize_t)starts[i][j];
                 hcounts[i][j] = (hsize_t)counts[i][j];

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -656,7 +656,7 @@ int e3sm_io_driver_hdf5::put_vara (int fid,
 
     // Extend rec dim
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5_EXT_DIM)
-    if (dims[0] < hstart[0] + hblock[0]) {
+    if (ndim && (dims[0] < hstart[0] + hblock[0])) {
         dims[0] = hstart[0] + hblock[0];
         if (fp->recsize < (MPI_Offset)(dims[0])) { fp->recsize = dims[0]; }
 
@@ -793,7 +793,7 @@ int e3sm_io_driver_hdf5::put_vars (int fid,
 
     // Extend rec dim
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5_EXT_DIM)
-    if (dims[0] < hstart[0] + (hblock[0] - 1) * hstride[0] + 1) {
+    if (ndim && (dims[0] < hstart[0] + (hblock[0] - 1) * hstride[0] + 1)) {
         dims[0] = hstart[0] + (hblock[0] - 1) * hstride[0] + 1;
         if (fp->recsize < (MPI_Offset)(dims[0])) { fp->recsize = dims[0]; }
 


### PR DESCRIPTION
Fix uninitialized starts and counts on Dwrite_n
Do not test for record dim extension on scalar datasets
Count write size internally instead of using file size