### PR TITLE
Add option to sleep between two consecutive time steps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -186,6 +186,8 @@
        [-s num] Stride interval of ranks for selecting MPI processes to perform
                 I/O tasks (default: 1, i.e. all MPI processes).\n\
        [-g num] Number of subfiles, used by ADIOS I/O only (default: 1).
+       [-t time] Add sleep time to emulate the computation in order to 
+                 overlapping I/O when Async VOL is used.
        [-o path] Output file path (folder name when subfiling is used, file
                  name otherwise).
        [-a api]  I/O library name
@@ -390,7 +392,7 @@
 
 ## Example Output Shown on Screen
 ```
-  % mpiexec -n 16 ./e3sm_io -o can_F_out.nc datasets/f_case_866x72_16p.nc
+  % mpiexec -n 16 src/e3sm_io -o can_F_out.nc datasets/f_case_866x72_16p.nc
   ==== Benchmarking F case =============================
   Total number of MPI processes      = 16
   Number of IO processes             = 16
@@ -406,22 +408,25 @@
   No. variables use decomposition D1 =    323
   No. variables use decomposition D2 =     63
   Total no. climate variables        =    414
+  Total no. attributes               =   1421
   Total no. noncontiguous requests   = 1977687
   Max   no. noncontiguous requests   = 189503
+  Min   no. noncontiguous requests   =  63170
   Write no. records (time dim)       =      1
   I/O flush frequency                =      1
   No. I/O flush calls                =      1
   -----------------------------------------------------------
-  Total write amount                 = 16.16 MiB = 0.02 GiB
-  Max Time of I/O preparing          = 0.0012 sec
-  Max Time of file open/create       = 0.0003 sec
-  Max Time of define variables       = 0.0674 sec
-  Max Time of posting write requests = 0.0331 sec
-  Max Time of write flushing         = 0.7664 sec
-  Max Time of close                  = 0.0044 sec
-  Max end-to-end time                = 0.8729 sec
-  I/O bandwidth (write-only)         = 21.0894 MiB/sec
-  I/O bandwidth (open-to-close)      = 18.5172 MiB/sec
+  Total write amount                         = 16.16 MiB = 0.02 GiB
+  Time of I/O preparing              min/max =   0.0008 /   0.0013
+  Time of file open/create           min/max =   0.0005 /   0.0006
+  Time of define variables           min/max =   0.0031 /   0.0033
+  Time of posting write requests     min/max =   0.0124 /   0.0257
+  Time of write flushing             min/max =   0.2817 /   0.2837
+  Time of close                      min/max =   0.0029 /   0.0029
+  end-to-end time                    min/max =   0.3175 /   0.3176
+  Emulate computation time (sleep)   min/max =   0.0000 /   0.0000
+  I/O bandwidth in MiB/sec (write-only)      = 56.9648
+  I/O bandwidth in MiB/sec (open-to-close)   = 50.8962
   -----------------------------------------------------------
   ==== Benchmarking F case =============================
   Total number of MPI processes      = 16
@@ -438,24 +443,27 @@
   No. variables use decomposition D1 =     22
   No. variables use decomposition D2 =      1
   Total no. climate variables        =     51
+  Total no. attributes               =    142
   Total no. noncontiguous requests   =  38332
   Max   no. noncontiguous requests   =   3668
+  Min   no. noncontiguous requests   =   1225
   Write no. records (time dim)       =      1
   I/O flush frequency                =      1
   No. I/O flush calls                =      1
   -----------------------------------------------------------
-  Total write amount                 = 0.34 MiB = 0.00 GiB
-  Max Time of I/O preparing          = 0.0000 sec
-  Max Time of file open/create       = 0.0048 sec
-  Max Time of define variables       = 0.0063 sec
-  Max Time of posting write requests = 0.0007 sec
-  Max Time of write flushing         = 0.0099 sec
-  Max Time of close                  = 0.0006 sec
-  Max end-to-end time                = 0.0223 sec
-  I/O bandwidth (write-only)         = 34.0947 MiB/sec
-  I/O bandwidth (open-to-close)      = 15.1156 MiB/sec
+  Total write amount                         = 0.34 MiB = 0.00 GiB
+  Time of I/O preparing              min/max =   0.0000 /   0.0000
+  Time of file open/create           min/max =   0.0005 /   0.0005
+  Time of define variables           min/max =   0.0002 /   0.0003
+  Time of posting write requests     min/max =   0.0002 /   0.0004
+  Time of write flushing             min/max =   0.0034 /   0.0034
+  Time of close                      min/max =   0.0002 /   0.0003
+  end-to-end time                    min/max =   0.0049 /   0.0049
+  Emulate computation time (sleep)   min/max =   0.0000 /   0.0000
+  I/O bandwidth in MiB/sec (write-only)      = 98.0321
+  I/O bandwidth in MiB/sec (open-to-close)   = 68.3491
   -----------------------------------------------------------
-  read_decomp=0.00 e3sm_io_core=0.90 MPI init-to-finalize=0.90
+  read_decomp=0.00 e3sm_io_core=0.32 MPI init-to-finalize=0.33
   -----------------------------------------------------------
 ```
 ## Output Files

