### PR TITLE
put_varn in hdf5_log driver defaults to use H5Dwrite_n in logvol

### DIFF
--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -74,7 +74,7 @@ e3sm_io_driver_hdf5::e3sm_io_driver_hdf5 (e3sm_io_config *cfg) : e3sm_io_driver 
             this->use_logvol = true;
             env              = getenv ("E3SM_IO_HDF5_USE_LOGVOL_WRITEN");
             if (env) {
-                if (std::string (env) == "1") { this->use_logvol_varn = true; }
+                if (std::string (env) == "0") { this->use_logvol_varn = false; }
             }
         }
     }

--- a/src/drivers/e3sm_io_driver_hdf5_log.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_log.cpp
@@ -49,7 +49,7 @@ e3sm_io_driver_hdf5_log::e3sm_io_driver_hdf5_log (e3sm_io_config *cfg) : e3sm_io
 
     env = getenv ("E3SM_IO_HDF5_USE_LOGVOL_WRITEN");
     if (env) {
-        if (std::string (env) == "1") { this->use_logvol_varn = true; }
+        if (std::string (env) == "0") { this->use_logvol_varn = false; }
     }
 
 err_out:;

--- a/src/drivers/e3sm_io_driver_hdf5_log.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5_log.hpp
@@ -23,7 +23,7 @@ class e3sm_io_driver_hdf5_log : public e3sm_io_driver_hdf5 {
     hid_t log_vlid;
         
     // Config
-    bool use_logvol_varn  = false;
+    bool use_logvol_varn  = true;
     bool merge_varn       = false;
 
    public:


### PR DESCRIPTION
Switch to H5Dwrite only when the environment variable is explicitly set to 0