### PR TITLE
various fixes for reads

### DIFF
--- a/src/cases/e3sm_io_case.cpp
+++ b/src/cases/e3sm_io_case.cpp
@@ -343,7 +343,7 @@ int e3sm_io_case::inq_var(e3sm_io_config &cfg,
                           e3sm_io_driver &driver,
                           case_meta      *cmeta,
                           int             ncid,
-                          std::string     name,
+                          char           *name,
                           int             dim_time,
                           int            *dimids,
                           MPI_Datatype    itype,
@@ -356,9 +356,9 @@ int e3sm_io_case::inq_var(e3sm_io_config &cfg,
     err = driver.inq_varid(ncid, name, &varp->vid);
     CHECK_ERR
 
-    varp->_name = strdup(name.c_str());
+    varp->_name = strdup(name);
 
-    err = driver.inq_var(ncid, varp->vid, name, &varp->xType,
+    err = driver.inq_var(ncid, varp->vid, NULL, &varp->xType,
                          &varp->ndims, dimids, NULL);
     CHECK_ERR
 

--- a/src/cases/e3sm_io_case.cpp
+++ b/src/cases/e3sm_io_case.cpp
@@ -12,7 +12,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h> /* strcpy(), strcat() */
+#include <string.h> /* strcpy(), strcat(), strdup() */
 #include <assert.h>
 
 #include <e3sm_io.h>

--- a/src/cases/e3sm_io_case.cpp
+++ b/src/cases/e3sm_io_case.cpp
@@ -157,6 +157,9 @@ int e3sm_io_case::rd_test(e3sm_io_config &cfg,
     if (cfg.strategy != canonical)
         ERR_OUT ("Read is only supported in canonical storage layout")
 
+    if (cfg.api == hdf5)
+        ERR_OUT ("Read currently does not support HDF5 methods")
+
     /* construct I/O metadata */
     err = calc_metadata(&cfg, &decom);
     CHECK_ERR
@@ -324,6 +327,9 @@ int e3sm_io_case::def_var(e3sm_io_config            &cfg,
             wr_buf.rec_txt_buflen += varp->vlen + wr_buf.gap;
         else if (varp->iType == MPI_FLOAT)
             wr_buf.rec_flt_buflen += varp->vlen + wr_buf.gap;
+        else if (varp->iType == MPI_LONG_LONG)
+            wr_buf.rec_lld_buflen += varp->vlen + wr_buf.gap;
+        else assert(0);
     } else {
         if (varp->iType == MPI_DOUBLE)
             wr_buf.fix_dbl_buflen += varp->vlen + wr_buf.gap;
@@ -333,6 +339,9 @@ int e3sm_io_case::def_var(e3sm_io_config            &cfg,
             wr_buf.fix_txt_buflen += varp->vlen + wr_buf.gap;
         else if (varp->iType == MPI_FLOAT)
             wr_buf.fix_flt_buflen += varp->vlen + wr_buf.gap;
+        else if (varp->iType == MPI_LONG_LONG)
+            wr_buf.fix_lld_buflen += varp->vlen + wr_buf.gap;
+        else assert(0);
     }
 err_out:
     return err;
@@ -343,7 +352,7 @@ int e3sm_io_case::inq_var(e3sm_io_config &cfg,
                           e3sm_io_driver &driver,
                           case_meta      *cmeta,
                           int             ncid,
-                          char           *name,
+                          const char     *name,
                           int             dim_time,
                           int            *dimids,
                           MPI_Datatype    itype,
@@ -354,6 +363,7 @@ int e3sm_io_case::inq_var(e3sm_io_config &cfg,
     int err=0, j;
 
     err = driver.inq_varid(ncid, name, &varp->vid);
+if (err != 0) printf("name=%s\n",name);
     CHECK_ERR
 
     varp->_name = strdup(name);
@@ -405,6 +415,9 @@ int e3sm_io_case::inq_var(e3sm_io_config &cfg,
             wr_buf.rec_txt_buflen += varp->vlen + wr_buf.gap;
         else if (varp->iType == MPI_FLOAT)
             wr_buf.rec_flt_buflen += varp->vlen + wr_buf.gap;
+        else if (varp->iType == MPI_LONG_LONG)
+            wr_buf.rec_lld_buflen += varp->vlen + wr_buf.gap;
+        else assert(0);
     } else {
         if (varp->iType == MPI_DOUBLE)
             wr_buf.fix_dbl_buflen += varp->vlen + wr_buf.gap;
@@ -414,6 +427,9 @@ int e3sm_io_case::inq_var(e3sm_io_config &cfg,
             wr_buf.fix_txt_buflen += varp->vlen + wr_buf.gap;
         else if (varp->iType == MPI_FLOAT)
             wr_buf.fix_flt_buflen += varp->vlen + wr_buf.gap;
+        else if (varp->iType == MPI_LONG_LONG)
+            wr_buf.fix_lld_buflen += varp->vlen + wr_buf.gap;
+        else assert(0);
     }
 err_out:
     return err;

--- a/src/cases/e3sm_io_case.hpp
+++ b/src/cases/e3sm_io_case.hpp
@@ -21,23 +21,25 @@ typedef struct {
     size_t  gap;
 
     /* buffers for fixed-size variables */
-    size_t  fix_txt_buflen; char   *fix_txt_buf;
-    size_t  fix_int_buflen; int    *fix_int_buf;
-    size_t  fix_flt_buflen; float  *fix_flt_buf;
-    size_t  fix_dbl_buflen; double *fix_dbl_buf;
+    size_t  fix_txt_buflen; char      *fix_txt_buf;
+    size_t  fix_int_buflen; int       *fix_int_buf;
+    size_t  fix_flt_buflen; float     *fix_flt_buf;
+    size_t  fix_dbl_buflen; double    *fix_dbl_buf;
+    size_t  fix_lld_buflen; long long *fix_lld_buf;
 
     /* buffers for record variables */
-    size_t  rec_txt_buflen; char   *rec_txt_buf;
-    size_t  rec_int_buflen; int    *rec_int_buf;
-    size_t  rec_flt_buflen; float  *rec_flt_buf;
-    size_t  rec_dbl_buflen; double *rec_dbl_buf;
+    size_t  rec_txt_buflen; char      *rec_txt_buf;
+    size_t  rec_int_buflen; int       *rec_int_buf;
+    size_t  rec_flt_buflen; float     *rec_flt_buf;
+    size_t  rec_dbl_buflen; double    *rec_dbl_buf;
+    size_t  rec_lld_buflen; long long *rec_lld_buf;
 } io_buffers;
 
 typedef struct {
     int vid;         /* variable ID, returned from the driver */
 
     char *_name;     /* name of variable */
-    int fill_id;  /* fill value variable ID returned from adios driver */
+    int fill_id;     /* fill value variable ID returned from adios driver */
     int frame_id;    /* frame variable ID returned from adios driver */
     int decom_id;    /* decomposition map variable ID returned from adios driver */
     int piodecomid;  /* map IDs used on Scorpio starting at 512 */
@@ -167,7 +169,7 @@ class e3sm_io_case {
                     e3sm_io_driver             &driver,
                     case_meta                  *cmeta,
                     int                         ncid,
-                    char                       *name,
+                    const char                 *name,
                     int                         dim_time,
                     int                        *dimids,
                     MPI_Datatype                itype,
@@ -401,22 +403,28 @@ int scorpio_write_var(e3sm_io_driver &driver,
     /* increment I/O buffer sizes */                                          \
     if (varp->isRecVar) {                                                     \
         if (varp->iType == MPI_DOUBLE)                                        \
-            wr_buf.rec_dbl_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.rec_dbl_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_INT)                                      \
-            wr_buf.rec_int_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.rec_int_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_CHAR)                                     \
-            wr_buf.rec_txt_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.rec_txt_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_FLOAT)                                    \
-            wr_buf.rec_flt_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.rec_flt_buflen   += varp->vlen + wr_buf.gap;               \
+        else if (varp->iType == MPI_LONG_LONG)                                \
+            wr_buf.rec_lld_buflen += varp->vlen + wr_buf.gap;                 \
+        else assert(0)                                                        \
     } else {                                                                  \
         if (varp->iType == MPI_DOUBLE)                                        \
-            wr_buf.fix_dbl_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.fix_dbl_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_INT)                                      \
-            wr_buf.fix_int_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.fix_int_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_CHAR)                                     \
-            wr_buf.fix_txt_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.fix_txt_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_FLOAT)                                    \
-            wr_buf.fix_flt_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.fix_flt_buflen   += varp->vlen + wr_buf.gap;               \
+        else if (varp->iType == MPI_LONG_LONG)                                \
+            wr_buf.fix_lld_buflen += varp->vlen + wr_buf.gap;                 \
+        else assert(0)                                                        \
     }                                                                         \
 }
 #endif
@@ -522,22 +530,28 @@ int scorpio_write_var(e3sm_io_driver &driver,
     /* increment I/O buffer sizes */                                          \
     if (varp->isRecVar) {                                                     \
         if (varp->iType == MPI_DOUBLE)                                        \
-            wr_buf.rec_dbl_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.rec_dbl_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_INT)                                      \
-            wr_buf.rec_int_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.rec_int_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_CHAR)                                     \
-            wr_buf.rec_txt_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.rec_txt_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_FLOAT)                                    \
-            wr_buf.rec_flt_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.rec_flt_buflen   += varp->vlen + wr_buf.gap;               \
+        else if (varp->iType == MPI_LONG_LONG)                                \
+            wr_buf.rec_lld_buflen += varp->vlen + wr_buf.gap;                 \
+        else assert(0)                                                        \
     } else {                                                                  \
         if (varp->iType == MPI_DOUBLE)                                        \
-            wr_buf.fix_dbl_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.fix_dbl_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_INT)                                      \
-            wr_buf.fix_int_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.fix_int_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_CHAR)                                     \
-            wr_buf.fix_txt_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.fix_txt_buflen   += varp->vlen + wr_buf.gap;               \
         else if (varp->iType == MPI_FLOAT)                                    \
-            wr_buf.fix_flt_buflen += varp->vlen + wr_buf.gap;                 \
+            wr_buf.fix_flt_buflen   += varp->vlen + wr_buf.gap;               \
+        else if (varp->iType == MPI_LONG_LONG)                                \
+            wr_buf.fix_lld_buflen += varp->vlen + wr_buf.gap;                 \
+        else assert(0)                                                        \
     }                                                                         \
 }
 #endif

