### PR TITLE
enable netcdf4 only if NetCDF 4.9.0 and later

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@
   + Experimental software developed as part of the Datalib project
 * (Optional) [ADIOS 2.7.1](https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.7.1.tar.gz)
   + Configured with parallel I/O support (cmake with `-DADIOS2_USE_MPI=ON` is required)
-* (Optional) [NetCDF-C 4.8.1](https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.8.1.tar.gz)
+* (Optional) [NetCDF-C 4.9.0](https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.9.0.tar.gz)
   + Configured with parallel HDF5 support (i.e. `--enable-netcdf4`)
   + Note currently this option fails to run due to a
     [bug](https://github.com/Unidata/netcdf-c/issues/2251) in NetCDF-C.
@@ -79,12 +79,12 @@
   + Configure NetCDF-C with parallel HDF5 I/O enabled.
   + Run `make install`
   + Example build commands are given below. This example will install
-    the NetCDF library under the folder `${HOME}/NetCDF/4.8.1`.
+    the NetCDF library under the folder `${HOME}/NetCDF/4.9.0`.
     ```
-    % wget https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.8.1.tar.gz
-    % tar -zxf v4.8.1.tar.gz
-    % cd netcdf-c-4.8.1
-    % ./configure --prefix=${HOME}/NetCDF/4.8.1 \
+    % wget https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.9.0.tar.gz
+    % tar -zxf v4.9.0.tar.gz
+    % cd netcdf-c-4.9.0
+    % ./configure --prefix=${HOME}/NetCDF/4.9.0 \
                   CC=mpicc \
                   CPPFLAGS=-I${HOME}/HDF5/1.13.0/include \
                   LDFLAGS=-L${HOME}/HDF5/1.13.0/lib \
@@ -121,6 +121,7 @@
                   --with-hdf5=${HOME}/HDF5/1.13.0 \
                   --with-logvol=${HOME}/Log_VOL/1.1.0 \
                   --with-adios2=${HOME}/ADIOS2/2.7.1 \
+                  --with-netcdf4=${HOME}/NetCDF/4.9.0 \
                   CC=mpicc CXX=mpicxx
     % make
     ```
@@ -208,13 +209,13 @@
 
 ### Current supported APIs (option `-a`) and I/O strategies (option `-x`)
   + Table below lists the supported combinations.
-     |           | pnetcdf | hdf5 | hdf5_log | netcdf4 | adios |
-     |-----------|:-------:|:----:|:--------:|:-------:|:-----:|
-     | canonical | yes     | yes  | no       | yes     | no    |
-     | log       | no      | yes  | yes      | yes*    | no    |
-     | blob      | yes     | yes  | no       | no      | yes   |
+     |           | pnetcdf | hdf5 | hdf5_log | netcdf4* | adios |
+     |-----------|:-------:|:----:|:--------:|:--------:|:-----:|
+     | canonical | yes     | yes  | no       | yes      | no    |
+     | log       | no      | yes  | yes      | yes      | no    |
+     | blob      | yes     | yes  | no       | no       | yes   |
      
-     `*` Requires setting of 2 VOL environment variables. See description below.
+     `*` NetCDF-C version 4.9.0 or newer is required.
 
   + **-a pnetcdf -x canonical**
     * A single NetCDF file in the classic CDF5 format will be created. All

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ endif
 if ENABLE_LOGVOL
    TESTS_ENVIRONMENT += export ENABLE_LOGVOL=1;
    TESTS_ENVIRONMENT += export LOGVOL_LIB_PATH="@LOGVOL_LIB_PATH@";
+   TESTS_ENVIRONMENT += export H5LDUMP="@H5LDUMP@";
 endif
 
 TESTS = test.sh
@@ -40,7 +41,7 @@ EXTRA_DIST =   test.sh \
                AUTHORS \
                slurm.knl
 
-ptest: $(check_PROGRAMS)
+ptest: src/e3sm_io
 	@echo "==========================================================="
 	@echo "    Parallel testing on 16 MPI processes"
 	@echo "==========================================================="

--- a/configure.ac
+++ b/configure.ac
@@ -330,7 +330,7 @@ AM_CONDITIONAL(ENABLE_PNC, [test "x$have_pnc" = xyes])
 have_hdf5=no
 have_multi_dset=no
 AC_ARG_WITH([hdf5],
-   [AS_HELP_STRING([--with-hdf5@<:@=INC,LIB | =DIR@:>@], 
+   [AS_HELP_STRING([--with-hdf5@<:@=INC,LIB | =DIR@:>@],
                    [Enable HDF5 feature and provide the HDF5 installation path(s):
     --with-hdf5=INC,LIB for include and lib paths separated by a comma.
     --with-hdf5=DIR for the path containing include/ and lib/ subdirectories.
@@ -420,7 +420,7 @@ AC_ARG_WITH([netcdf4],
         if test -n "$withval"; then
           netcdf4_inc="$withval/include"
           netcdf4_lib="$withval/lib"
-          netcdf4_bindir="$NETCDF4_INSTALL/bin"
+          netcdf4_bindir="$withval/bin"
         fi
         ;;
    esac
@@ -506,7 +506,7 @@ AC_ARG_WITH([netcdf4],
       AC_MSG_WARN([
       ------------------------------------------------------------
       NetCDF was not built with parallel NetCDF 4 support.
-      Disable NetCDF4. 
+      Disable NetCDF4.
       ------------------------------------------------------------])
       have_netcdf4 = no
    elif test "x$netcdf4_lib" != x ; then
@@ -535,11 +535,13 @@ AC_ARG_WITH([logvol],
      *,*)
         logvol_inc="`echo $withval |cut -f1 -d,`"
         logvol_lib="`echo $withval |cut -f2 -d, -s`"
+        logvol_bindir="$logvol_inc/../bin"
         ;;
      *)
         if test -n "$withval"; then
           logvol_inc="$withval/include"
           logvol_lib="$withval/lib"
+          logvol_bindir="$withval/bin"
         fi
         ;;
    esac
@@ -570,6 +572,15 @@ AC_ARG_WITH([logvol],
    fi
    if test "x$have_logvol" = xyes ; then
       AC_SUBST(LOGVOL_LIB_PATH, [$logvol_lib])
+   fi
+   if test "x$logvol_bindir" != x ; then
+      AC_PATH_PROG([h5ldump],[h5ldump],,[$logvol_bindir])
+   else
+      dnl Check h5ldump under $PATH
+      AC_PATH_PROG([h5ldump],[h5ldump])
+   fi
+   if test "x$h5ldump" != x ; then
+      AC_SUBST(H5LDUMP, [$h5ldump])
    fi
 ])
 AM_CONDITIONAL(ENABLE_LOGVOL, [test "x$have_logvol" = xyes])
@@ -650,9 +661,9 @@ if test "x${have_pnc}" = xno && test "x${have_nc4}" = xno && test "x${have_hdf5}
    -----------------------------------------------------------------------
     At least one API driver must be enabled.
     Use configure command-line option --with-pnetcdf=/path/to/implementation
-    to specify the location of PnetCDF installation. 
+    to specify the location of PnetCDF installation.
     Use configure command-line option --with-netcdf4=/path/to/implementation
-    to specify the location of NetCDF installation. 
+    to specify the location of NetCDF installation.
     Use configure command-line option --with-hdf5=/path/to/implementation
     to specify the location of HDF5 installation.
     Use configure command-line option --with-adios2=/path/to/implementation

--- a/configure.ac
+++ b/configure.ac
@@ -433,6 +433,7 @@ AC_ARG_WITH([netcdf4],
    if test "x$netcdf4_config" != x ; then
       netcdf4_cflags=`$netcdf4_config --cflags`
       netcdf4_lflags=`$netcdf4_config --libs`
+      netcdf4_version=`$netcdf4_config --version | cut -d' ' -f2 | cut -d'-' -f1`
    else
       netcdf4_cflags="-I$netcdf4_inc"
       netcdf4_lflags="-L$netcdf4_lib"
@@ -453,17 +454,48 @@ AC_ARG_WITH([netcdf4],
          LDFLAGS="$LDFLAGS $netcdf4_lflags"
       fi
    fi
-   AC_CHECK_HEADER([netcdf.h], [have_netcdf4=yes], [have_netcdf4=no])
+   AC_CHECK_HEADERS([netcdf.h netcdf_meta.h], [have_netcdf4=yes], [have_netcdf4=no])
    if test "x$have_netcdf4" = xno ; then
       AC_MSG_WARN([
       -----------------------------------------------------------------------
-      Missing NetCDF-header files 'netcdf4_c.h' required to build E3SM_IO. Use
-      configure command-line option --with-netcdf4=/path/to/implementation
-      to specify the location of NetCDF installation. Disable NetCDF 4 support.
+      Missing NetCDF-header files 'netcdf.h' or 'netcdf_meta.h' which are
+      required to build E3SM_IO. Use configure command-line option
+      --with-netcdf4=/path/to/implementation to specify the location of
+      NetCDF-4 installation. Disable NetCDF-4 support.
       -----------------------------------------------------------------------])
    fi
 
-   AC_MSG_CHECKING([if NetCDF $netcdf_version is configured with parallel I/O enabled])
+   if test "x$have_netcdf4" = xyes ; then
+      AC_MSG_CHECKING([NetCDF-C version])
+      if test "x$netcdf4_version" = x ; then
+         nc_version_major=`${EGREP} NC_VERSION_MAJOR $netcdf4_inc/netcdf_meta.h| head -1 | cut -d' ' -f3`
+         nc_version_minor=`${EGREP} NC_VERSION_MINOR $netcdf4_inc/netcdf_meta.h| head -1 | cut -d' ' -f3`
+         nc_version_patch=`${EGREP} NC_VERSION_PATCH $netcdf4_inc/netcdf_meta.h| head -1 | cut -d' ' -f3`
+         netcdf4_version="${nc_version_major}.${nc_version_minor}.${nc_version_patch}"
+      fi
+      AC_MSG_RESULT([$netcdf4_version])
+
+      dnl Check if NetCDF version is 4.9.0 or later
+      AC_MSG_CHECKING([whether NetCDF-C version is 4.9.0 or later])
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <netcdf_meta.h>
+#define VER_NUM (NC_VERSION_MAJOR*1000000 + NC_VERSION_MINOR*1000 + NC_VERSION_PATCH)
+#if (VER_NUM < 4009000)
+#error NetCDF version is older than 4.9.0
+#endif
+      ]])], [netcdf_ge_4_9_0=yes], [netcdf_ge_4_9_0=no])
+      AC_MSG_RESULT([$netcdf_ge_4_9_0])
+
+      if test "x${netcdf_ge_4_9_0}" = xno; then
+         AC_MSG_ERROR([
+         ------------------------------------------------------------
+         Supplied NetCDF-4 version is $netcdf4_version, but 4.9.0 or later
+         is required. Abort.
+         ------------------------------------------------------------])
+      fi
+   fi
+
+   AC_MSG_CHECKING([if NetCDF-4 is configured with parallel I/O enabled])
    if test "x$netcdf4_config" != x ; then
       netcdf4_has_par=`$netcdf4_config --has-parallel4`
    else

--- a/src/drivers/e3sm_io_driver_nc4.cpp
+++ b/src/drivers/e3sm_io_driver_nc4.cpp
@@ -73,7 +73,7 @@ int e3sm_io_driver_nc4::create (std::string path, MPI_Comm comm, MPI_Info info, 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_OPEN)
 
-    err = nc_create_par (path.c_str (), NC_CLOBBER | NC_NETCDF4, comm, info, fid);
+    err = nc_create_par (path.c_str (), NC_CLOBBER | NC_NETCDF4 | NC_NODIMSCALE_ATTACH, comm, info, fid);
     CHECK_NCERR
 
     /* turn off fill mode for the entire file */

--- a/test.sh
+++ b/test.sh
@@ -86,6 +86,7 @@ for DECOM in "${DECOMPS[@]}" ; do
         fi
     done
 done
+if test $VERBOSE = 1 ; then echo ""; fi
 
 for API in "${APIS[@]}" ; do
     ap=($API)
@@ -96,12 +97,12 @@ for API in "${APIS[@]}" ; do
 
     for CONFIG in "${CONFIGS[@]}" ; do
         IN_FILE=datasets/${CONFIG}
-        OUT_FILE="${OUT_PATH}/${ap[0]}_${ap[1]}_${CONFIG}"
+        OUT_FILE_BASE="${OUT_PATH}/${ap[0]}_${ap[1]}_${CONFIG}"
         if test "x${ap[0]}" = xpnetcdf ; then
-           IN_FILE="${srcdir}/${IN_FILE}.nc"
-           OUT_FILE+=".nc"
+           FILE_EXT="nc"
+           IN_FILE="${srcdir}/${IN_FILE}.${FILE_EXT}"
         elif test "x${ap[0]}" = xnetcdf4 ; then
-           OUT_FILE+=".nc4"
+           FILE_EXT="nc4"
            if test "x${ap[1]}" = xlog ; then
               # This option requires the two VOL environment variables to be set.
               export HDF5_PLUGIN_PATH="$LOGVOL_LIB_PATH"
@@ -109,19 +110,48 @@ for API in "${APIS[@]}" ; do
               # Decomposition file must be read with native VOL, use nc file
               IN_FILE="${srcdir}/${IN_FILE}.nc"
            else
-              IN_FILE+=".nc4"
+              IN_FILE+=".${FILE_EXT}"
            fi
         elif test "x${ap[0]}" = xhdf5 || test "x${ap[0]}" = xhdf5_log ; then
-           IN_FILE+=".h5"
-           OUT_FILE+=".h5"
+           FILE_EXT="h5"
+           IN_FILE+=".${FILE_EXT}"
         elif test "x${ap[0]}" = xadios ; then
-           IN_FILE+=".bp"
-           OUT_FILE+=".bp"
+           FILE_EXT="bp"
+           IN_FILE+=".${FILE_EXT}"
         fi
 
-        CMD="${RUN} ${EXEC} -k -a ${ap[0]} -f -1 -r 2 -x ${ap[1]} -y 2 -o ${OUT_FILE} ${IN_FILE}"
-        if test $VERBOSE = 1 ; then echo "${CMD}"; fi
+        # construct real output file names
+        OUT_FILE="${OUT_FILE_BASE}.${FILE_EXT}"
+        if test $CONFIG = f_case_866x72_16p ; then
+           REAL_OUT_FILE="${OUT_FILE_BASE}_h0.${FILE_EXT} ${OUT_FILE_BASE}_h1.${FILE_EXT}"
+        elif test $CONFIG = g_case_cmpaso_16p ; then
+           REAL_OUT_FILE="${OUT_FILE_BASE}.${FILE_EXT}"
+        elif test $CONFIG = i_case_f19_g16_16p ; then
+           REAL_OUT_FILE="${OUT_FILE_BASE}_h0.${FILE_EXT} ${OUT_FILE_BASE}_h1.${FILE_EXT}"
+        fi
+
+        CMD="${RUN} ${EXEC} -k -a ${ap[0]} -r 2 -x ${ap[1]} -y 2 -o ${OUT_FILE} ${IN_FILE}"
+        echo "${CMD}"
         ${CMD}
+
+        # for log strategy, check if the output files are log-based VOL files
+        if test "x${ap[1]}" = xlog ; then
+           unset HDF5_VOL_CONNECTOR
+           unset HDF5_PLUGIN_PATH
+
+           for f in $REAL_OUT_FILE
+           do
+             echo "$H5LDUMP -k $f"
+             FILE_KIND=`$H5LDUMP -k $f`
+             if test "x${FILE_KIND}" != xHDF5-LogVOL ; then
+                echo "Error: Output file $f is not Log VOL, but ${FILE_KIND}"
+                exit 1
+             else
+                echo "Success: Output file $f is ${FILE_KIND}"
+                echo ""
+             fi
+           done
+        fi
     done
 done
 

--- a/test.sh
+++ b/test.sh
@@ -48,13 +48,6 @@ if test "x${ENABLE_ADIOS2}" = x1 ; then
 fi
 
 if test "x${ENABLE_NETCDF4}" = x1 ; then
-   if test "x$#" = x0 ; then :; else
-      echo "==================================================================="
-      echo "Warning: skip NetCDF-4 parallel tests due to a bug in NetCDF-C"
-      echo "         version 4.8.1 and prior. See bug issue"
-      echo "         https://github.com/Unidata/netcdf-c/issues/2251"
-      echo "==================================================================="
-   fi
    APIS+=("netcdf4 canonical")
    export LD_LIBRARY_PATH=${HDF5_LIB_PATH}:${NETCDF4_LIB_PATH}:${LD_LIBRARY_PATH}
    if test "x${ENABLE_LOGVOL}" = x1 ; then
@@ -108,7 +101,6 @@ for API in "${APIS[@]}" ; do
            IN_FILE="${srcdir}/${IN_FILE}.nc"
            OUT_FILE+=".nc"
         elif test "x${ap[0]}" = xnetcdf4 ; then
-           if test "x$#" = x0 ; then :; else continue; fi
            OUT_FILE+=".nc4"
            if test "x${ap[1]}" = xlog ; then
               # This option requires the two VOL environment variables to be set.

--- a/tests/icase_def.c
+++ b/tests/icase_def.c
@@ -93,23 +93,31 @@ err = nc_def_dim(ncid, "levdcmp", 15, &dimids[18]); ERR
 err = nc_def_dim(ncid, "levtrc", 10, &dimids[19]); ERR
 err = nc_def_dim(ncid, "hist_interval", 2, &dimids[20]); ERR
 
+#ifdef DIM_SCALE
 err = nc_def_var(ncid, "levgrnd", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 22, "coordinate soil levels"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 1, "m"); ERR
+#endif
 
+#ifdef DIM_SCALE
 err = nc_def_var(ncid, "levlak", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 22, "coordinate lake levels"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 1, "m"); ERR
+#endif
 
+#ifdef DIM_SCALE
 err = nc_def_var(ncid, "levdcmp", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 22, "coordinate soil levels"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 1, "m"); ERR
+#endif
 
+#ifdef DIM_SCALE
 err = nc_def_var(ncid, "time", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 4, "time"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 30, "days since 0001-01-01 00:00:00"); ERR
 err = nc_put_att(ncid, varid, "calendar", NC_CHAR, 6, "noleap"); ERR
 err = nc_put_att(ncid, varid, "bounds", NC_CHAR, 11, "time_bounds"); ERR
+#endif
 
 err = nc_def_var(ncid, "mcdate", NC_INT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 23, "current date (YYYYMMDD)"); ERR
@@ -134,17 +142,21 @@ err = nc_def_var(ncid, "date_written", NC_CHAR, 2, dimids, &varid); ERR
 
 err = nc_def_var(ncid, "time_written", NC_CHAR, 2, dimids, &varid); ERR
 
+#ifdef DIM_SCALE
 err = nc_def_var(ncid, "lon", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 20, "coordinate longitude"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 12, "degrees_east"); ERR
 err = nc_put_att(ncid, varid, "_FillValue", NC_FLOAT, 1, buf); ERR
 err = nc_put_att(ncid, varid, "missing_value", NC_FLOAT, 1, buf); ERR
+#endif
 
+#ifdef DIM_SCALE
 err = nc_def_var(ncid, "lat", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 19, "coordinate latitude"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 13, "degrees_north"); ERR
 err = nc_put_att(ncid, varid, "_FillValue", NC_FLOAT, 1, buf); ERR
 err = nc_put_att(ncid, varid, "missing_value", NC_FLOAT, 1, buf); ERR
+#endif
 
 err = nc_def_var(ncid, "area", NC_FLOAT, 2, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 15, "grid cell areas"); ERR

--- a/tests/icase_def.c
+++ b/tests/icase_def.c
@@ -23,10 +23,16 @@ static void def(int ncid);
 
 int main(int argc, char *argv[])
 {
-   int err=NC_NOERR, ncid;
+   int err=NC_NOERR, ncid, cmode;
 
    MPI_Init(&argc, &argv);
-   err = nc_create_par("testfile.nc", NC_NETCDF4|NC_CLOBBER, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid); ERR
+
+   cmode = NC_CLOBBER | NC_NETCDF4;
+#ifdef NC_NODIMSCALE_ATTACH
+   cmode |= NC_NODIMSCALE_ATTACH
+#endif
+
+   err = nc_create_par("testfile.nc", cmode, MPI_COMM_WORLD, MPI_INFO_NULL, &ncid); ERR
    err = nc_set_fill(ncid, NC_NOFILL, NULL); ERR
 
    /* define global attributes, dimensions, variables */
@@ -93,31 +99,23 @@ err = nc_def_dim(ncid, "levdcmp", 15, &dimids[18]); ERR
 err = nc_def_dim(ncid, "levtrc", 10, &dimids[19]); ERR
 err = nc_def_dim(ncid, "hist_interval", 2, &dimids[20]); ERR
 
-#ifdef DIM_SCALE
 err = nc_def_var(ncid, "levgrnd", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 22, "coordinate soil levels"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 1, "m"); ERR
-#endif
 
-#ifdef DIM_SCALE
 err = nc_def_var(ncid, "levlak", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 22, "coordinate lake levels"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 1, "m"); ERR
-#endif
 
-#ifdef DIM_SCALE
 err = nc_def_var(ncid, "levdcmp", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 22, "coordinate soil levels"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 1, "m"); ERR
-#endif
 
-#ifdef DIM_SCALE
 err = nc_def_var(ncid, "time", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 4, "time"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 30, "days since 0001-01-01 00:00:00"); ERR
 err = nc_put_att(ncid, varid, "calendar", NC_CHAR, 6, "noleap"); ERR
 err = nc_put_att(ncid, varid, "bounds", NC_CHAR, 11, "time_bounds"); ERR
-#endif
 
 err = nc_def_var(ncid, "mcdate", NC_INT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 23, "current date (YYYYMMDD)"); ERR
@@ -142,21 +140,17 @@ err = nc_def_var(ncid, "date_written", NC_CHAR, 2, dimids, &varid); ERR
 
 err = nc_def_var(ncid, "time_written", NC_CHAR, 2, dimids, &varid); ERR
 
-#ifdef DIM_SCALE
 err = nc_def_var(ncid, "lon", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 20, "coordinate longitude"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 12, "degrees_east"); ERR
 err = nc_put_att(ncid, varid, "_FillValue", NC_FLOAT, 1, buf); ERR
 err = nc_put_att(ncid, varid, "missing_value", NC_FLOAT, 1, buf); ERR
-#endif
 
-#ifdef DIM_SCALE
 err = nc_def_var(ncid, "lat", NC_FLOAT, 1, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 19, "coordinate latitude"); ERR
 err = nc_put_att(ncid, varid, "units", NC_CHAR, 13, "degrees_north"); ERR
 err = nc_put_att(ncid, varid, "_FillValue", NC_FLOAT, 1, buf); ERR
 err = nc_put_att(ncid, varid, "missing_value", NC_FLOAT, 1, buf); ERR
-#endif
 
 err = nc_def_var(ncid, "area", NC_FLOAT, 2, dimids, &varid); ERR
 err = nc_put_att(ncid, varid, "long_name", NC_CHAR, 15, "grid cell areas"); ERR


### PR DESCRIPTION
NC_NODIMSCALE_ATTACH is first defined in NetCDF-C version 4.9.0.
This flag is required to run netcdf4 option. See
https://github.com/Unidata/netcdf-c/issues/2251