### PR TITLE
Use FTS if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -214,6 +214,16 @@ AC_LANG_POP(C++)
 
 AC_PROG_RANLIB
 
+AC_HEADER_STAT
+AC_HEADER_STDC
+AC_CHECK_HEADERS([fts.h])
+
+# Force to use MPICXX to check C++ header
+saved_CC=$CC
+CC=$MPICXX
+AC_CHECK_HEADERS_ONCE([filesystem])
+CC=$saved_CC
+
 AC_CHECK_DECL([access], [], [], [[#include <unistd.h>]])
 if test "x$ac_cv_have_decl_access" = xyes ; then
    AC_CHECK_FUNCS([access])


### PR DESCRIPTION
This commit uses fts functions if they are available, as Danqing Wu
at ANL reported that C++ header file filesystem.hpp is not always
available.

* GCC 7.4 or 7.5 supports "-std=c++17" option, but "#include <filesystem>" is not supported.
  "-std=c++2a" or -std=c++20" is not recognized.
* GCC 8.1 or 9.4 supports "-std=c++17" or "-std=c++2a", and "#include <filesystem>" is also supported.
  "-std=c++20" is not recognized.
* GCC 10.1 or higher supports "-std=c++17", "-std=c++2a", "-std=c++20" and "#include <filesystem>"