--- a/src/cases/e3sm_io_case.hpp
+++ b/src/cases/e3sm_io_case.hpp
@@ -167,7 +167,7 @@ class e3sm_io_case {
                     e3sm_io_driver             &driver,
                     case_meta                  *cmeta,
                     int                         ncid,
-                    std::string                 name,
+                    char                       *name,
                     int                         dim_time,
                     int                        *dimids,
                     MPI_Datatype                itype,
@@ -489,7 +489,7 @@ int scorpio_write_var(e3sm_io_driver &driver,
 }
 #define INQ_VAR(name, xtype, nDims, dimids, itype, decomid) {                 \
     varp++;                                                                   \
-    err = e3sm_io_case::inq_var(cfg, decom, driver, cmeta, ncid, name,        \
+    err = e3sm_io_case::inq_var(cfg, decom, driver, cmeta, ncid, (char*)name, \
                                 dim_time, dimids, itype, decomid, varp);      \
     if (err != 0) goto err_out;                                               \
 }

--- a/src/cases/e3sm_io_case.hpp
+++ b/src/cases/e3sm_io_case.hpp
@@ -147,6 +147,33 @@ class e3sm_io_case {
                            int dim_max_nreqs[MAX_NUM_DECOMP],
                            int g_dimids[MAX_NUM_DECOMP][MAX_NDIMS]);
 
+        int def_var(e3sm_io_config             &cfg,
+                    e3sm_io_decom              &decom,
+                    e3sm_io_driver             &driver,
+                    case_meta                  *cmeta,
+                    int                         ncid,
+                    std::string                 name,
+                    std::map<int, std::string> &dnames,
+                    int                         xtype,
+                    int                         nDims,
+                    int                         dim_time,
+                    int                        *dimids,
+                    MPI_Datatype                itype,
+                    int                         decomid,
+                    var_meta                   *varp);
+
+        int inq_var(e3sm_io_config             &cfg,
+                    e3sm_io_decom              &decom,
+                    e3sm_io_driver             &driver,
+                    case_meta                  *cmeta,
+                    int                         ncid,
+                    std::string                 name,
+                    int                         dim_time,
+                    int                        *dimids,
+                    MPI_Datatype                itype,
+                    int                         decomid,
+                    var_meta                   *varp);
+
     public:
          e3sm_io_case();
         ~e3sm_io_case();
@@ -318,6 +345,14 @@ int scorpio_write_var(e3sm_io_driver &driver,
     cmeta->num_attrs++;                                                       \
 }
 #define DEF_VAR(name, xtype, nDims, dimids, itype, decomid) {                 \
+    varp++;                                                                   \
+    err = e3sm_io_case::def_var(cfg, decom, driver, cmeta, ncid, name,        \
+                                dnames, xtype,  nDims, dim_time, dimids,      \
+                                itype, decomid, varp);                        \
+    if (err != 0) goto err_out;                                               \
+}
+#if 0
+#define DEF_VAR(name, xtype, nDims, dimids, itype, decomid) {                 \
     /* nDims and dimids are canonical dimensions */                           \
     int _i, *_dimids = dimids;                                                \
     varp++;                                                                   \
@@ -384,13 +419,13 @@ int scorpio_write_var(e3sm_io_driver &driver,
             wr_buf.fix_flt_buflen += varp->vlen + wr_buf.gap;                 \
     }                                                                         \
 }
+#endif
 #define INQ_DIM(name, num, dimid) {                                           \
     err = driver.inq_dim(ncid, name, dimid);                                  \
     CHECK_ERR                                                                 \
     if (cfg.api == adios) dnames[*dimid] = name;                              \
 }
