### PR TITLE
Support to hdf5 canonical strategy

### DIFF
--- a/src/cases/var_wr_case.cpp
+++ b/src/cases/var_wr_case.cpp
@@ -307,8 +307,10 @@ int e3sm_io_case::var_wr_case(e3sm_io_config &cfg,
     fix_dbl_buf_ptr = wr_buf.fix_dbl_buf;
 
     for (rec_no=0; rec_no<cmeta->nrecs; rec_no++) {
-        err = driver.expand_rec_size (ncid, rec_no + 1);
-        CHECK_ERR
+        if (cfg.api == hdf5 && cfg.strategy == canonical) {
+            err = driver.expand_rec_size (ncid, rec_no + 1);
+            CHECK_ERR
+        }
 
         if (cfg.api == adios || (cfg.strategy == blob && cfg.api == hdf5) ||
             rec_no % cmeta->ffreq == 0) {

--- a/src/cases/var_wr_case.cpp
+++ b/src/cases/var_wr_case.cpp
@@ -307,6 +307,8 @@ int e3sm_io_case::var_wr_case(e3sm_io_config &cfg,
     fix_dbl_buf_ptr = wr_buf.fix_dbl_buf;
 
     for (rec_no=0; rec_no<cmeta->nrecs; rec_no++) {
+        err = driver.expand_rec_size (ncid, rec_no + 1);
+        CHECK_ERR
 
         if (cfg.api == adios || (cfg.strategy == blob && cfg.api == hdf5) ||
             rec_no % cmeta->ffreq == 0) {

--- a/src/drivers/e3sm_io_driver.hpp
+++ b/src/drivers/e3sm_io_driver.hpp
@@ -27,6 +27,7 @@ class e3sm_io_driver {
     virtual int inq_malloc_size (MPI_Offset *size)                                = 0;
     virtual int inq_malloc_max_size (MPI_Offset *size)                            = 0;
     virtual int inq_rec_size (int fid, MPI_Offset *size)                          = 0;
+    virtual int expand_rec_size (int fid, MPI_Offset size)                        = 0;
     virtual int def_var (
         int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did) = 0;
     virtual int def_local_var (

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -326,6 +326,10 @@ int e3sm_io_driver_adios2::inq_rec_size (int fid, MPI_Offset *size) {
     return 0;
 }
 
+int e3sm_io_driver_adios2::expand_rec_size (int fid, MPI_Offset size) {
+    return 0;
+}
+
 int e3sm_io_driver_adios2::def_var (
     int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did) {
     int err = 0;

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -101,6 +101,7 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
     int inq_malloc_size (MPI_Offset *size);
     int inq_malloc_max_size (MPI_Offset *size);
     int inq_rec_size (int fid, MPI_Offset *size);
+    int expand_rec_size (int fid, MPI_Offset size);
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);

--- a/src/drivers/e3sm_io_driver_h5blob.cpp
+++ b/src/drivers/e3sm_io_driver_h5blob.cpp
@@ -335,6 +335,10 @@ int e3sm_io_driver_h5blob::inq_rec_size (int fid, MPI_Offset *size) {
     return 0;
 }
 
+int e3sm_io_driver_h5blob::expand_rec_size (int fid, MPI_Offset size) {
+    return 0;
+}
+
 int e3sm_io_driver_h5blob::def_var(int          fid,
                                    std::string  name,
                                    nc_type      xtype,

--- a/src/drivers/e3sm_io_driver_h5blob.hpp
+++ b/src/drivers/e3sm_io_driver_h5blob.hpp
@@ -57,6 +57,7 @@ class e3sm_io_driver_h5blob : public e3sm_io_driver {
     int inq_malloc_size (MPI_Offset *size);
     int inq_malloc_max_size (MPI_Offset *size);
     int inq_rec_size (int fid, MPI_Offset *size);
+    int expand_rec_size (int fid, MPI_Offset size);
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -56,10 +56,6 @@ e3sm_io_driver_hdf5::e3sm_io_driver_hdf5 (e3sm_io_config *cfg) : e3sm_io_driver 
         throw "The HDF5 used does not support multi-dataset write";
 #endif
     }
-#ifdef E3SM_IO_DEBUG
-    else if (cfg->api == hdf5_ra) {
-    }
-#endif
 
     if ((cfg->chunksize != 0) && (cfg->filter != none)) {
         throw "Fitler requries chunking in HDF5";

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -28,6 +28,7 @@ e3sm_io_driver_hdf5::e3sm_io_driver_hdf5 (e3sm_io_config *cfg) : e3sm_io_driver 
     int err     = 0;
     herr_t herr = 0;
     int i;
+    char *env;
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
 
@@ -80,6 +81,11 @@ e3sm_io_driver_hdf5::e3sm_io_driver_hdf5 (e3sm_io_config *cfg) : e3sm_io_driver 
         if (std::string (env) == "1") { this->merge_varn = true; }
     }
     */
+
+    env = getenv ("E3SM_IO_HDF5_FLUSH_COLL");
+    if (env) {
+        if (std::string (env) == "1") { this->collective_flush = true; }
+    }
 
 err_out:;
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5)

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -107,6 +107,9 @@ int e3sm_io_driver_hdf5::create (std::string path, MPI_Comm comm, MPI_Info info,
 
     fp = new hdf5_file (*this);
 
+    err = MPI_Comm_dup(comm, &(fp->comm));
+    CHECK_MPIERR
+
     err = MPI_Comm_rank (comm, &(fp->rank));
     CHECK_MPIERR
 
@@ -153,6 +156,9 @@ int e3sm_io_driver_hdf5::open (std::string path, MPI_Comm comm, MPI_Info info, i
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
 
     fp = new hdf5_file (*this);
+
+    err = MPI_Comm_dup(comm, &(fp->comm));
+    CHECK_MPIERR
 
     err = MPI_Comm_rank (comm, &(fp->rank));
     CHECK_MPIERR
@@ -204,6 +210,8 @@ int e3sm_io_driver_hdf5::close (int fid) {
 
     herr = H5Fclose (fp->id);
     CHECK_HERR
+
+    MPI_Comm_free(&(fp->comm));
 
     delete fp;
 
@@ -338,6 +346,7 @@ int e3sm_io_driver_hdf5::def_var (
 
     *did = fp->dids.size ();
     fp->dids.push_back (h5did);
+    fp->inv_dids[h5did] = *did;
 
 err_out:;
     if (sid != -1) H5Sclose (sid);
@@ -368,6 +377,7 @@ int e3sm_io_driver_hdf5::inq_var (int fid, std::string name, int *did) {
 
     *did = fp->dids.size ();
     fp->dids.push_back (h5did);
+    fp->inv_dids[h5did] = *did;
 
 err_out:;
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5)

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -78,6 +78,7 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
 
    private:
     // Config
+    bool collective_flush = false;
     bool use_dwrite_multi = false;
     bool merge_varn       = false;
 

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -45,13 +45,11 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
             hid_t dset_space_id; /* dataset selection dataspace ID */
             hid_t mem_type_id;   /* memory datatype ID */
             hid_t mem_space_id;  /* memory selection dataspace ID */
-            union {
-                void *rbuf;       /* pointer to read buffer */
-                const void *wbuf; /* pointer to write buffer */
-            } u;
+            void *buf;           /* pointer to data buffer */
         } H5D_rw_multi_t;
 #endif
-        std::vector<H5D_rw_multi_t> multi_datasets;
+        std::vector<H5D_rw_multi_t> wreqs;
+        std::vector<H5D_rw_multi_t> rreqs;
 
         std::vector<std::vector<e3sm_io_driver_hdf5::Index_order> > dataset_segments;
 

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -33,9 +33,9 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
         e3sm_io_driver_hdf5 &driver;
         e3sm_io_config *cfg;
         hid_t id;
-        std::vector<hid_t> dids;
-        std::vector<hsize_t> dsizes;
-        std::map<hid_t, int> inv_dids;
+        std::vector<hid_t> dids; // HDF5 dataset IDs
+        std::vector<hsize_t> dsizes; // Size of dimensions
+        std::map<hid_t, int> inv_dids;  // Inverse of dids
         MPI_Offset recsize = 0;
         MPI_Offset putsize = 0;
         MPI_Offset getsize = 0;
@@ -94,6 +94,7 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
     int inq_malloc_size (MPI_Offset *size);
     int inq_malloc_max_size (MPI_Offset *size);
     int inq_rec_size (int fid, MPI_Offset *size);
+    int expand_rec_size (int fid, MPI_Offset size);
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -29,11 +29,13 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
    protected:
     class hdf5_file {
        public:
+        MPI_Comm comm;
         e3sm_io_driver_hdf5 &driver;
         e3sm_io_config *cfg;
         hid_t id;
         std::vector<hid_t> dids;
         std::vector<hsize_t> dsizes;
+        std::map<hid_t, int> inv_dids;
         MPI_Offset recsize = 0;
         MPI_Offset putsize = 0;
         MPI_Offset getsize = 0;

--- a/src/drivers/e3sm_io_driver_hdf5_agg.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_agg.cpp
@@ -266,7 +266,7 @@ int e3sm_io_driver_hdf5::hdf5_file::flush_multidatasets () {
             CHECK_HERR
 
             // Dummy type for dummy call
-            tid = H5Dget_type (dsid);
+            tid = H5Dget_type (dids[j]);
             CHECK_HID(tid)
 
             for (i = 0; i < nreqs_all[j]; ++i) {
@@ -370,7 +370,7 @@ herr_t e3sm_io_driver_hdf5::hdf5_file::pull_multidatasets () {
             CHECK_HERR
 
             // Dummy type for dummy call
-            tid = H5Dget_type (dsid);
+            tid = H5Dget_type (dids[j]);
             CHECK_HID(tid)
 
             for (i = 0; i < nreqs_all[j]; ++i) {

--- a/src/drivers/e3sm_io_driver_hdf5_agg.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_agg.cpp
@@ -235,7 +235,7 @@ int e3sm_io_driver_hdf5::hdf5_file::flush_multidatasets () {
     int *nreqs = NULL;  // # requests per dataset
     int *nreqs_all;  // max # requests per dataset across all processes
 
-    MPI_Comm_rank (MPI_COMM_WORLD, &rank);
+    MPI_Comm_rank (comm, &rank);
 
 #ifdef HDF5_HAVE_DWRITE_MULTI
     if (this->driver.use_dwrite_multi) {    
@@ -338,7 +338,7 @@ herr_t e3sm_io_driver_hdf5::hdf5_file::pull_multidatasets () {
     int *nreqs = NULL;  // # requests per dataset
     int *nreqs_all;  // max # requests per dataset across all processes
     
-    MPI_Comm_rank (MPI_COMM_WORLD, &rank);
+    MPI_Comm_rank (comm, &rank);
 
     // printf("Rank %d number of datasets to be written %d\n", rank, multi_datasets.size());
 #ifdef HDF5_HAVE_DWRITE_MULTI
@@ -503,7 +503,7 @@ int e3sm_io_driver_hdf5::put_varn_merge (int fid,
 
     // Call H5DWrite
     int rank;
-    MPI_Comm_rank (MPI_COMM_WORLD, &rank);
+    MPI_Comm_rank (fp->comm, &rank);
 
 #if defined(DEBUG) && DEBUG == 1
     char filename[128];

--- a/src/drivers/e3sm_io_driver_hdf5_log.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_log.cpp
@@ -82,6 +82,9 @@ int e3sm_io_driver_hdf5_log::create (std::string path, MPI_Comm comm, MPI_Info i
 
     fp = new hdf5_file (*this);
 
+    err = MPI_Comm_dup(comm, &(fp->comm));
+    CHECK_MPIERR
+
     err = MPI_Comm_rank (comm, &(fp->rank));
     CHECK_MPIERR
 
@@ -128,6 +131,9 @@ int e3sm_io_driver_hdf5_log::open (std::string path, MPI_Comm comm, MPI_Info inf
 
     fp = new hdf5_file (*this);
 
+    err = MPI_Comm_dup(comm, &(fp->comm));
+    CHECK_MPIERR
+    
     err = MPI_Comm_rank (comm, &(fp->rank));
     CHECK_MPIERR
 

--- a/src/drivers/e3sm_io_driver_hdf5_log.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_log.cpp
@@ -733,7 +733,7 @@ int e3sm_io_driver_hdf5_log::get_varn (int fid,
     hid_t tid = -1;
     MPI_Offset getsize;
     MPI_Offset **count;
-    // hsize_t **hstarts = NULL, **hcounts;
+    hsize_t **hstarts = NULL, **hcounts;
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
 
@@ -770,7 +770,6 @@ int e3sm_io_driver_hdf5_log::get_varn (int fid,
             throw "Unrecognized mode";
     }
 
-#if false  // H5Dread_n not implemented
     if (this->use_logvol_varn) {
         E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5_SEL)
         // Convert starts and counts;
@@ -789,12 +788,10 @@ int e3sm_io_driver_hdf5_log::get_varn (int fid,
             }
         }
         E3SM_IO_TIMER_SWAP (E3SM_IO_TIMER_HDF5_SEL,E3SM_IO_TIMER_HDF5_RD)
-        // herr = H5Dread_n (did, mtype, nreq, hstarts, hcounts, dxplid, buf);
-        // CHECK_HERR
+        herr = H5Dread_n (did, mtype, nreq, hstarts, hcounts, dxplid, buf);
+        CHECK_HERR
         E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5_RD)
-    } else
-#endif
-    {
+    } else {
         // Call H5DWrite
         for (i = 0; i < nreq; i++) {
             rsize = esize;

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -154,6 +154,10 @@ err_out:
     return err;
 }
 
+int e3sm_io_driver_pnc::expand_rec_size (int fid, MPI_Offset size) {
+    return 0;
+}
+
 int e3sm_io_driver_pnc::def_var (
     int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *varid) {
     int err;

--- a/src/drivers/e3sm_io_driver_pnc.hpp
+++ b/src/drivers/e3sm_io_driver_pnc.hpp
@@ -62,6 +62,7 @@ class e3sm_io_driver_pnc : public e3sm_io_driver {
     int inq_malloc_size (MPI_Offset *size);
     int inq_malloc_max_size (MPI_Offset *size);
     int inq_rec_size (int fid, MPI_Offset *size);
+    int expand_rec_size (int fid, MPI_Offset size);
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -200,11 +200,6 @@ int main (int argc, char **argv) {
                     cfg.api = hdf5_log;
                 else if (strcmp (optarg, "adios") == 0)
                     cfg.api = adios;
-#ifdef E3SM_IO_DEBUG
-                /* For debug purpose only */
-                else if (strcmp (optarg, "hdf5_ra") == 0)
-                    cfg.api = hdf5_ra;
-#endif
                 else
                     ERR_OUT ("Unknown API")
                 break;
@@ -323,18 +318,6 @@ int main (int argc, char **argv) {
         else if (cfg.strategy == blob)
             ERR_OUT ("HDF5 multi-dataset with blob I/O strategy is not supported yet")
     }
-
-#ifdef E3SM_IO_DEBUG
-    /* For debug purpose only */
-    if (cfg.api == hdf5_ra) {
-        if (cfg.strategy == undef_io)
-            cfg.strategy = canonical;
-        else if (cfg.strategy == log)
-            ERR_OUT ("HDF5 multi-dataset with log I/O strategy is not supported yet")
-        else if (cfg.strategy == blob)
-            ERR_OUT ("HDF5 multi-dataset with blob I/O strategy is not supported yet")
-    }
-#endif
 
     if (cfg.api == hdf5_log) {
 #ifndef ENABLE_LOGVOL

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -303,8 +303,22 @@ int main (int argc, char **argv) {
 #endif
         if (cfg.strategy == undef_io)
             cfg.strategy = canonical;
-        else if (cfg.strategy == log)
-            ERR_OUT ("HDF5 rearranger with log I/O strategy is not supported yet")
+
+        if (cfg.strategy == canonical){
+            char *env;
+            // Block the use of log-based VOL
+            env = getenv ("HDF5_VOL_CONNECTOR");
+            if (env && (strncmp (env, "LOG", 3) == 0)) {
+                ERR_OUT ("HDF5 with canonical strategy is not compatible with log-based VOL")    
+            }
+        } else if (cfg.strategy == log) {
+            char *env;
+            // Make sure to use log-based VOL
+            env = getenv ("HDF5_VOL_CONNECTOR");
+            if (!env || (strncmp (env, "LOG", 3) != 0)) {
+                ERR_OUT ("HDF5 with log strategy must use log-based VOL")    
+            }
+        }
     }
 
     if (cfg.api == hdf5_md) {

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -72,7 +72,6 @@ typedef enum e3sm_io_api {
     pnetcdf,
     hdf5,
     hdf5_md,
-    hdf5_ra,
     hdf5_log,
     adios,
     undef_api

--- a/src/e3sm_io_core.cpp
+++ b/src/e3sm_io_core.cpp
@@ -163,10 +163,9 @@ done_check:
             ERR_OUT ("HDF5 support was not enabled in this build")
 #endif
             break;
-#ifdef E3SM_IO_DEBUG
-        case hdf5_ra:
-#endif
         case hdf5_md:
+            ERR_OUT("HDF5 does not support multi-dataset APIs")
+            break;
         case hdf5_log:
 #ifdef ENABLE_HDF5
 #ifdef ENABLE_LOGVOL


### PR DESCRIPTION
Allow -a hdf5 -x canonical to run on HDF5 native VOL.
Translate get/put_varn to n H5Dread/write. Follow blocking collective call with dummy H5Dread/write if n differs across processes.
Flush non-blocking request by replaying requests of each dataset as varn call.
Introduce new driver API to set extent of record variables (datasets). H5Dset_extent must be collective, so cannot be done in a put_var call.
Remove legacy hdf5_ra codes.