### PR TITLE
evictions_enabled removed for native hdf5

### DIFF
--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -182,7 +182,7 @@ int e3sm_io_driver_hdf5::open (std::string path, MPI_Comm comm, MPI_Info info, i
     mdcc.max_size         = 128 * 1024 * 1024;
     mdcc.min_size         = 32 * 1024 * 1024;
     mdcc.initial_size     = 32 * 1024 * 1024;
-    mdcc.evictions_enabled = false;
+    // mdcc.evictions_enabled = false;
     mdcc.incr_mode = H5C_incr__off;
     mdcc.decr_mode = H5C_decr__off;
     mdcc.set_initial_size = true;


### PR DESCRIPTION
Otherwise, it throws an error.