-#define GET_GATTR_TXT(name, dbuf) {                                           \
-    char buf[2014];                                                           \
+#define GET_GATTR_TXT(name, buf) {                                            \
     err = driver.get_att(ncid, NC_GLOBAL, prefix+name, buf);                  \
     CHECK_ERR                                                                 \
     cmeta->num_attrs++;                                                       \
@@ -453,6 +488,13 @@ int scorpio_write_var(e3sm_io_driver &driver,
     cmeta->num_attrs++;                                                       \
 }
 #define INQ_VAR(name, xtype, nDims, dimids, itype, decomid) {                 \
+    varp++;                                                                   \
+    err = e3sm_io_case::inq_var(cfg, decom, driver, cmeta, ncid, name,        \
+                                dim_time, dimids, itype, decomid, varp);      \
+    if (err != 0) goto err_out;                                               \
+}
+#if 0
+#define INQ_VAR(name, xtype, nDims, dimids, itype, decomid) {                 \
     /* nDims and dimids are canonical dimensions */                           \
     int _i, *_dimids = dimids;                                                \
     varp++;                                                                   \
@@ -498,3 +540,5 @@ int scorpio_write_var(e3sm_io_driver &driver,
             wr_buf.fix_flt_buflen += varp->vlen + wr_buf.gap;                 \
     }                                                                         \
 }
+#endif
+

--- a/src/cases/header_inq_F_case.cpp
+++ b/src/cases/header_inq_F_case.cpp
@@ -111,7 +111,7 @@ int e3sm_io_case::inq_var_decomp(e3sm_io_config &cfg,
             ival = 6;
             GET_ATTR_INT("piotype", 1, &ival)
         }
-        err = driver.inq_varid(ncid, "/__pio__/info/nproc", &vars[j].vid);
+        err = driver.inq_varid(ncid, (char*)"/__pio__/info/nproc", &vars[j].vid);
         CHECK_ERR
     }
     else {

--- a/src/cases/header_inq_F_case.cpp
+++ b/src/cases/header_inq_F_case.cpp
@@ -100,7 +100,7 @@ int e3sm_io_case::inq_var_decomp(e3sm_io_config &cfg,
 
             varp = vars + j;
             sprintf (name, "/__pio__/decomp/%d", (j + 512));
-            err = driver.inq_var(ncid, name, &varp->vid);
+            err = driver.inq_varid(ncid, name, &varp->vid);
             CHECK_ERR
 
             for (i=0; i<decom.ndims[j]; i++)
@@ -111,7 +111,7 @@ int e3sm_io_case::inq_var_decomp(e3sm_io_config &cfg,
             ival = 6;
             GET_ATTR_INT("piotype", 1, &ival)
         }
-        err = driver.inq_var(ncid, "/__pio__/info/nproc", &vars[j].vid);
+        err = driver.inq_varid(ncid, "/__pio__/info/nproc", &vars[j].vid);
         CHECK_ERR
     }
     else {

--- a/src/cases/header_inq_I_case.cpp
+++ b/src/cases/header_inq_I_case.cpp
@@ -1021,11 +1021,11 @@ int e3sm_io_case::inq_I_case(e3sm_io_config   &cfg,
     GET_ATTR_FILL(fillv)
     GET_ATTR_FLT1("missing_value", &missv)
 
-    /* float INQICIT(time, lat, lon) */
+    /* float DEFICIT(time, lat, lon) */
     dimids[0] = dim_time;
     dimids[1] = dim_lat;
     dimids[2] = dim_lon;
-    INQ_VAR("INQICIT", NC_FLOAT, 3, dimids, REC_ITYPE, 0)
+    INQ_VAR("DEFICIT", NC_FLOAT, 3, dimids, REC_ITYPE, 0)
     GET_ATTR_TXT("long_name", txtBuf)
     GET_ATTR_TXT("units", txtBuf)
     GET_ATTR_TXT("cell_methods", txtBuf)

--- a/src/cases/utils.cpp
+++ b/src/cases/utils.cpp
@@ -61,19 +61,23 @@ void e3sm_io_case::wr_buf_init(int gap)
     wr_buf.fix_int_buflen = 0;
     wr_buf.fix_flt_buflen = 0;
     wr_buf.fix_dbl_buflen = 0;
+    wr_buf.fix_lld_buflen = 0;
     wr_buf.rec_txt_buflen = 0;
     wr_buf.rec_int_buflen = 0;
     wr_buf.rec_flt_buflen = 0;
     wr_buf.rec_dbl_buflen = 0;
+    wr_buf.rec_lld_buflen = 0;
 
     wr_buf.fix_txt_buf = NULL;
     wr_buf.fix_int_buf = NULL;
     wr_buf.fix_flt_buf = NULL;
     wr_buf.fix_dbl_buf = NULL;
+    wr_buf.fix_lld_buf = NULL;
     wr_buf.rec_txt_buf = NULL;
     wr_buf.rec_int_buf = NULL;
     wr_buf.rec_flt_buf = NULL;
     wr_buf.rec_dbl_buf = NULL;
+    wr_buf.rec_lld_buf = NULL;
 }
 
 /*----< wr_buf_malloc() >----------------------------------------------------*/
@@ -89,10 +93,12 @@ int e3sm_io_case::wr_buf_malloc(e3sm_io_config &cfg, int ffreq)
         wr_buf.fix_int_buflen += 64;
         wr_buf.fix_flt_buflen += 64;
         wr_buf.fix_dbl_buflen += 64;
+        wr_buf.fix_lld_buflen += 64;
         wr_buf.rec_txt_buflen += 64;
         wr_buf.rec_int_buflen += 64;
         wr_buf.rec_flt_buflen += 64;
         wr_buf.rec_dbl_buflen += 64;
+        wr_buf.rec_lld_buflen += 64;
     }
 
     if (cfg.api != adios && !(cfg.strategy == blob && cfg.api == hdf5)) {
@@ -106,6 +112,7 @@ int e3sm_io_case::wr_buf_malloc(e3sm_io_config &cfg, int ffreq)
         wr_buf.rec_int_buflen *= ffreq;
         wr_buf.rec_flt_buflen *= ffreq;
         wr_buf.rec_dbl_buflen *= ffreq;
+        wr_buf.rec_lld_buflen *= ffreq;
     }
 
     /* allocate and initialize write buffers */
@@ -113,19 +120,23 @@ int e3sm_io_case::wr_buf_malloc(e3sm_io_config &cfg, int ffreq)
     wr_buf.fix_int_buf = (int*)    malloc(wr_buf.fix_int_buflen * sizeof(int));
     wr_buf.fix_flt_buf = (float*)  malloc(wr_buf.fix_flt_buflen * sizeof(float));
     wr_buf.fix_dbl_buf = (double*) malloc(wr_buf.fix_dbl_buflen * sizeof(double));
+    wr_buf.fix_lld_buf = (long long*) malloc(wr_buf.fix_lld_buflen * sizeof(long long));
     wr_buf.rec_txt_buf = (char*)   malloc(wr_buf.rec_txt_buflen * sizeof(char));
     wr_buf.rec_int_buf = (int*)    malloc(wr_buf.rec_int_buflen * sizeof(int));
     wr_buf.rec_flt_buf = (float*)  malloc(wr_buf.rec_flt_buflen * sizeof(float));
     wr_buf.rec_dbl_buf = (double*) malloc(wr_buf.rec_dbl_buflen * sizeof(double));
+    wr_buf.rec_lld_buf = (long long*) malloc(wr_buf.rec_lld_buflen * sizeof(long long));
 
     for (j=0; j<wr_buf.fix_txt_buflen; j++) wr_buf.fix_txt_buf[j] = 'a' + rank;
     for (j=0; j<wr_buf.fix_int_buflen; j++) wr_buf.fix_int_buf[j] = rank;
     for (j=0; j<wr_buf.fix_flt_buflen; j++) wr_buf.fix_flt_buf[j] = rank;
     for (j=0; j<wr_buf.fix_dbl_buflen; j++) wr_buf.fix_dbl_buf[j] = rank;
+    for (j=0; j<wr_buf.fix_lld_buflen; j++) wr_buf.fix_lld_buf[j] = rank;
     for (j=0; j<wr_buf.rec_txt_buflen; j++) wr_buf.rec_txt_buf[j] = 'a' + rank;
     for (j=0; j<wr_buf.rec_int_buflen; j++) wr_buf.rec_int_buf[j] = rank;
     for (j=0; j<wr_buf.rec_flt_buflen; j++) wr_buf.rec_flt_buf[j] = rank;
     for (j=0; j<wr_buf.rec_dbl_buflen; j++) wr_buf.rec_dbl_buf[j] = rank;
+    for (j=0; j<wr_buf.rec_lld_buflen; j++) wr_buf.rec_lld_buf[j] = rank;
 
     return 0;
 }
