### PR TITLE
Performance improvement in HDF5 drivers

### DIFF
--- a/src/drivers/Makefile.am
+++ b/src/drivers/Makefile.am
@@ -29,6 +29,12 @@ H_SRCS +=   e3sm_io_driver_hdf5.hpp \
             blob_ncmpio.h
 endif
 
+if ENABLE_LOGVOL
+C_SRCS +=   e3sm_io_driver_hdf5_log.cpp
+
+H_SRCS +=   e3sm_io_driver_hdf5_log.hpp 
+endif
+
 if ENABLE_ADIOS2
 C_SRCS += e3sm_io_driver_adios2.cpp
 H_SRCS += e3sm_io_driver_adios2.hpp

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -680,14 +680,6 @@ int e3sm_io_driver_hdf5::put_vara (int fid,
 
     E3SM_IO_TIMER_SWAP (E3SM_IO_TIMER_HDF5_SEL, E3SM_IO_TIMER_HDF5_WR)
     switch (mode) {
-        case indep: {
-            dxplid = this->dxplid_indep;
-            break;
-        }
-        case coll: {
-            dxplid = this->dxplid_coll;
-            break;
-        }
         case nb: {
             dxplid = this->dxplid_indep_nb;
             break;
@@ -698,6 +690,14 @@ int e3sm_io_driver_hdf5::put_vara (int fid,
             } else {
                 throw "bput not supported";
             }
+            break;
+        }
+        case indep: {
+            dxplid = this->dxplid_indep;
+            break;
+        }
+        case coll: {
+            dxplid = this->dxplid_coll;
             break;
         }
         default:
@@ -815,14 +815,6 @@ int e3sm_io_driver_hdf5::put_vars (int fid,
 
     E3SM_IO_TIMER_SWAP (E3SM_IO_TIMER_HDF5_SEL, E3SM_IO_TIMER_HDF5_WR)
     switch (mode) {
-        case indep: {
-            dxplid = this->dxplid_indep;
-            break;
-        }
-        case coll: {
-            dxplid = this->dxplid_coll;
-            break;
-        }
         case nb: {
             dxplid = this->dxplid_indep_nb;
             break;
@@ -833,6 +825,14 @@ int e3sm_io_driver_hdf5::put_vars (int fid,
             } else {
                 throw "bput not supported";
             }
+            break;
+        }
+        case indep: {
+            dxplid = this->dxplid_indep;
+            break;
+        }
+        case coll: {
+            dxplid = this->dxplid_coll;
             break;
         }
         default:
@@ -958,14 +958,6 @@ int e3sm_io_driver_hdf5::put_varn_expand (int fid,
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5_EXT_DIM)
 
     switch (mode) {
-        case indep: {
-            dxplid = this->dxplid_indep;
-            break;
-        }
-        case coll: {
-            dxplid = this->dxplid_coll;
-            break;
-        }
         case nb: {
             dxplid = this->dxplid_indep_nb;
             break;
@@ -976,6 +968,14 @@ int e3sm_io_driver_hdf5::put_varn_expand (int fid,
             } else {
                 throw "bput not supported";
             }
+            break;
+        }
+        case indep: {
+            dxplid = this->dxplid_indep;
+            break;
+        }
+        case coll: {
+            dxplid = this->dxplid_coll;
             break;
         }
         default:
@@ -1183,20 +1183,20 @@ int e3sm_io_driver_hdf5::get_vara (int fid,
 
     E3SM_IO_TIMER_SWAP (E3SM_IO_TIMER_HDF5_SEL, E3SM_IO_TIMER_HDF5_RD)
     switch (mode) {
-        case indep: {
-            dxplid = this->dxplid_indep;
-            break;
-        }
-        case coll: {
-            dxplid = this->dxplid_coll;
-            break;
-        }
         case nb: {
             dxplid = this->dxplid_indep_nb;
             break;
         }
         case nbe: {
             throw "bput not supported for read";
+            break;
+        }
+        case indep: {
+            dxplid = this->dxplid_indep;
+            break;
+        }
+        case coll: {
+            dxplid = this->dxplid_coll;
             break;
         }
         default:
@@ -1297,20 +1297,20 @@ int e3sm_io_driver_hdf5::get_vars (int fid,
 
     E3SM_IO_TIMER_SWAP (E3SM_IO_TIMER_HDF5_SEL, E3SM_IO_TIMER_HDF5_RD)
     switch (mode) {
-        case indep: {
-            dxplid = this->dxplid_indep;
-            break;
-        }
-        case coll: {
-            dxplid = this->dxplid_coll;
-            break;
-        }
         case nb: {
             dxplid = this->dxplid_indep_nb;
             break;
         }
         case nbe: {
             throw "bput not supported for read";
+            break;
+        }       
+        case indep: {
+            dxplid = this->dxplid_indep;
+            break;
+        }
+        case coll: {
+            dxplid = this->dxplid_coll;
             break;
         }
         default:
@@ -1417,20 +1417,20 @@ int e3sm_io_driver_hdf5::get_varn_expand (int fid,
     CHECK_HID (ndim)
 
     switch (mode) {
-        case indep: {
-            dxplid = this->dxplid_indep;
-            break;
-        }
-        case coll: {
-            dxplid = this->dxplid_coll;
-            break;
-        }
         case nb: {
             dxplid = this->dxplid_indep_nb;
             break;
         }
         case nbe: {
             throw "bput not supported in read";
+            break;
+        }
+        case indep: {
+            dxplid = this->dxplid_indep;
+            break;
+        }
+        case coll: {
+            dxplid = this->dxplid_coll;
             break;
         }
         default:

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -104,6 +104,7 @@ int e3sm_io_driver_hdf5::create (std::string path, MPI_Comm comm, MPI_Info info,
     int err = 0;
     herr_t herr;
     hid_t faplid;
+    H5AC_cache_config_t mdcc;
     hdf5_file *fp;
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
@@ -118,6 +119,16 @@ int e3sm_io_driver_hdf5::create (std::string path, MPI_Comm comm, MPI_Info info,
     herr = H5Pset_fapl_mpio (faplid, comm, info);
     CHECK_HERR
     herr = H5Pset_coll_metadata_write (faplid, true);
+    CHECK_HERR
+    // Enlarge metadata cache
+    mdcc.version = H5AC__CURR_CACHE_CONFIG_VERSION;
+    herr         = H5Pget_mdc_config (faplid, &mdcc);
+    CHECK_HERR
+    mdcc.max_size         = 128 * 1024 * 1024;
+    mdcc.min_size         = 32 * 1024 * 1024;
+    mdcc.initial_size     = 32 * 1024 * 1024;
+    mdcc.set_initial_size = true;
+    herr                  = H5Pset_mdc_config (faplid, &mdcc);
     CHECK_HERR
 
     fp->id = H5Fcreate (path.c_str (), H5F_ACC_TRUNC, H5P_DEFAULT, faplid);
@@ -137,6 +148,7 @@ int e3sm_io_driver_hdf5::open (std::string path, MPI_Comm comm, MPI_Info info, i
     int err = 0;
     herr_t herr;
     hid_t faplid;
+    H5AC_cache_config_t mdcc;
     hdf5_file *fp;
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
@@ -151,6 +163,16 @@ int e3sm_io_driver_hdf5::open (std::string path, MPI_Comm comm, MPI_Info info, i
     herr = H5Pset_fapl_mpio (faplid, comm, info);
     CHECK_HERR
     herr = H5Pset_coll_metadata_write (faplid, true);
+    CHECK_HERR
+    // Enlarge metadata cache
+    mdcc.version = H5AC__CURR_CACHE_CONFIG_VERSION;
+    herr         = H5Pget_mdc_config (faplid, &mdcc);
+    CHECK_HERR
+    mdcc.max_size         = 128 * 1024 * 1024;
+    mdcc.min_size         = 32 * 1024 * 1024;
+    mdcc.initial_size     = 32 * 1024 * 1024;
+    mdcc.set_initial_size = true;
+    herr                  = H5Pset_mdc_config (faplid, &mdcc);
     CHECK_HERR
 
     fp->id = H5Fopen (path.c_str (), H5F_ACC_RDONLY, faplid);

--- a/src/drivers/e3sm_io_driver_hdf5_log.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5_log.hpp
@@ -1,0 +1,129 @@
+/*********************************************************************
+ *
+ * Copyright (C) 2021, Northwestern University
+ * See COPYRIGHT notice in top-level directory.
+ *
+ * This program is part of the E3SM I/O benchmark.
+ *
+ *********************************************************************/
+//
+#pragma once
+//
+#include <map>
+#include <vector>
+//
+#include <hdf5.h>
+#include <mpi.h>
+//
+#include <e3sm_io.h>
+
+#include <e3sm_io_driver.hpp>
+
+class e3sm_io_driver_hdf5_log : public e3sm_io_driver {
+    class hdf5_file_log {
+       public:
+        e3sm_io_driver_hdf5_log &driver;
+        e3sm_io_config *cfg;
+        hid_t id;
+        std::vector<hid_t> dids;
+        std::vector<hsize_t> dsizes;
+        MPI_Offset recsize = 0;
+        MPI_Offset putsize = 0;
+        MPI_Offset getsize = 0;
+        int rank;
+
+        hdf5_file_log (e3sm_io_driver_hdf5_log &x) : driver (x), cfg{x.cfg} {};
+    };
+
+    std::vector<hdf5_file_log *> files;
+    hid_t dxplid_coll;
+    hid_t dxplid_indep;
+    hid_t dxplid_coll_nb;
+    hid_t dxplid_indep_nb;
+    hid_t log_vlid;
+
+    hsize_t one[H5S_MAX_RANK];
+
+    // Config
+    bool use_logvol       = false;
+    bool use_logvol_varn  = false;
+    bool use_dwrite_multi = false;
+    bool merge_varn       = false;
+
+   public:
+    e3sm_io_driver_hdf5_log (e3sm_io_config *cfg);
+    ~e3sm_io_driver_hdf5_log ();
+    int create (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
+    int open (std::string path, MPI_Comm comm, MPI_Info info, int *fid);
+    int close (int fid);
+    int inq_file_info (int fid, MPI_Info *info);
+    int inq_file_size (std::string path, MPI_Offset *size);
+    int inq_put_size (MPI_Offset *size);
+    int inq_get_size (MPI_Offset *size);
+    int inq_malloc_size (MPI_Offset *size);
+    int inq_malloc_max_size (MPI_Offset *size);
+    int inq_rec_size (int fid, MPI_Offset *size);
+    int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
+    int def_local_var (
+        int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
+    int inq_var (int fid, std::string name, int *did);
+    int inq_var_name(int ncid, int varid, char *name);
+    int inq_var_off (int fid, int vid, MPI_Offset *off);
+    int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);
+    int inq_dim (int fid, std::string name, int *dimid);
+    int inq_dimlen (int fid, int dimid, MPI_Offset *size);
+    int enddef (int fid);
+    int redef (int fid);
+    int wait (int fid);
+    int put_att (int fid, int vid, std::string name, nc_type xtype, MPI_Offset size, const void *buf);
+    int get_att (int fid, int vid, std::string name, void *buf);
+    int put_varl (int fid, int vid, MPI_Datatype itype, void *buf, e3sm_io_op_mode mode);
+    int put_vara (int fid,
+                  int vid,
+                  MPI_Datatype itype,
+                  MPI_Offset *start,
+                  MPI_Offset *count,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int put_vars (int fid,
+                  int vid,
+                  MPI_Datatype itype,
+                  MPI_Offset *start,
+                  MPI_Offset *count,
+                  MPI_Offset *stride,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int put_varn (int fid,
+                  int vid,
+                  MPI_Datatype itype,
+                  int nreq,
+                  MPI_Offset **starts,
+                  MPI_Offset **counts,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int get_vara (int fid,
+                  int vid,
+                  MPI_Datatype itype,
+                  MPI_Offset *start,
+                  MPI_Offset *count,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int get_vars (int fid,
+                  int vid,
+                  MPI_Datatype itype,
+                  MPI_Offset *start,
+                  MPI_Offset *count,
+                  MPI_Offset *stride,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+    int get_varn (int fid,
+                  int vid,
+                  MPI_Datatype itype,
+                  int nreq,
+                  MPI_Offset **starts,
+                  MPI_Offset **counts,
+                  void *buf,
+                  e3sm_io_op_mode mode);
+};
+
+

--- a/src/e3sm_io_core.cpp
+++ b/src/e3sm_io_core.cpp
@@ -29,6 +29,9 @@
 #include <hdf5.h>
 #include <e3sm_io_driver_hdf5.hpp>
 #include <e3sm_io_driver_h5blob.hpp>
+#ifdef ENABLE_LOGVOL
+#include <e3sm_io_driver_hdf5_log.hpp>
+#endif
 #endif
 
 #ifdef ENABLE_ADIOS2
@@ -166,7 +169,11 @@ done_check:
         case hdf5_md:
         case hdf5_log:
 #ifdef ENABLE_HDF5
-            driver = new e3sm_io_driver_hdf5 (cfg);
+#ifdef ENABLE_LOGVOL
+            driver = new e3sm_io_driver_hdf5_log (cfg);
+#else
+            ERR_OUT ("Log VOL support was not enabled in this build")
+#endif
 #else
             ERR_OUT ("HDF5 support was not enabled in this build")
 #endif


### PR DESCRIPTION
Change order in switch for I/O mode.
Make hdf5_log separate driver.
Set metadata cache to 128 MiB.