### PR TITLE
Allow using logvol in HDF5 driver

### DIFF
--- a/src/cases/var_wr_case.cpp
+++ b/src/cases/var_wr_case.cpp
@@ -307,7 +307,7 @@ int e3sm_io_case::var_wr_case(e3sm_io_config &cfg,
     fix_dbl_buf_ptr = wr_buf.fix_dbl_buf;
 
     for (rec_no=0; rec_no<cmeta->nrecs; rec_no++) {
-        if ((cfg.api == hdf5 && cfg.strategy == canonical) || cfg.api == netcdf4) {
+        if ((cfg.api == hdf5 && cfg.strategy != blob) || cfg.api == netcdf4) {
             err = driver.expand_rec_size (ncid, rec_no + 1);
             CHECK_ERR
         }

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -15,6 +15,9 @@
 //
 #include <sys/stat.h>
 //
+#ifdef ENABLE_LOGVOL
+#include <H5VL_log.h>
+#endif
 #include <hdf5.h>
 //
 #include <e3sm_io.h>
@@ -31,6 +34,15 @@ e3sm_io_driver_hdf5::e3sm_io_driver_hdf5 (e3sm_io_config *cfg) : e3sm_io_driver 
 	char *env;
 
 	E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
+
+    // Register LOG VOL plugin
+	if(cfg->strategy == log) {
+    	this->log_vlid = H5VLregister_connector (&H5VL_log_g, H5P_DEFAULT);
+    	CHECK_HID (this->log_vlid)
+	}
+	else{
+		this->log_vlid = -1;
+	}
 
 	/*
 	this->dxplid_coll = H5Pcreate (H5P_DATASET_XFER);
@@ -127,6 +139,10 @@ int e3sm_io_driver_hdf5::create (std::string path, MPI_Comm comm, MPI_Info info,
 	CHECK_HERR
 	herr = H5Pset_coll_metadata_write (faplid, true);
 	CHECK_HERR
+	if (cfg->strategy == log) {
+		herr = H5Pset_vol (faplid, this->log_vlid, NULL);
+    	CHECK_HERR
+	}
 	// Enlarge metadata cache
 	mdcc.version = H5AC__CURR_CACHE_CONFIG_VERSION;
 	herr		 = H5Pget_mdc_config (faplid, &mdcc);
@@ -177,6 +193,10 @@ int e3sm_io_driver_hdf5::open (std::string path, MPI_Comm comm, MPI_Info info, i
 	CHECK_HERR
 	herr = H5Pset_coll_metadata_write (faplid, true);
 	CHECK_HERR
+	if (cfg->strategy == log) {
+		herr = H5Pset_vol (faplid, this->log_vlid, NULL);
+    	CHECK_HERR
+	}
 	// Enlarge metadata cache
 	mdcc.version = H5AC__CURR_CACHE_CONFIG_VERSION;
 	herr		 = H5Pget_mdc_config (faplid, &mdcc);

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -68,6 +68,8 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
 // #endif
     };
 
+    hid_t log_vlid;
+
     std::vector<hdf5_file *> files;
     hid_t dxplid_coll;
     hid_t dxplid_indep;

--- a/src/drivers/e3sm_io_driver_hdf5_log.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_log.cpp
@@ -56,10 +56,6 @@ e3sm_io_driver_hdf5_log::e3sm_io_driver_hdf5_log (e3sm_io_config *cfg) : e3sm_io
     herr = H5Pset_nonblocking (this->dxplid_indep_nb, H5VL_LOG_REQ_NONBLOCKING);
     CHECK_HERR
 
-    // Register LOG VOL plugin
-    this->log_vlid = H5VLregister_connector (&H5VL_log_g, H5P_DEFAULT);
-    CHECK_HID (this->log_vlid)
-
     env = getenv ("E3SM_IO_HDF5_USE_LOGVOL_WRITEN");
     if (env) {
         if (std::string (env) == "0") { this->use_logvol_varn = false; }

--- a/src/drivers/e3sm_io_driver_hdf5_log.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5_log.hpp
@@ -19,9 +19,7 @@
 
 #include <e3sm_io_driver.hpp>
 
-class e3sm_io_driver_hdf5_log : public e3sm_io_driver_hdf5 {
-    hid_t log_vlid;
-        
+class e3sm_io_driver_hdf5_log : public e3sm_io_driver_hdf5 {      
     // Config
     bool use_logvol_varn  = true;
     bool merge_varn       = false;

--- a/src/drivers/e3sm_io_driver_nc4.cpp
+++ b/src/drivers/e3sm_io_driver_nc4.cpp
@@ -20,6 +20,7 @@
 #include <e3sm_io_err.h>
 
 #include <e3sm_io_driver_nc4.hpp>
+#include <e3sm_io_profile.hpp>
 
 #define CHECK_NCERR                                                                             \
     {                                                                                           \
@@ -73,8 +74,14 @@ e3sm_io_driver_nc4::~e3sm_io_driver_nc4 () {}
 int e3sm_io_driver_nc4::create (std::string path, MPI_Comm comm, MPI_Info info, int *fid) {
     int err;
 
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_OPEN)
+
     err = nc_create_par (path.c_str (), NC_CLOBBER | NC_NETCDF4, comm, info, fid);
     CHECK_NCERR
+
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_OPEN)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
 
 err_out:
     return err;
@@ -83,8 +90,14 @@ err_out:
 int e3sm_io_driver_nc4::open (std::string path, MPI_Comm comm, MPI_Info info, int *fid) {
     int err;
 
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_OPEN)
+
     err = nc_open_par (path.c_str (), NC_NOWRITE, comm, info, fid);
     CHECK_NCERR
+
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_OPEN)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
 
 err_out:
     return err;
@@ -93,8 +106,14 @@ err_out:
 int e3sm_io_driver_nc4::close (int fid) {
     int err;
 
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_CLOSE)
+
     err = nc_close (fid);
     CHECK_NCERR
+
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_CLOSE)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
 
 err_out:
     return err;
@@ -164,6 +183,9 @@ int e3sm_io_driver_nc4::expand_rec_size (int fid, MPI_Offset size) {
     std::vector<size_t> start;    // Starting coordinate to write in var
     char buf[16];                // Dummy buffer
 
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_RESIZE)
+
     err = nc_inq_unlimdim (fid, &udimid);
     CHECK_NCERR
 
@@ -198,6 +220,8 @@ int e3sm_io_driver_nc4::expand_rec_size (int fid, MPI_Offset size) {
     }
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_RESIZE)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
@@ -210,6 +234,9 @@ int e3sm_io_driver_nc4::def_var (
     size_t *dlen = NULL;           // Dim len
     size_t *csize;  // Chunk size
     MPI_Offset vsize;  // Var size
+
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_DEF_VAR)
 
     err = nc_def_var (fid, name.c_str (), xtype, ndim, dimids, varid);
     CHECK_NCERR
@@ -240,6 +267,8 @@ int e3sm_io_driver_nc4::def_var (
 
 err_out:
     if(dlen) { free(dlen); }
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_DEF_VAR)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
@@ -256,18 +285,28 @@ err_out:
 int e3sm_io_driver_nc4::inq_var (int fid, std::string name, int *varid) {
     int err;
 
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_INQ_VAR)
+
     err = nc_inq_varid (fid, name.c_str (), varid);
     CHECK_NCERR
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_INQ_VAR)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
 int e3sm_io_driver_nc4::inq_var_name (int ncid, int varid, char *name) {
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_INQ_VAR)
+
     int err = nc_inq_varname (ncid, varid, name);
     CHECK_NCERR
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_INQ_VAR)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
@@ -283,20 +322,30 @@ err_out:
 int e3sm_io_driver_nc4::def_dim (int fid, std::string name, MPI_Offset size, int *dimid) {
     int err;
 
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_DEF_DIM)
+
     err = nc_def_dim (fid, name.c_str (), size, dimid);
     CHECK_NCERR
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_DEF_DIM)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
 int e3sm_io_driver_nc4::inq_dim (int fid, std::string name, int *dimid) {
     int err;
 
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_INQ_DIM)
+
     err = nc_inq_dimid (fid, name.c_str (), dimid);
     CHECK_NCERR
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_INQ_DIM)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
@@ -304,12 +353,17 @@ int e3sm_io_driver_nc4::inq_dimlen (int fid, int dimid, MPI_Offset *size) {
     int err = 0;
     size_t len;
 
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_INQ_DIM)
+
     err = nc_inq_dimlen (fid, dimid, &len);
     CHECK_NCERR
 
     *size = len;
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_INQ_DIM)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
@@ -329,20 +383,30 @@ int e3sm_io_driver_nc4::put_att (
     int fid, int vid, std::string name, nc_type xtype, MPI_Offset size, const void *buf) {
     int err;
 
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_PUT_ATT)
+
     err = nc_put_att (fid, vid, name.c_str (), xtype, size, buf);
     CHECK_NCERR
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_PUT_ATT)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
 int e3sm_io_driver_nc4::get_att (int fid, int vid, std::string name, void *buf) {
     int err;
 
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_GET_ATT)
+
     err = nc_get_att (fid, vid, name.c_str (), buf);
     CHECK_NCERR
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_GET_ATT)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
@@ -369,6 +433,9 @@ int e3sm_io_driver_nc4::put_vara (int fid,
     int ndim;        // Variable #dim
     size_t bsize;    // Block size
     nc_type xtype;    // Type of the variable
+
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_PUT_VAR)
 
     nc_inq_vartype (fid, vid, &xtype);
     err = e3sm_io_xlen_nc_type (xtype, &xesize);
@@ -473,6 +540,8 @@ int e3sm_io_driver_nc4::put_vara (int fid,
     CHECK_NCERR
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_PUT_VAR)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 int e3sm_io_driver_nc4::put_vars (int fid,
@@ -489,6 +558,9 @@ int e3sm_io_driver_nc4::put_vars (int fid,
     ptrdiff_t *ncstride = NULL;     // Stride in int32
     int esize;                     // Element size of variable type
     nc_type xtype;                 // Type of the variable
+    
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_PUT_VAR)
 
     err = nc_inq_varndims (fid, vid, &ndim);
     CHECK_NCERR
@@ -538,6 +610,8 @@ int e3sm_io_driver_nc4::put_vars (int fid,
 
 err_out:
     if (ncstride) { free (ncstride); }
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_PUT_VAR)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
@@ -557,6 +631,9 @@ int e3sm_io_driver_nc4::put_varn (int fid,
     int xesize;                   // Element size of variable type
     int ndim;                   // Variable #dim
     nc_type xtype;               // Type of the variable
+
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_PUT_VAR)
 
     err = nc_inq_varndims (fid, vid, &ndim);
     CHECK_NCERR
@@ -609,6 +686,8 @@ int e3sm_io_driver_nc4::put_varn (int fid,
     }
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_PUT_VAR)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
@@ -625,6 +704,9 @@ int e3sm_io_driver_nc4::get_vara (int fid,
     int ndim;        // Variable #dim
     size_t bsize;    // Block size
     nc_type xtype;    // Type of the variable
+
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_GET_VAR)
 
     nc_inq_vartype (fid, vid, &xtype);
     err = e3sm_io_xlen_nc_type (xtype, &xesize);
@@ -728,6 +810,8 @@ int e3sm_io_driver_nc4::get_vara (int fid,
     CHECK_NCERR
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_GET_VAR)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 int e3sm_io_driver_nc4::get_vars (int fid,
@@ -744,6 +828,9 @@ int e3sm_io_driver_nc4::get_vars (int fid,
     ptrdiff_t *ncstride = NULL;     // Stride in int32
     int esize;                     // Element size of variable type
     nc_type xtype;                 // Type of the variable
+
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_GET_VAR)
 
     err = nc_inq_varndims (fid, vid, &ndim);
     CHECK_NCERR
@@ -793,6 +880,8 @@ int e3sm_io_driver_nc4::get_vars (int fid,
 
 err_out:
     if (ncstride) { free (ncstride); }
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_GET_VAR)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }
 
@@ -812,6 +901,9 @@ int e3sm_io_driver_nc4::get_varn (int fid,
     int xesize;                   // Element size of variable type
     int ndim;                   // Variable #dim
     nc_type xtype;               // Type of the variable
+
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_GET_VAR)
 
     err = nc_inq_varndims (fid, vid, &ndim);
     CHECK_NCERR
@@ -864,5 +956,7 @@ int e3sm_io_driver_nc4::get_varn (int fid,
     }
 
 err_out:
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_GET_VAR)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
     return err;
 }

--- a/src/e3sm_io_profile_timers.m4
+++ b/src/e3sm_io_profile_timers.m4
@@ -28,6 +28,19 @@ define(`E3SM_IO_TIMERS', `( `total', dnl
                             `adios2_get_var', dnl
                             `adios2_flush', dnl
                             `adios2_close', dnl
+                            `nc4', dnl
+                            `nc4_open', dnl
+                            `nc4_enddef', dnl
+                            `nc4_resize', dnl
+                            `nc4_def_dim', dnl
+                            `nc4_inq_dim', dnl
+                            `nc4_def_var', dnl
+                            `nc4_inq_var', dnl
+                            `nc4_put_att', dnl
+                            `nc4_get_att', dnl
+                            `nc4_put_var', dnl
+                            `nc4_get_var', dnl
+                            `nc4_close', dnl
 
 )')`'dnl
 


### PR DESCRIPTION
Use logvol in hdf5 driver if strategy is log
Check if HDF5_VOL_CONNECTOR is compatible with API and strategy selection
Profiling timers for nc4 driver