@@ -137,27 +148,33 @@ void e3sm_io_case::wr_buf_free(void)
     if (wr_buf.fix_int_buf != NULL) free(wr_buf.fix_int_buf);
     if (wr_buf.fix_flt_buf != NULL) free(wr_buf.fix_flt_buf);
     if (wr_buf.fix_dbl_buf != NULL) free(wr_buf.fix_dbl_buf);
+    if (wr_buf.fix_lld_buf != NULL) free(wr_buf.fix_lld_buf);
     if (wr_buf.rec_txt_buf != NULL) free(wr_buf.rec_txt_buf);
     if (wr_buf.rec_int_buf != NULL) free(wr_buf.rec_int_buf);
     if (wr_buf.rec_flt_buf != NULL) free(wr_buf.rec_flt_buf);
     if (wr_buf.rec_dbl_buf != NULL) free(wr_buf.rec_dbl_buf);
+    if (wr_buf.rec_lld_buf != NULL) free(wr_buf.rec_lld_buf);
 
     wr_buf.fix_txt_buf = NULL;
     wr_buf.fix_int_buf = NULL;
     wr_buf.fix_flt_buf = NULL;
     wr_buf.fix_dbl_buf = NULL;
+    wr_buf.fix_lld_buf = NULL;
     wr_buf.rec_txt_buf = NULL;
     wr_buf.rec_int_buf = NULL;
     wr_buf.rec_flt_buf = NULL;
     wr_buf.rec_dbl_buf = NULL;
+    wr_buf.rec_lld_buf = NULL;
 
     wr_buf.fix_txt_buflen = 0;
     wr_buf.fix_int_buflen = 0;
     wr_buf.fix_flt_buflen = 0;
     wr_buf.fix_dbl_buflen = 0;
+    wr_buf.fix_lld_buflen = 0;
     wr_buf.rec_txt_buflen = 0;
     wr_buf.rec_int_buflen = 0;
     wr_buf.rec_flt_buflen = 0;
     wr_buf.rec_dbl_buflen = 0;
+    wr_buf.rec_lld_buflen = 0;
 }
 

--- a/src/cases/var_rd_case.cpp
+++ b/src/cases/var_rd_case.cpp
@@ -436,8 +436,8 @@ int e3sm_io_case::var_rd_case(e3sm_io_config &cfg,
     cmeta->num_flushes     = nflushes;
     cmeta->num_decomp_vars = num_decomp_vars;
     cmeta->my_nreqs        = my_nreqs;
-    cmeta->metadata_WR     = metadata_size;
-    cmeta->amount_WR       = total_size;
+    cmeta->metadata_RD     = metadata_size;
+    cmeta->amount_RD       = total_size;
     cmeta->end2end_time    = MPI_Wtime () - cmeta->end2end_time;
 
     /* check if there is any PnetCDF internal malloc residue */

--- a/src/drivers/blob_ncmpio.c
+++ b/src/drivers/blob_ncmpio.c
@@ -15,7 +15,7 @@
 #endif
 
 #include <stdio.h>
-#include <string.h>
+#include <string.h> /* strdup() */
 #include <assert.h>
 #include <mpi.h>
 

--- a/src/drivers/e3sm_io_driver.cpp
+++ b/src/drivers/e3sm_io_driver.cpp
@@ -16,6 +16,7 @@
 #include <cstdlib>
 #include <cstring>
 //
+#include <string.h> /* strdup() */
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/drivers/e3sm_io_driver.hpp
+++ b/src/drivers/e3sm_io_driver.hpp
@@ -32,9 +32,9 @@ class e3sm_io_driver {
         int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did) = 0;
     virtual int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did) = 0;
-    virtual int inq_varid(int fid, std::string name, int *did)                               = 0;
-    virtual int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
-                        int *ndimsp, int *dimids, int *nattsp) = 0;
+    virtual int inq_varid(int fid, const char *name, int *did) = 0;
+    virtual int inq_var(int fid, int varid, char *name, nc_type *xtypep, int *ndimsp,
+                        int *dimids, int *nattsp) = 0;
     virtual int inq_var_name (int fid, int did, char *name)                                  = 0;
     virtual int inq_var_off (int fid, int vid, MPI_Offset *off)                              = 0;
     virtual int def_dim (int fid, std::string name, MPI_Offset size, int *dimid)             = 0;

--- a/src/drivers/e3sm_io_driver.hpp
+++ b/src/drivers/e3sm_io_driver.hpp
@@ -32,7 +32,9 @@ class e3sm_io_driver {
         int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did) = 0;
     virtual int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did) = 0;
-    virtual int inq_var (int fid, std::string name, int *did)                                = 0;
+    virtual int inq_varid(int fid, std::string name, int *did)                               = 0;
+    virtual int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
+                        int *ndimsp, int *dimids, int *nattsp) = 0;
     virtual int inq_var_name (int fid, int did, char *name)                                  = 0;
     virtual int inq_var_off (int fid, int vid, MPI_Offset *off)                              = 0;
     virtual int def_dim (int fid, std::string name, MPI_Offset size, int *dimid)             = 0;

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -451,7 +451,9 @@ err_out:;
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_ADIOS2)
     return err;
 }
