### PR TITLE
Change default setting for number of subfiles

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -815,6 +815,13 @@ if test "x$have_logvol" = xyes ; then
    if test "x$have_h5pset_buffered" = xyes ; then
       AC_DEFINE([LOGVOL_HAVE_H5PSET_BUFFERED], [1], [Whether log-based VOL have H5Pset_buffered])
    fi
+
+   # Check if the 2nd argument of H5Pget_subfiling is declared as type int*
+   # In Log VOL 1.3.0, it was declared as type hbool_t*
+   AC_CHECK_DECLS([[H5Pget_subfiling(hid_t, int*)]], [], [], [[#include <H5VL_log.h>]])
+   if test x$ac_cv_have_decl_H5Pget_subfiling_hid_t__intp_ = xyes; then
+      AC_DEFINE([LOGVOL_HAVE_GET_NSUBFILES], [1], [Whether log-based VOL can set the number of subfiles])
+   fi
    CC=$saved_CC
 fi
 

--- a/src/cases/report_timing.cpp
+++ b/src/cases/report_timing.cpp
@@ -139,13 +139,21 @@ int print_timing_WR(e3sm_io_config *cfg,
         else /* write happens at file close for hdf5 blob and adios blob */
             wTime = max_dbl[5];
 
-        if (cfg->strategy == blob) {
+        if (cfg->strategy == log && cfg->api == hdf5_log) {
+            if (cfg->num_subfiles != 0) {
+                printf("History output folder names        = %s.subfiles\n", cmeta->outfile);
+                printf("History output subfile names       = %s.subfiles/%s.xxxx\n",
+                       cmeta->outfile, basename(cmeta->outfile));
+            }
+            printf("Number of subfiles                 = %d\n", cfg->num_subfiles);
+        }
+        else if (cfg->strategy == blob) {
             printf("History output name base           = %s\n", cfg->out_path);
             if (cfg->api == adios) {
                 printf("History output folder name         = %s.bp.dir\n", cmeta->outfile);
                 printf("History output subfile names       = %s.bp.dir/%s.bp.xxxx\n",
                        cmeta->outfile, basename(cmeta->outfile));
-                printf("Number of subfiles                 = %d\n", cfg->num_group);
+                printf("Number of subfiles                 = %d\n", cfg->num_subfiles);
                 if (cfg->verbose)
                     printf("Output file size                   = %.2f MiB = %.2f GiB\n",
                         (double)cmeta->file_size / 1048576, (double)cmeta->file_size / 1073741824);

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -176,7 +176,7 @@ int e3sm_io_driver_adios2::create (std::string path, MPI_Comm comm, MPI_Info inf
     aerr = adios2_set_engine (fp->iop, "BP3");
     CHECK_AERR
 
-    sprintf (ng, "%d", cfg->num_group);
+    sprintf (ng, "%d", cfg->num_subfiles);
     aerr = adios2_set_parameter (fp->iop, "substreams", ng);
     CHECK_AERR
     aerr = adios2_set_parameter (fp->iop, "CollectiveMetadata", "OFF");
@@ -688,8 +688,8 @@ int e3sm_io_driver_adios2::put_att (
 
     // ADIOS2 write attributes in each subfile
     // Instead of finding the exact process writing the attribute 
-    // we count them in the first num_group processes
-    if (fp->rank < cfg->num_group) {
+    // we count them in the first num_subfiles processes
+    if (fp->rank < cfg->num_subfiles) {
         esize = adios2_type_size (atype);
         this->amount_WR += size * esize;
     }

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -79,7 +79,9 @@ e3sm_io_driver_hdf5::e3sm_io_driver_hdf5 (e3sm_io_config *cfg) : e3sm_io_driver 
         throw "Fitler requries chunking in HDF5";
     }
 
-    if (cfg->num_group != 1) { throw "Subfiling not supported by HDF5 driver"; }
+    /* Note cfg->num_subfiles is used by the log-based VOL method and ignored
+     * by others.
+     */
 
     /*
     env = getenv ("E3SM_IO_HDF5_ENABLE_LOGVOL");

--- a/src/drivers/e3sm_io_driver_hdf5_log.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5_log.hpp
@@ -23,6 +23,7 @@ class e3sm_io_driver_hdf5_log : public e3sm_io_driver_hdf5 {
     // Config
     bool use_logvol_varn  = true;
     bool merge_varn       = false;
+    int num_subfiles      = 0;
 
    public:
     e3sm_io_driver_hdf5_log (e3sm_io_config *cfg);

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -101,7 +101,9 @@ static void usage (char *argv0) {
                 and HDF5 blob I/O options, which always flushes at file close).\n\
        [-s num] Stride interval of ranks for selecting MPI processes to perform\n\
                 I/O tasks (default: 1, i.e. all MPI processes).\n\
-       [-g num] Number of subfiles, used by ADIOS I/O only (default: 1).\n\
+       [-g num] Number of subfiles, used by Log-based VOL and ADIOS I/O only,\n\
+                -1 for one subfile per compute node, 0 to disable subfiling,\n\
+                (default: 0).\n\
        [-o path] Output file path (folder name when subfiling is used, file\n\
                  name otherwise).\n\
        [-a api]  I/O library name\n\
@@ -144,7 +146,7 @@ int main (int argc, char **argv) {
     cfg.io_comm        = MPI_COMM_WORLD;
     cfg.info           = MPI_INFO_NULL;
     cfg.num_iotasks    = cfg.np;
-    cfg.num_group      = 1;
+    cfg.num_subfiles   = 0;
     cfg.out_path[0]    = '\0';
     cfg.in_path[0]     = '\0';
     cfg.decomp_path[0] = '\0';
@@ -254,7 +256,7 @@ int main (int argc, char **argv) {
                 cfg.hx = atoi (optarg);
                 break;
             case 'g':
-                cfg.num_group = atoi (optarg);
+                cfg.num_subfiles = atoi (optarg);
                 break;
             case 'c':
                 cfg.chunksize = atoll (optarg);

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -138,7 +138,7 @@ typedef struct e3sm_io_config {
     MPI_Comm io_comm;
     MPI_Info info;
     int num_iotasks;
-    int num_group;
+    int num_subfiles;
 
     char in_path[E3SM_IO_MAX_PATH];
     char out_path[E3SM_IO_MAX_PATH];
@@ -163,8 +163,7 @@ typedef struct e3sm_io_config {
     int io_stride;
     int profiling;
 
-    /* below 3 are used for PnetCDF blob I/O subfiling */
-    int      num_subfiles; /* number of subfiles */
+    /* below are used for PnetCDF blob I/O subfiling */
     int      subfile_ID;   /* unique file identifier for subfiles */
     MPI_Comm sub_comm;     /* communicator for a subfile */
     int      sub_rank;     /* rank in sub_comm */

--- a/src/read_decomp.cpp
+++ b/src/read_decomp.cpp
@@ -129,7 +129,7 @@ int read_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
     decom_cfg.io_comm        = MPI_COMM_WORLD;
     decom_cfg.info           = MPI_INFO_NULL;
     decom_cfg.num_iotasks    = nprocs;
-    decom_cfg.num_group      = 1;
+    decom_cfg.num_subfiles   = 0;
     decom_cfg.out_path[0]    = '\0';
     decom_cfg.in_path[0]     = '\0';
     decom_cfg.decomp_path[0] = '\0';

--- a/utils/dat2decomp.cpp
+++ b/utils/dat2decomp.cpp
@@ -631,7 +631,7 @@ int main (int argc, char **argv) {
     cfg.io_comm        = comm;
     cfg.info           = MPI_INFO_NULL;
     cfg.num_iotasks    = 1;
-    cfg.num_group      = 1;
+    cfg.num_subfiles   = 0;
     cfg.out_path[0]    = '\0';
     cfg.in_path[0]     = '\0';
     cfg.decomp_path[0] = '\0';

--- a/utils/decomp_copy.cpp
+++ b/utils/decomp_copy.cpp
@@ -138,7 +138,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
     cfg_in.io_comm        = MPI_COMM_SELF;
     cfg_in.info           = MPI_INFO_NULL;
     cfg_in.num_iotasks    = cfg_in.np;
-    cfg_in.num_group      = 1;
+    cfg_in.num_subfiles   = 0;
     cfg_in.out_path[0]    = '\0';
     cfg_in.in_path[0]     = '\0';
     cfg_in.decomp_path[0] = '\0';
@@ -446,7 +446,7 @@ int main (int argc, char **argv) {
     cfg.info           = MPI_INFO_NULL;
     cfg.np             = nprocs;
     cfg.num_iotasks    = cfg.np;
-    cfg.num_group      = 1;
+    cfg.num_subfiles   = 0;
     cfg.out_path[0]    = '\0';
     cfg.in_path[0]     = '\0';
     cfg.decomp_path[0] = '\0';


### PR DESCRIPTION
* Rename num_group to num_subfiles
* Command-line option -g is to set the number of subfiles.
* Extend option -g to both ADIOS and HDF5 Log-based VOL
* Ignore option -g when using other I/O methods.
* When -g is set to 0, subfiling is disabled.
* When -g is not set, subfiling is disabled.
* When -g is set to a negative value, one subfile per compute node.

When using the HDF5 Log-based VOL, the number of subfiles can also be
set through environment variable H5VL_LOG_NSUBFILES. This environment
variable supersedes the command-line option -g. Its values are similar
to option -g described above. See Log-based VOL pull request 32
https://github.com/DataLib-ECP/vol-log-based/pull/32