### PR TITLE
adios driver use bp4

### DIFF
--- a/src/drivers/e3sm_io_driver.cpp
+++ b/src/drivers/e3sm_io_driver.cpp
@@ -104,6 +104,14 @@ e3sm_io_driver *e3sm_io_get_driver (const char *filename, /* NULL is for read */
          */
         path = remove_file_system_type_prefix(filename);
 
+// ADIOS2?
+#ifdef ENABLE_ADIOS2
+        if(e3sm_io_driver_adios2::compatible(std::string(path))) {
+            cfg->api = adios;
+            goto done_check;
+        }
+#endif
+
         /* must include config.h on 32-bit machines, as AC_SYS_LARGEFILE is
          * called at the configure time and it defines _FILE_OFFSET_BITS to 64
          * if large file feature is supported.
@@ -166,15 +174,6 @@ e3sm_io_driver *e3sm_io_get_driver (const char *filename, /* NULL is for read */
             goto done_check;
         }
 #endif
-
-// ADIOS2?
-#ifdef ENABLE_ADIOS2
-        if(e3sm_io_driver_adios2::compatible(std::string(path))) {
-            cfg->api = adios;
-            goto done_check;
-        }
-#endif
-
 
 done_check:
         if (cfg->rank == 0 && fd >= 0) { close (fd); }

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -114,7 +114,8 @@ static void usage (char *argv0) {
            hdf5:      HDF5 library\n\
            hdf5_md:   HDF5 library using multi-dataset I/O APIs\n\
            hdf5_log:  HDF5 library with Log-based VOL\n\
-           adios:     ADIOS library using BP3 format\n\
+           adios_bp3: ADIOS library using BP3 format\n\
+           adios:     ADIOS library using BP4 format\n\
        [-x strategy] I/O strategy\n\
            canonical: Store variables in the canonical layout (default).\n\
            log:       Store variables in the log-based storage layout.\n\

--- a/utils/wrap_runs.sh
+++ b/utils/wrap_runs.sh
@@ -46,7 +46,7 @@ elif test "$1" = ./dat2decomp ; then
       CMD="$1 -a bp -i $LIST_FILE -o $1.bp"
       echo $CMD
       $CMD
-      rm -rf $1.bp.dir
+      rm -rf $1.bp*
    fi
 elif test "$1" = ./decomp_copy ; then
    if test "x${ENABLE_PNC}" = x1 && test "x${ENABLE_HDF5}" = x1 ; then
@@ -68,7 +68,7 @@ elif test "$1" = ./decomp_copy ; then
       CMD="$1 -a bp -i $NC_FILE -o $1.bp"
       echo $CMD
       $CMD
-      rm -rf $1.bp.dir
+      rm -rf $1.bp*
    fi
 elif test "$1" = ./datstat ; then
    CMD="$1 -d $top_srcdir/datasets/piodecomp16tasks16io02dims_ioid_548.dat"


### PR DESCRIPTION
move from BP3 to BP4 in adios driver.
no change to Scorpio wrapper.
BP 3 read capability preserved in adios driver for reading decomposition file.