-int e3sm_io_driver_adios2::inq_var (int fid, std::string name, int *did) {
+
+int e3sm_io_driver_adios2::inq_varid(int fid, std::string name, int *did)
+{
     int err = 0;
     adios2_error aerr;
     adios2_file *fp = this->files[fid];
@@ -478,6 +480,14 @@ int e3sm_io_driver_adios2::inq_var (int fid, std::string name, int *did) {
 
 err_out:;
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_ADIOS2)
+    return err;
+}
+
+int e3sm_io_driver_adios2::inq_var (int fid, int varid, std::string &name,
+                                    nc_type *xtypep, int *ndimsp, int *dimids,
+                                    int *nattsp)
+{
+    int err=0;
     return err;
 }
 

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -452,7 +452,7 @@ err_out:;
     return err;
 }
 
-int e3sm_io_driver_adios2::inq_varid(int fid, std::string name, int *did)
+int e3sm_io_driver_adios2::inq_varid(int fid, const char *name, int *did)
 {
     int err = 0;
     adios2_error aerr;
@@ -463,7 +463,7 @@ int e3sm_io_driver_adios2::inq_varid(int fid, std::string name, int *did)
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_ADIOS2)
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_ADIOS2_INQ_VAR)
-    dp = adios2_inquire_variable (fp->iop, name.c_str ());
+    dp = adios2_inquire_variable (fp->iop, name);
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_ADIOS2_INQ_VAR)
     // inq_var is used to check whether a variable exist so error is expected
     if (!dp) {
@@ -483,9 +483,8 @@ err_out:;
     return err;
 }
 
-int e3sm_io_driver_adios2::inq_var (int fid, int varid, std::string &name,
-                                    nc_type *xtypep, int *ndimsp, int *dimids,
-                                    int *nattsp)
+int e3sm_io_driver_adios2::inq_var (int fid, int varid, char *name, nc_type *xtypep,
+                                    int *ndimsp, int *dimids, int *nattsp)
 {
     int err=0;
     return err;

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -111,9 +111,9 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
-    int inq_varid(int fid, std::string name, int *did);
-    int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
-                int *ndimsp, int *dimids, int *nattsp);
+    int inq_varid(int fid, const char *name, int *did);
+    int inq_var(int fid, int varid, char *name, nc_type *xtypep, int *ndimsp,
+                int *dimids, int *nattsp);
     int inq_var_name(int ncid, int varid, char *name);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);

--- a/src/drivers/e3sm_io_driver_adios2.hpp
+++ b/src/drivers/e3sm_io_driver_adios2.hpp
@@ -111,7 +111,9 @@ class e3sm_io_driver_adios2 : public e3sm_io_driver {
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
-    int inq_var (int fid, std::string name, int *did);
+    int inq_varid(int fid, std::string name, int *did);
+    int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
+                int *ndimsp, int *dimids, int *nattsp);
     int inq_var_name(int ncid, int varid, char *name);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);

--- a/src/drivers/e3sm_io_driver_h5blob.cpp
+++ b/src/drivers/e3sm_io_driver_h5blob.cpp
@@ -361,7 +361,7 @@ err_out:
     return err;
 }
 
-int e3sm_io_driver_h5blob::inq_varid (int fid, std::string name, int *did) {
+int e3sm_io_driver_h5blob::inq_varid (int fid, const char *name, int *did) {
     int err = 0;
 
     ERR_OUT ("HDF5 blob I/O does not implement inq_varid yet")
@@ -370,9 +370,8 @@ err_out:
     return err;
 }
 
-int e3sm_io_driver_h5blob::inq_var (int fid, int varid, std::string &name,
-                                    nc_type *xtypep, int *ndimsp, int *dimids,
-                                    int *nattsp)
+int e3sm_io_driver_h5blob::inq_var (int fid, int varid, char *name, nc_type *xtypep,
+                                    int *ndimsp, int *dimids, int *nattsp)
 {
     int err=0;
     ERR_OUT ("HDF5 blob I/O does not implement inq_var yet")

--- a/src/drivers/e3sm_io_driver_h5blob.cpp
+++ b/src/drivers/e3sm_io_driver_h5blob.cpp
@@ -361,9 +361,20 @@ err_out:
     return err;
 }
 
-int e3sm_io_driver_h5blob::inq_var (int fid, std::string name, int *did) {
+int e3sm_io_driver_h5blob::inq_varid (int fid, std::string name, int *did) {
     int err = 0;
 
+    ERR_OUT ("HDF5 blob I/O does not implement inq_varid yet")
+
+err_out:
+    return err;
+}
+
+int e3sm_io_driver_h5blob::inq_var (int fid, int varid, std::string &name,
+                                    nc_type *xtypep, int *ndimsp, int *dimids,
+                                    int *nattsp)
+{
+    int err=0;
     ERR_OUT ("HDF5 blob I/O does not implement inq_var yet")
 
 err_out:

--- a/src/drivers/e3sm_io_driver_h5blob.hpp
+++ b/src/drivers/e3sm_io_driver_h5blob.hpp
@@ -61,9 +61,9 @@ class e3sm_io_driver_h5blob : public e3sm_io_driver {
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
-    int inq_varid(int fid, std::string name, int *did);
-    int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
-                int *ndimsp, int *dimids, int *nattsp);
+    int inq_varid(int fid, const char *name, int *did);
+    int inq_var(int fid, int varid, char *name, nc_type *xtypep, int *ndimsp,
+                int *dimids, int *nattsp);
     int inq_var_name(int ncid, int varid, char *name);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);

--- a/src/drivers/e3sm_io_driver_h5blob.hpp
+++ b/src/drivers/e3sm_io_driver_h5blob.hpp
@@ -61,7 +61,9 @@ class e3sm_io_driver_h5blob : public e3sm_io_driver {
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
-    int inq_var (int fid, std::string name, int *did);
+    int inq_varid(int fid, std::string name, int *did);
+    int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
+                int *ndimsp, int *dimids, int *nattsp);
     int inq_var_name(int ncid, int varid, char *name);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -473,7 +473,7 @@ err_out:;
     return err;
 }
 
-int e3sm_io_driver_hdf5::inq_var (int fid, std::string name, int *did) {
+int e3sm_io_driver_hdf5::inq_varid (int fid, std::string name, int *did) {
     int err       = 0;
     hdf5_file *fp = this->files[fid];
     hid_t h5did;
@@ -496,6 +496,14 @@ int e3sm_io_driver_hdf5::inq_var (int fid, std::string name, int *did) {
 
 err_out:;
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5)
+    return err;
+}
+
+int e3sm_io_driver_hdf5::inq_var (int fid, int varid, std::string &name,
+                                  nc_type *xtypep, int *ndimsp, int *dimids,
+                                  int *nattsp)
+{
+    int err=0;
     return err;
 }
 

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -473,7 +473,7 @@ err_out:;
     return err;
 }
 
-int e3sm_io_driver_hdf5::inq_varid (int fid, std::string name, int *did) {
+int e3sm_io_driver_hdf5::inq_varid (int fid, const char *name, int *did) {
     int err       = 0;
     hdf5_file *fp = this->files[fid];
     hid_t h5did;
@@ -482,13 +482,13 @@ int e3sm_io_driver_hdf5::inq_varid (int fid, std::string name, int *did) {
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
 
     // inq_var is used to check whether a variable exist
-    exist = H5Lexists(fp->id, name.c_str (), H5P_DEFAULT);
+    exist = H5Lexists(fp->id, name, H5P_DEFAULT);
     if (exist == false){
         err = -1;
         goto err_out;
     }
 
-    h5did = H5Dopen2 (fp->id, name.c_str (), H5P_DEFAULT);
+    h5did = H5Dopen2 (fp->id, name, H5P_DEFAULT);
     CHECK_HID(h5did)
 
     *did = fp->dids.size ();
@@ -499,9 +499,8 @@ err_out:;
     return err;
 }
 
-int e3sm_io_driver_hdf5::inq_var (int fid, int varid, std::string &name,
-                                  nc_type *xtypep, int *ndimsp, int *dimids,
-                                  int *nattsp)
+int e3sm_io_driver_hdf5::inq_var (int fid, int varid, char *name, nc_type *xtypep,
+                                  int *ndimsp, int *dimids, int *nattsp)
 {
     int err=0;
     return err;

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -110,9 +110,9 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
-    int inq_varid(int fid, std::string name, int *did);
-    int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
-                int *ndimsp, int *dimids, int *nattsp);
+    int inq_varid(int fid, const char *name, int *did);
+    int inq_var(int fid, int varid, char *name, nc_type *xtypep, int *ndimsp,
+                int *dimids, int *nattsp);
     int inq_var_name(int ncid, int varid, char *name);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);

--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -110,7 +110,9 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
-    int inq_var (int fid, std::string name, int *did);
+    int inq_varid(int fid, std::string name, int *did);
+    int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
+                int *ndimsp, int *dimids, int *nattsp);
     int inq_var_name(int ncid, int varid, char *name);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);