--- a/src/cases/report_timing.cpp
+++ b/src/cases/report_timing.cpp
@@ -200,6 +200,7 @@ int print_timing_WR(e3sm_io_config *cfg,
         printf("Time of write flushing             min/max = %8.4f / %8.4f\n", min_dbl[4], max_dbl[4]);
         printf("Time of close                      min/max = %8.4f / %8.4f\n", min_dbl[5], max_dbl[5]);
         printf("end-to-end time                    min/max = %8.4f / %8.4f\n", min_dbl[6], max_dbl[6]);
+        printf("Emulate computation time (sleep)   min/max = %8.4f / %8.4f\n", (double)(cfg->comp_time), (double)(cfg->comp_time));
         printf("I/O bandwidth in MiB/sec (write-only)      = %.4f\n",
                (double)sum_amount_WR / 1048576.0 / wTime);
         printf("I/O bandwidth in MiB/sec (open-to-close)   = %.4f\n",

--- a/src/cases/var_wr_case.cpp
+++ b/src/cases/var_wr_case.cpp
@@ -307,6 +307,10 @@ int e3sm_io_case::var_wr_case(e3sm_io_config &cfg,
     fix_dbl_buf_ptr = wr_buf.fix_dbl_buf;
 
     for (rec_no=0; rec_no<cmeta->nrecs; rec_no++) {
+        if (cfg.comp_time > 0) {
+            sleep ((unsigned int)(cfg.comp_time));
+        }
+
         if ((cfg.api == hdf5 && cfg.strategy != blob) || cfg.api == netcdf4) {
             err = driver.expand_rec_size (ncid, rec_no + 1);
             CHECK_ERR
@@ -441,7 +445,7 @@ int e3sm_io_case::var_wr_case(e3sm_io_config &cfg,
     cmeta->my_nreqs        = my_nreqs;
     cmeta->metadata_WR     = metadata_size;
     cmeta->amount_WR       = total_size;
-    cmeta->end2end_time    = MPI_Wtime() - cmeta->end2end_time;
+    cmeta->end2end_time    = MPI_Wtime () - cmeta->end2end_time;
 
     /* check if there is any PnetCDF internal malloc residue */
     check_malloc(&cfg, &driver);

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -269,6 +269,7 @@ int e3sm_io_driver_hdf5::inq_file_info (int fid, MPI_Info *info) {
 
     pid = H5Fget_access_plist (fp->id);
     CHECK_HID (pid);
+    // Only MPI VFD supports H5Pget_fapl_mpio
     fdid = H5Pget_driver (pid);
     CHECK_HID (fdid)
     if (fdid ==	H5FD_MPIO){

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -263,14 +263,21 @@ int e3sm_io_driver_hdf5::inq_file_info (int fid, MPI_Info *info) {
     int err = 0;
     herr_t herr;
     hdf5_file *fp = this->files[fid];
-    hid_t pid;
+    hid_t pid, fdid;
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
 
     pid = H5Fget_access_plist (fp->id);
     CHECK_HID (pid);
-    herr = H5Pget_fapl_mpio (pid, NULL, info);
-    CHECK_HERR
+    fdid = H5Pget_driver (pid);
+    CHECK_HID (fdid)
+    if (fdid ==	H5FD_MPIO){
+        herr = H5Pget_fapl_mpio (pid, NULL, info);
+        CHECK_HERR
+    }
+    else{
+        *info = MPI_INFO_NULL;
+    }
 
 err_out:;
     if (pid != -1) H5Pclose (pid);

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -104,6 +104,8 @@ static void usage (char *argv0) {
        [-g num] Number of subfiles, used by Log-based VOL and ADIOS I/O only,\n\
                 -1 for one subfile per compute node, 0 to disable subfiling,\n\
                 (default: 0).\n\
+       [-t time] Add sleep time to emulate the computation in order to \n\
+                 overlapping I/O when Async VOL is used.\n\
        [-o path] Output file path (folder name when subfiling is used, file\n\
                  name otherwise).\n\
        [-a api]  I/O library name\n\
@@ -165,6 +167,7 @@ int main (int argc, char **argv) {
     cfg.non_contig_buf = 0;
     cfg.io_stride      = 1;
     cfg.sub_comm       = MPI_COMM_NULL;
+    cfg.comp_time      = 0;
 
     for (i = 0; i < MAX_NUM_DECOMP; i++) {
         cfg.G_case.nvars_D[i]    = 0;
@@ -187,7 +190,7 @@ int main (int argc, char **argv) {
     ffreq = 1;
 
     /* command-line arguments */
-    while ((i = getopt (argc, argv, "vkr:s:o:i:dmf:ha:x:g:y:p")) != EOF)
+    while ((i = getopt (argc, argv, "vkr:s:o:i:dmf:ha:x:g:y:pt:")) != EOF)
         switch (i) {
             case 'v':
                 cfg.verbose = 1;
@@ -260,6 +263,9 @@ int main (int argc, char **argv) {
                 break;
             case 'c':
                 cfg.chunksize = atoll (optarg);
+                break;
+            case 't':
+                cfg.comp_time = atoi (optarg);
                 break;
             case 'p':
                 cfg.profiling = 1;

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -161,6 +161,7 @@ typedef struct e3sm_io_config {
     int two_buf;
     int non_contig_buf;
     int io_stride;
+    int comp_time;   /* Emulate computation time (sleep) for a time step */
     int profiling;
 
     /* below are used for PnetCDF blob I/O subfiling */


### PR DESCRIPTION
Add a command line option -t to specify the delay time (sec) before in each record (timestep) that simulates the computation time.
On each iteration, the benchmark will repeat the data buffer initialization routine until the specified computation time has passed.