--- a/src/drivers/e3sm_io_driver_nc4.cpp
+++ b/src/drivers/e3sm_io_driver_nc4.cpp
@@ -284,7 +284,7 @@ err_out:
     return err;
 }
 
-int e3sm_io_driver_nc4::inq_var (int fid, std::string name, int *varid) {
+int e3sm_io_driver_nc4::inq_varid (int fid, std::string name, int *varid) {
     int err;
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
@@ -292,6 +292,24 @@ int e3sm_io_driver_nc4::inq_var (int fid, std::string name, int *varid) {
 
     err = nc_inq_varid (fid, name.c_str (), varid);
     // inq_var is used to check whether a variable exist so error is expected
+
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_INQ_VAR)
+    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)
+    return err;
+}
+
+int e3sm_io_driver_nc4::inq_var (int fid, int varid, std::string &name,
+                                 nc_type *xtypep, int *ndimsp, int *dimids,
+                                 int *nattsp)
+{
+    int err;
+    char _name[1024];
+
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
+    E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_INQ_VAR)
+
+    err = nc_inq_var (fid, varid, _name, xtypep, ndimsp, dimids, nattsp);
+    name = strdup(_name);
 
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_INQ_VAR)
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)

--- a/src/drivers/e3sm_io_driver_nc4.cpp
+++ b/src/drivers/e3sm_io_driver_nc4.cpp
@@ -11,6 +11,7 @@
 #endif
 //
 #include <sys/stat.h>
+#include <string.h> /* strdup() */
 //
 #include <e3sm_io.h>
 #include <e3sm_io_err.h>

--- a/src/drivers/e3sm_io_driver_nc4.cpp
+++ b/src/drivers/e3sm_io_driver_nc4.cpp
@@ -285,13 +285,13 @@ err_out:
     return err;
 }
 
-int e3sm_io_driver_nc4::inq_varid (int fid, std::string name, int *varid) {
+int e3sm_io_driver_nc4::inq_varid (int fid, const char *name, int *varid) {
     int err;
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_INQ_VAR)
 
-    err = nc_inq_varid (fid, name.c_str (), varid);
+    err = nc_inq_varid (fid, name, varid);
     // inq_var is used to check whether a variable exist so error is expected
 
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_INQ_VAR)
@@ -299,18 +299,15 @@ int e3sm_io_driver_nc4::inq_varid (int fid, std::string name, int *varid) {
     return err;
 }
 
-int e3sm_io_driver_nc4::inq_var (int fid, int varid, std::string &name,
-                                 nc_type *xtypep, int *ndimsp, int *dimids,
-                                 int *nattsp)
+int e3sm_io_driver_nc4::inq_var (int fid, int varid, char *name, nc_type *xtypep,
+                                 int *ndimsp, int *dimids, int *nattsp)
 {
     int err;
-    char _name[1024];
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4)
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_NC4_INQ_VAR)
 
-    err = nc_inq_var (fid, varid, _name, xtypep, ndimsp, dimids, nattsp);
-    name = strdup(_name);
+    err = nc_inq_var (fid, varid, name, xtypep, ndimsp, dimids, nattsp);
 
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4_INQ_VAR)
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_NC4)

--- a/src/drivers/e3sm_io_driver_nc4.hpp
+++ b/src/drivers/e3sm_io_driver_nc4.hpp
@@ -39,9 +39,9 @@ class e3sm_io_driver_nc4 : public e3sm_io_driver {
 	int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
 	int def_local_var (
 		int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
-        int inq_varid(int fid, std::string name, int *did);
-        int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
-                    int *ndimsp, int *dimids, int *nattsp);
+        int inq_varid(int fid, const char *name, int *did);
+        int inq_var(int fid, int varid, char *name, nc_type *xtypep, int *ndimsp,
+                    int *dimids, int *nattsp);
 	int inq_var_name (int ncid, int varid, char *name);
 	int inq_var_off (int fid, int vid, MPI_Offset *off);
 	int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);

--- a/src/drivers/e3sm_io_driver_nc4.hpp
+++ b/src/drivers/e3sm_io_driver_nc4.hpp
@@ -39,7 +39,9 @@ class e3sm_io_driver_nc4 : public e3sm_io_driver {
 	int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
 	int def_local_var (
 		int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
-	int inq_var (int fid, std::string name, int *did);
+        int inq_varid(int fid, std::string name, int *did);
+        int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
+                    int *ndimsp, int *dimids, int *nattsp);
 	int inq_var_name (int ncid, int varid, char *name);
 	int inq_var_off (int fid, int vid, MPI_Offset *off);
 	int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -253,10 +253,21 @@ err_out:
     return err;
 }
 
-int e3sm_io_driver_pnc::inq_var (int fid, std::string name, int *varid) {
+int e3sm_io_driver_pnc::inq_varid (int fid, std::string name, int *varid) {
 
     // inq_var is used to check whether a variable exist so error is expected
     return ncmpi_inq_varid (fid, name.c_str (), varid);
+}
+
+int e3sm_io_driver_pnc::inq_var (int fid, int varid, std::string &name,
+                                 nc_type *xtypep, int *ndimsp, int *dimids,
+                                 int *nattsp)
+{
+    char _name[1024];
+    int err;
+    err = ncmpi_inq_var(fid, varid, _name, xtypep, ndimsp, dimids, nattsp);
+    name = strdup(_name);
+    return err;
 }
 
 int e3sm_io_driver_pnc::inq_var_name(int   ncid,

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -11,6 +11,7 @@
 #endif
 //
 #include <sys/stat.h>
+#include <string.h> /* strdup() */
 //
 #include <e3sm_io.h>
 #include <e3sm_io_err.h>

--- a/src/drivers/e3sm_io_driver_pnc.cpp
+++ b/src/drivers/e3sm_io_driver_pnc.cpp
@@ -254,20 +254,17 @@ err_out:
     return err;
 }
 
-int e3sm_io_driver_pnc::inq_varid (int fid, std::string name, int *varid) {
+int e3sm_io_driver_pnc::inq_varid (int fid, const char *name, int *varid) {
 
     // inq_var is used to check whether a variable exist so error is expected
-    return ncmpi_inq_varid (fid, name.c_str (), varid);
+    return ncmpi_inq_varid (fid, name, varid);
 }
 
-int e3sm_io_driver_pnc::inq_var (int fid, int varid, std::string &name,
-                                 nc_type *xtypep, int *ndimsp, int *dimids,
-                                 int *nattsp)
+int e3sm_io_driver_pnc::inq_var (int fid, int varid, char *name, nc_type *xtypep,
+                                 int *ndimsp, int *dimids, int *nattsp)
 {
-    char _name[1024];
     int err;
-    err = ncmpi_inq_var(fid, varid, _name, xtypep, ndimsp, dimids, nattsp);
-    name = strdup(_name);
+    err = ncmpi_inq_var(fid, varid, name, xtypep, ndimsp, dimids, nattsp);
     return err;
 }
 

--- a/src/drivers/e3sm_io_driver_pnc.hpp
+++ b/src/drivers/e3sm_io_driver_pnc.hpp
@@ -43,7 +43,9 @@ class e3sm_io_driver_pnc : public e3sm_io_driver {
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
-    int inq_var (int fid, std::string name, int *did);
+    int inq_varid(int fid, std::string name, int *did);
+    int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
+                int *ndimsp, int *dimids, int *nattsp);
     int inq_var_name(int ncid, int varid, char *name);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);

--- a/src/drivers/e3sm_io_driver_pnc.hpp
+++ b/src/drivers/e3sm_io_driver_pnc.hpp
@@ -43,9 +43,9 @@ class e3sm_io_driver_pnc : public e3sm_io_driver {
     int def_var (int fid, std::string name, nc_type xtype, int ndim, int *dimids, int *did);
     int def_local_var (
         int fid, std::string name, nc_type xtype, int ndim, MPI_Offset *dsize, int *did);
-    int inq_varid(int fid, std::string name, int *did);
-    int inq_var(int fid, int varid, std::string &name, nc_type *xtypep,
-                int *ndimsp, int *dimids, int *nattsp);
+    int inq_varid(int fid, const char *name, int *did);
+    int inq_var(int fid, int varid, char *name, nc_type *xtypep, int *ndimsp,
+                int *dimids, int *nattsp);
     int inq_var_name(int ncid, int varid, char *name);
     int inq_var_off (int fid, int vid, MPI_Offset *off);
     int def_dim (int fid, std::string name, MPI_Offset size, int *dimid);

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -106,6 +106,8 @@ static void usage (char *argv0) {
                 (default: 0).\n\
        [-t time] Add sleep time to emulate the computation in order to \n\
                  overlapping I/O when Async VOL is used.\n\
+       [-i path] Input file path (folder name when subfiling is used, file\n\
+                 name otherwise).\n\
        [-o path] Output file path (folder name when subfiling is used, file\n\
                  name otherwise).\n\
        [-a api]  I/O library name\n\

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -116,6 +116,7 @@ typedef struct {
     int num_decomp_vars;         /* no. climate variables decomposed */
     int nvars_D[MAX_NUM_DECOMP]; /* no. climate variables per decomposition */
     MPI_Offset metadata_WR;
+    MPI_Offset metadata_RD;
     MPI_Offset amount_WR;
     MPI_Offset amount_RD;
     MPI_Offset my_nreqs;

--- a/src/e3sm_io_core.cpp
+++ b/src/e3sm_io_core.cpp
@@ -24,7 +24,6 @@ extern "C" int e3sm_io_core (e3sm_io_config *cfg, e3sm_io_decom *decom) {
     int err=0;
     e3sm_io_case *tcase    = NULL;
     e3sm_io_driver *driver = NULL;
-    char *ext;
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_TOTAL)
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_CORE)
@@ -37,7 +36,8 @@ extern "C" int e3sm_io_core (e3sm_io_config *cfg, e3sm_io_decom *decom) {
     /* perform read */
     if (cfg->rd) {
         e3sm_io_api api_tmp = cfg->api;
-        char path[1028];
+        char path[1028], *ext;
+        ext = strrchr(cfg->in_path, '.');
 
         E3SM_IO_TIMER_START (E3SM_IO_TIMER_INIT_DRIVER)
         /* construct file name */

--- a/src/e3sm_io_core.cpp
+++ b/src/e3sm_io_core.cpp
@@ -62,6 +62,13 @@ extern "C" int e3sm_io_core (e3sm_io_config *cfg, e3sm_io_decom *decom) {
         else{
             strcpy(path, cfg->in_path);
         }
+        if (cfg->strategy == blob && cfg->api != adios) {
+            /* append subfile ID to subfile name */
+            char sub_str[8];
+            sprintf(sub_str, ".%04d", cfg->subfile_ID);
+            strcat(path, sub_str);
+        }
+
         driver = e3sm_io_get_driver (path, cfg);
         CHECK_PTR (driver)
         E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_INIT_DRIVER)

--- a/src/read_decomp.cpp
+++ b/src/read_decomp.cpp
@@ -234,7 +234,7 @@ int read_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
 
         /* obtain varid of request variable Dx.nreqs */
         sprintf (name, "D%d.nreqs", id + 1);
-        err = driver->inq_var (ncid, name, &varid);
+        err = driver->inq_varid (ncid, name, &varid);
         CHECK_ERR
 
         /* read all numbers of requests */
@@ -260,7 +260,7 @@ int read_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
         /* read starting offsets of requests into disps[] */
         decom->disps[id] = (int *)malloc (nreqs * sizeof (int));
         sprintf (name, "D%d.offsets", id + 1);
-        err = driver->inq_var (ncid, name, &varid);
+        err = driver->inq_varid (ncid, name, &varid);
         CHECK_ERR
         err = driver->get_vara (ncid, varid, MPI_INT, &start, &count, decom->disps[id], coll);
         CHECK_ERR
@@ -268,7 +268,7 @@ int read_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
         /* read lengths of requests into blocklens[] */
         decom->blocklens[id] = (int *)malloc (nreqs * sizeof (int));
         sprintf (name, "D%d.lengths", id + 1);
-        err = driver->inq_var (ncid, name, &varid);
+        err = driver->inq_varid (ncid, name, &varid);
         CHECK_ERR
         err = driver->get_vara (ncid, varid, MPI_INT, &start, &count, decom->blocklens[id], coll);
         CHECK_ERR
@@ -291,7 +291,7 @@ int read_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
              */
             /* obtain varid of request variable Dx.raw_nreqs */
             sprintf (name, "D%d.raw_nreqs", id + 1);
-            err = driver->inq_var (ncid, name, &varid);
+            err = driver->inq_varid (ncid, name, &varid);
             has_raw_decom = (err == 0) ? 1 :  0;
 
             if (has_raw_decom) {
@@ -319,7 +319,7 @@ int read_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
                     (MPI_Offset *)malloc (decom->raw_nreqs[id] * sizeof (MPI_Offset));
                 raw_offsets_int = (int *)malloc (decom->raw_nreqs[id] * sizeof (int));
                 sprintf (name, "D%d.raw_offsets", id + 1);
-                err = driver->inq_var (ncid, name, &varid);
+                err = driver->inq_varid (ncid, name, &varid);
                 CHECK_ERR
                 err = driver->get_vara (ncid, varid, MPI_INT, &start, &count, raw_offsets_int, coll);
                 CHECK_ERR

--- a/test.sh
+++ b/test.sh
@@ -136,6 +136,12 @@ for API in "${APIS[@]}" ; do
         CMD="${RUN} ${EXEC} -k -a ${ap[0]} -r 2 -x ${ap[1]} -y 2 -o ${OUT_FILE} ${IN_FILE}"
         echo "CMD = ${CMD}"
         ${CMD}
+        # run read operations (currently support pnetcdf, netcdf4 and canonical only)
+        if test "x${ap[1]}" = xcanonical && "x${ap[0]}" != xhdf5 ; then
+           CMD="${RUN} ${EXEC} -k -a ${ap[0]} -r 2 -x ${ap[1]} -y 2 -i ${OUT_FILE} ${IN_FILE}"
+           echo "CMD = ${CMD}"
+           ${CMD}
+        fi
 
         # test replay on blob files
         if test "x${ap[1]}" = xblob ; then

--- a/utils/dat2decomp.cpp
+++ b/utils/dat2decomp.cpp
@@ -17,7 +17,7 @@
 #include <mpi.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <string.h> /* strdup() */
 #include <unistd.h> /* getopt() */
 
 #include <e3sm_io.h>

--- a/utils/decomp_copy.cpp
+++ b/utils/decomp_copy.cpp
@@ -250,7 +250,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
 
         // Di.nreqs
         name = "D" + std::to_string (i) + ".nreqs";
-        err  = din->inq_varid (fidi, name, &varnri);
+        err  = din->inq_varid (fidi, name.c_str(), &varnri);
         CHECK_ERR
         err = dout->def_var (fido, name, NC_INT, 1, &dimnpo, &varnro);
         CHECK_ERR
@@ -267,7 +267,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
         if (have_raw) {
             // Di.raw_nreqs
             name = "D" + std::to_string (i) + ".raw_nreqs";
-            err  = din->inq_varid (fidi, name, &varnrri);
+            err  = din->inq_varid (fidi, name.c_str(), &varnrri);
             CHECK_ERR
             err = dout->def_var (fido, name, NC_INT, 1, &dimnpo, &varnrro);
             CHECK_ERR
@@ -284,7 +284,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
 
         // Di.offsets
         name = "D" + std::to_string (i) + ".offsets";
-        err  = din->inq_varid (fidi, name, &varoffi);
+        err  = din->inq_varid (fidi, name.c_str(), &varoffi);
         CHECK_ERR
         err = dout->def_var (fido, name, NC_INT, 1, &dimnro, &varoffo);
         CHECK_ERR
@@ -301,7 +301,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
         if (have_raw) {
             // Di.raw_offsets
             name = "D" + std::to_string (i) + ".raw_offsets";
-            err  = din->inq_varid (fidi, name, &varroffi);
+            err  = din->inq_varid (fidi, name.c_str(), &varroffi);
             CHECK_ERR
             err = dout->def_var (fido, name, NC_INT, 1, &dimnrro, &varroffo);
             CHECK_ERR
@@ -318,7 +318,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
 
         // Di.lengths
         name = "D" + std::to_string (i) + ".lengths";
-        err  = din->inq_varid (fidi, name, &varleni);
+        err  = din->inq_varid (fidi, name.c_str(), &varleni);
         CHECK_ERR
         err = dout->def_var (fido, name, NC_INT, 1, &dimnro, &varleno);
         CHECK_ERR

--- a/utils/decomp_copy.cpp
+++ b/utils/decomp_copy.cpp
@@ -250,7 +250,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
 
         // Di.nreqs
         name = "D" + std::to_string (i) + ".nreqs";
-        err  = din->inq_var (fidi, name, &varnri);
+        err  = din->inq_varid (fidi, name, &varnri);
         CHECK_ERR
         err = dout->def_var (fido, name, NC_INT, 1, &dimnpo, &varnro);
         CHECK_ERR
@@ -267,7 +267,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
         if (have_raw) {
             // Di.raw_nreqs
             name = "D" + std::to_string (i) + ".raw_nreqs";
-            err  = din->inq_var (fidi, name, &varnrri);
+            err  = din->inq_varid (fidi, name, &varnrri);
             CHECK_ERR
             err = dout->def_var (fido, name, NC_INT, 1, &dimnpo, &varnrro);
             CHECK_ERR
@@ -284,7 +284,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
 
         // Di.offsets
         name = "D" + std::to_string (i) + ".offsets";
-        err  = din->inq_var (fidi, name, &varoffi);
+        err  = din->inq_varid (fidi, name, &varoffi);
         CHECK_ERR
         err = dout->def_var (fido, name, NC_INT, 1, &dimnro, &varoffo);
         CHECK_ERR
@@ -301,7 +301,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
         if (have_raw) {
             // Di.raw_offsets
             name = "D" + std::to_string (i) + ".raw_offsets";
-            err  = din->inq_var (fidi, name, &varroffi);
+            err  = din->inq_varid (fidi, name, &varroffi);
             CHECK_ERR
             err = dout->def_var (fido, name, NC_INT, 1, &dimnrro, &varroffo);
             CHECK_ERR
@@ -318,7 +318,7 @@ int replay_decomp (e3sm_io_config *cfg, e3sm_io_decom *decom) {
 
         // Di.lengths
         name = "D" + std::to_string (i) + ".lengths";
-        err  = din->inq_var (fidi, name, &varleni);
+        err  = din->inq_varid (fidi, name, &varleni);
         CHECK_ERR
         err = dout->def_var (fido, name, NC_INT, 1, &dimnro, &varleno);
         CHECK_ERR


### PR DESCRIPTION
* Replace C macros DEF_VAR and INQ_VAR with subroutines def_var and inq_var. Long C macros make compile time very long, particularly when using icc.
* Split driver->inq_var() into driver->inq_varid() and driver->inq_var(), as driver->inq_var() should be general, like ncmpi_inq_var().
* add missing itype MPI_LONG_LONG

**TODO**
* add more read tests in test.sh (read currently only supports canonical PnetCDF and NetCDF4)
* implement driver->inq_var() for HDF5 and ADIOS drivers
