### PR TITLE
adios driver use BP5

### DIFF
--- a/.github/workflows/logvol_master.yml
+++ b/.github/workflows/logvol_master.yml
@@ -21,7 +21,8 @@ on:
       - 'tests/*'
 
 env:
-   HDF5_VERSION: 1.13.2
+   HDF5_VERSION_MAJOR: 1.14
+   HDF5_VERSION: 1.14.0
    
 jobs:
     build:
@@ -46,7 +47,7 @@ jobs:
             rm -rf HDF5
             mkdir HDF5
             cd HDF5
-            wget -cq https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.13/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz
+            wget -cq https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_VERSION_MAJOR}/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz
             tar -zxf hdf5-${HDF5_VERSION}.tar.gz
             cd hdf5-${HDF5_VERSION}
             ./configure --prefix=${GITHUB_WORKSPACE}/HDF5 \

--- a/.github/workflows/mpich_static.yml
+++ b/.github/workflows/mpich_static.yml
@@ -26,7 +26,7 @@ env:
    HDF5_VERSION: 1.13.2
    NETCDF4_VERSION: 4.9.0
    ADIOS_VERSION: 2.8.3
-   LOG_VOL_VERSION: 1.3.0
+   LOG_VOL_VERSION: 1.4.0
 
 jobs:
     build:

--- a/.github/workflows/mpich_static.yml
+++ b/.github/workflows/mpich_static.yml
@@ -147,9 +147,8 @@ jobs:
             rm -rf ADIOS
             mkdir ADIOS
             cd ADIOS
-            VERSION=2.8.3
-            wget -cq https://github.com/ornladios/ADIOS2/archive/refs/tags/v${VERSION}.tar.gz
-            tar -zxf v${VERSION}.tar.gz
+            wget -cq https://github.com/ornladios/ADIOS2/archive/refs/tags/v${ADIOS_VERSION}.tar.gz
+            tar -zxf v${ADIOS_VERSION}.tar.gz
             mkdir adios2_build
             cd adios2_build
             CC=${GITHUB_WORKSPACE}/MPICH/bin/mpicc \

--- a/.github/workflows/mpich_static.yml
+++ b/.github/workflows/mpich_static.yml
@@ -23,7 +23,8 @@ on:
 env:
    MPICH_VERSION: 4.0.2
    PNETCDF_VERSION: 1.12.3
-   HDF5_VERSION: 1.13.2
+   HDF5_VERSION_MAJOR: 1.14
+   HDF5_VERSION: 1.14.0
    NETCDF4_VERSION: 4.9.0
    ADIOS_VERSION: 2.8.3
    LOG_VOL_VERSION: 1.4.0
@@ -91,7 +92,7 @@ jobs:
             rm -rf HDF5
             mkdir HDF5
             cd HDF5
-            wget -cq https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.13/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz
+            wget -cq https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_VERSION_MAJOR}/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz
             tar -zxf hdf5-${HDF5_VERSION}.tar.gz
             cd hdf5-${HDF5_VERSION}
             ./configure --prefix=${GITHUB_WORKSPACE}/HDF5 \

--- a/.github/workflows/mpich_static.yml
+++ b/.github/workflows/mpich_static.yml
@@ -147,8 +147,9 @@ jobs:
             rm -rf ADIOS
             mkdir ADIOS
             cd ADIOS
-            wget -cq https://github.com/ornladios/ADIOS2/archive/refs/tags/v${ADIOS_VERSION}.tar.gz
-            tar -zxf v${ADIOS_VERSION}.tar.gz
+            VERSION=2.8.3
+            wget -cq https://github.com/ornladios/ADIOS2/archive/refs/tags/v${VERSION}.tar.gz
+            tar -zxf v${VERSION}.tar.gz
             mkdir adios2_build
             cd adios2_build
             CC=${GITHUB_WORKSPACE}/MPICH/bin/mpicc \

--- a/.github/workflows/ubuntu_ompi.yml
+++ b/.github/workflows/ubuntu_ompi.yml
@@ -22,7 +22,8 @@ on:
 
 env:
    PNETCDF_VERSION: 1.12.3
-   HDF5_VERSION: 1.13.2
+   HDF5_VERSION_MAJOR: 1.14
+   HDF5_VERSION: 1.14.0
    NETCDF4_VERSION: 4.9.0
    ADIOS_VERSION: 2.8.3
    LOG_VOL_VERSION: 1.4.0
@@ -67,7 +68,7 @@ jobs:
             rm -rf HDF5
             mkdir HDF5
             cd HDF5
-            wget -cq https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.13/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz
+            wget -cq https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${HDF5_VERSION_MAJOR}/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.gz
             tar -zxf hdf5-${HDF5_VERSION}.tar.gz
             cd hdf5-${HDF5_VERSION}
             ./configure --prefix=${GITHUB_WORKSPACE}/HDF5 \

--- a/.github/workflows/ubuntu_ompi.yml
+++ b/.github/workflows/ubuntu_ompi.yml
@@ -120,9 +120,8 @@ jobs:
             rm -rf ADIOS
             mkdir ADIOS
             cd ADIOS
-            VERSION=2.8.3
-            wget -cq https://github.com/ornladios/ADIOS2/archive/refs/tags/v${VERSION}.tar.gz
-            tar -zxf v${VERSION}.tar.gz
+            wget -cq https://github.com/ornladios/ADIOS2/archive/refs/tags/v${ADIOS_VERSION}.tar.gz
+            tar -zxf v${ADIOS_VERSION}.tar.gz
             mkdir adios2_build
             cd adios2_build
             cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/ADIOS \

--- a/.github/workflows/ubuntu_ompi.yml
+++ b/.github/workflows/ubuntu_ompi.yml
@@ -25,7 +25,7 @@ env:
    HDF5_VERSION: 1.13.2
    NETCDF4_VERSION: 4.9.0
    ADIOS_VERSION: 2.8.3
-   LOG_VOL_VERSION: 1.3.0
+   LOG_VOL_VERSION: 1.4.0
 
 jobs:
     build:

--- a/.github/workflows/ubuntu_ompi.yml
+++ b/.github/workflows/ubuntu_ompi.yml
@@ -120,8 +120,9 @@ jobs:
             rm -rf ADIOS
             mkdir ADIOS
             cd ADIOS
-            wget -cq https://github.com/ornladios/ADIOS2/archive/refs/tags/v${ADIOS_VERSION}.tar.gz
-            tar -zxf v${ADIOS_VERSION}.tar.gz
+            VERSION=2.8.3
+            wget -cq https://github.com/ornladios/ADIOS2/archive/refs/tags/v${VERSION}.tar.gz
+            tar -zxf v${VERSION}.tar.gz
             mkdir adios2_build
             cd adios2_build
             cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/ADIOS \

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -22,7 +22,7 @@
   + Configured with parallel I/O support (configured with `--enable-parallel` is required)
 * (Optional) [HDF5 Log VOL connector](https://github.com/DataLib-ECP/vol-log-based.git)
   + Experimental software developed as part of the Datalib project
-* (Optional) [ADIOS 2.8.1](https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.8.1.tar.gz)
+* (Optional) [ADIOS 2.8.3](https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.8.3.tar.gz)
   + Configured with parallel I/O support (cmake with `-DADIOS2_USE_MPI=ON` is required)
 * (Optional) [NetCDF-C 4.9.0](https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.9.0.tar.gz)
   + Configured with parallel HDF5 support (i.e. `--enable-netcdf4`)
@@ -75,13 +75,13 @@
   + Configure ADIOS with MPI support enabled (-DADIOS2_USE_MPI=ON)
   + Run `make install`
   + Example build commands are given below. This example will install
-    the ADIOS2 library under the folder `${HOME}/ADIOS2/2.8.1`.
+    the ADIOS2 library under the folder `${HOME}/ADIOS2/2.8.3`.
     ```
-    % wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.8.1.tar.gz
-    % tar -zxf v2.8.1.tar.gz
+    % wget https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.8.3.tar.gz
+    % tar -zxf v2.8.3.tar.gz
     % mkdir ADIOS2_BUILD
     % cd ADIOS2_BUILD
-    % cmake -DCMAKE_INSTALL_PREFIX=${HOME}/ADIOS2/2.8.1 -DADIOS2_USE_MPI=ON ../ADIOS2-2.8.1
+    % cmake -DCMAKE_INSTALL_PREFIX=${HOME}/ADIOS2/2.8.3 -DADIOS2_USE_MPI=ON ../ADIOS2-2.8.3
     % make -j 4 install
     ```
 * Build NetCDF-C
@@ -128,9 +128,9 @@
     % cd E3SM-IO
     % autoreconf -i
     % ./configure --with-pnetcdf=${HOME}/PnetCDF/1.12.3 \
-                  --with-hdf5=${HOME}/HDF5/1.14.0 \
-                  --with-logvol=${HOME}/Log_VOL/1.4.0 \
-                  --with-adios2=${HOME}/ADIOS2/2.8.1 \
+                  --with-hdf5=${HOME}/HDF5/1.13.2 \
+                  --with-logvol=${HOME}/Log_VOL/1.2.0 \
+                  --with-adios2=${HOME}/ADIOS2/2.8.3 \
                   --with-netcdf4=${HOME}/NetCDF/4.9.0 \
                   CC=mpicc CXX=mpicxx
     % make -j 8

--- a/src/cases/e3sm_io_case.cpp
+++ b/src/cases/e3sm_io_case.cpp
@@ -81,7 +81,7 @@ int e3sm_io_case::wr_test(e3sm_io_config &cfg,
             cmeta->ffreq = cmeta->nrecs;
 
         /* construct file name */
-        if (ext == NULL || (strcmp(ext, ".nc") && strcmp(ext, ".h5") && strcmp(ext, ".nc4")))
+        if (ext == NULL || (strcmp(ext, ".nc") && strcmp(ext, ".h5") && strcmp(ext, ".nc4") && strcmp(ext, ".bp")))
             sprintf(cmeta->outfile, "%s_h0", cfg.out_path);
         else { /* add "_h0" before file extension */
             strcpy(cmeta->outfile, cfg.out_path);
@@ -118,7 +118,7 @@ int e3sm_io_case::wr_test(e3sm_io_config &cfg,
             cmeta->ffreq = cmeta->nrecs;
 
         /* construct file name */
-        if (ext == NULL || (strcmp(ext, ".nc") && strcmp(ext, ".h5") && strcmp(ext, ".nc4")))
+        if (ext == NULL || (strcmp(ext, ".nc") && strcmp(ext, ".h5") && strcmp(ext, ".nc4") && strcmp(ext, ".bp")))
             sprintf(cmeta->outfile, "%s_h1", cfg.out_path);
         else { /* add "_h1" before file extension */
             strcpy(cmeta->outfile, cfg.out_path);

--- a/src/cases/e3sm_io_case.hpp
+++ b/src/cases/e3sm_io_case.hpp
@@ -42,6 +42,7 @@ typedef struct {
     int fill_id;     /* fill value variable ID returned from adios driver */
     int frame_id;    /* frame variable ID returned from adios driver */
     int decom_id;    /* decomposition map variable ID returned from adios driver */
+    int num_data_block_writers; /* number of data block_writers returned from adios driver */
     int piodecomid;  /* map IDs used on Scorpio starting at 512 */
     int ndims;                  /* number of dimensions */
     MPI_Offset dims[MAX_NDIMS]; /* dimension sizes */

--- a/src/cases/header_def_G_case.cpp
+++ b/src/cases/header_def_G_case.cpp
@@ -35,7 +35,7 @@ int add_gattrs(e3sm_io_config &cfg,
     if (cfg.strategy == blob) {
         if (cfg.api == adios) {
             PUT_GATTR_INT("/__pio__/fillmode", 256)
-            prefix = "pio_global/";
+            prefix = "/__pio__/global/";
         }
         else {
             MPI_Comm_size(cfg.io_comm, &nprocs);
@@ -891,7 +891,7 @@ int e3sm_io_case::def_G_case(e3sm_io_config   &cfg,
     nvars_decomp = 0;
     if (cfg.strategy == blob) {
         if (cfg.api == adios)
-            nvars_decomp = decom.num_decomp + 1;
+            nvars_decomp = (2 * decom.num_decomp) + 3;
         else
             nvars_decomp = NVARS_DECOMP * decom.num_decomp;
 

--- a/src/cases/header_def_I_case.cpp
+++ b/src/cases/header_def_I_case.cpp
@@ -35,7 +35,7 @@ int add_gattrs(e3sm_io_config &cfg,
     if (cfg.strategy == blob) {
         if (cfg.api == adios) {
             PUT_GATTR_INT("/__pio__/fillmode", 256)
-            prefix = "pio_global/";
+            prefix = "/__pio__/global/";
         }
         else {
             MPI_Comm_size(cfg.io_comm, &nprocs);
@@ -216,7 +216,7 @@ int e3sm_io_case::def_I_case(e3sm_io_config   &cfg,
     nvars_decomp = 0;
     if (cfg.strategy == blob) {
         if (cfg.api == adios)
-            nvars_decomp = decom.num_decomp + 1;
+            nvars_decomp = (2 * decom.num_decomp) + 3;
         else
             nvars_decomp = NVARS_DECOMP * decom.num_decomp;
 

--- a/src/cases/report_timing.cpp
+++ b/src/cases/report_timing.cpp
@@ -142,9 +142,8 @@ int print_timing_WR(e3sm_io_config *cfg,
         else if (cfg->strategy == blob) {
             printf("History output name base           = %s\n", cfg->out_path);
             if (cfg->api == adios) {
-                printf("History output folder name         = %s.bp.dir\n", cmeta->outfile);
-                printf("History output subfile names       = %s.bp.dir/%s.bp.xxxx\n",
-                       cmeta->outfile, basename(cmeta->outfile));
+                printf("History output folder name         = %s\n", cmeta->outfile);
+                printf("History output subfile names       = %s/dat.xxxx\n", cmeta->outfile);
                 printf("Number of subfiles                 = %d\n", cfg->num_subfiles);
                 if (cfg->verbose)
                     printf("Output file size                   = %.2f MiB = %.2f GiB\n",
@@ -353,9 +352,8 @@ int print_timing_RD(e3sm_io_config *cfg,
         else if (cfg->strategy == blob) {
             printf("History input name base            = %s\n", cfg->out_path);
             if (cfg->api == adios) {
-                printf("History input folder name          = %s.bp.dir\n", cmeta->outfile);
-                printf("History input subfile names        = %s.bp.dir/%s.bp.xxxx\n",
-                       cmeta->outfile, basename(cmeta->outfile));
+                printf("History input folder name          = %s\n", cmeta->outfile);
+                printf("History input subfile names        = %s/dat.xxxx\n", cmeta->outfile);
                 printf("Number of subfiles                 = %d\n", cfg->num_subfiles);
                 if (cfg->verbose)
                     printf("Input file size                    = %.2f MiB = %.2f GiB\n",

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -152,7 +152,7 @@ int e3sm_io_driver_adios2::create (std::string path, MPI_Comm comm, MPI_Info inf
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_ADIOS2)
 
     fp       = new adios2_file ();
-    fp->path = std::string (path) + ".bp"; /* BP5 files directory */
+    fp->path = std::string (path); /* BP5 files directory */
     err      = MPI_Comm_rank (comm, &(fp->rank));
     CHECK_MPIERR
 

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -152,7 +152,7 @@ int e3sm_io_driver_adios2::create (std::string path, MPI_Comm comm, MPI_Info inf
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_ADIOS2)
 
     fp       = new adios2_file ();
-    fp->path = std::string (path) + ".bp"; /* BP5 files directory */
+    fp->path = std::string (path); /* BP5 files directory */
     err      = MPI_Comm_rank (comm, &(fp->rank));
     CHECK_MPIERR
 
@@ -342,7 +342,7 @@ int e3sm_io_driver_adios2::inq_file_size (std::string path, MPI_Offset *size) {
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_ADIOS2)
 
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_ADIOS2_GET_FSIZE)
-    *size = get_dir_size (path + ".bp.dir");
+    *size = get_dir_size (path);
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_ADIOS2_GET_FSIZE)
 
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_ADIOS2)

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -152,7 +152,7 @@ int e3sm_io_driver_adios2::create (std::string path, MPI_Comm comm, MPI_Info inf
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_ADIOS2)
 
     fp       = new adios2_file ();
-    fp->path = std::string (path);
+    fp->path = std::string (path) + ".bp"; /* BP5 files directory */
     err      = MPI_Comm_rank (comm, &(fp->rank));
     CHECK_MPIERR
 
@@ -173,7 +173,7 @@ int e3sm_io_driver_adios2::create (std::string path, MPI_Comm comm, MPI_Info inf
 
     fp->iop = adios2_declare_io (fp->adp, "e3sm_wrap");
     CHECK_APTR (fp->iop)
-    aerr = adios2_set_engine (fp->iop, "BP3");
+    aerr = adios2_set_engine (fp->iop, "BP5");
     CHECK_AERR
 
     sprintf (ng, "%d", cfg->num_subfiles);
@@ -255,8 +255,8 @@ int e3sm_io_driver_adios2::close (int fid) {
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_ADIOS2)
 
     if (fp->ep) {
-        // aerr = adios2_end_step (fp->ep);
-        // CHECK_AERR
+        aerr = adios2_end_step (fp->ep);
+        CHECK_AERR
 
         E3SM_IO_TIMER_START (E3SM_IO_TIMER_ADIOS2_CLOSE)
         aerr = adios2_close (fp->ep);

--- a/src/drivers/e3sm_io_driver_adios2.cpp
+++ b/src/drivers/e3sm_io_driver_adios2.cpp
@@ -152,7 +152,7 @@ int e3sm_io_driver_adios2::create (std::string path, MPI_Comm comm, MPI_Info inf
     E3SM_IO_TIMER_START (E3SM_IO_TIMER_ADIOS2)
 
     fp       = new adios2_file ();
-    fp->path = std::string (path); /* BP5 files directory */
+    fp->path = std::string (path) + ".bp"; /* BP5 files directory */
     err      = MPI_Comm_rank (comm, &(fp->rank));
     CHECK_MPIERR
 

--- a/test.sh
+++ b/test.sh
@@ -126,9 +126,10 @@ for API in "${APIS[@]}" ; do
         OUT_FILE="${OUT_FILE_BASE}.${FILE_EXT}"
         if test $CONFIG = map_f_case_16p || test $CONFIG = map_i_case_16p ; then
            REAL_OUT_FILE="${OUT_FILE_BASE}_h0.${FILE_EXT} ${OUT_FILE_BASE}_h1.${FILE_EXT}"
-           if test "x${ap[0]}" = xadios ; then
-              REAL_OUT_FILE="${OUT_FILE}_h0.${FILE_EXT} ${OUT_FILE}_h1.${FILE_EXT}"
-           fi
+           # if test "x${ap[0]}" = xadios ; then
+           #    The line below is for BP3
+           #    REAL_OUT_FILE="${OUT_FILE}_h0.${FILE_EXT} ${OUT_FILE}_h1.${FILE_EXT}"
+           # fi
         elif test $CONFIG = map_g_case_16p ; then
            REAL_OUT_FILE="${OUT_FILE_BASE}.${FILE_EXT}"
         fi

--- a/test.sh
+++ b/test.sh
@@ -170,10 +170,10 @@ for API in "${APIS[@]}" ; do
         # check ADIOS BP files
         if test "x$BPSTAT" != x && test "x${ap[0]}" = xadios ; then
            if test $CONFIG = map_f_case_16p || test $CONFIG = map_i_case_16p ; then
-              CMD="${BPSTAT} ${OUT_FILE}_h0.${FILE_EXT}"
+              CMD="${BPSTAT} ${OUT_FILE_BASE}_h0.${FILE_EXT}"
               echo "CMD = ${CMD}"
               ${CMD}
-              CMD="${BPSTAT} ${OUT_FILE}_h1.${FILE_EXT}"
+              CMD="${BPSTAT} ${OUT_FILE_BASE}_h1.${FILE_EXT}"
               echo "CMD = ${CMD}"
               ${CMD}
            elif test $CONFIG = map_g_case_16p ; then

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@
 set -e
 
 DECOMP_REPLAY="utils/decomp_copy"
-BPSTAT="utils/bpstat"
+# BPSTAT="utils/bpstat"
 DECOMPS=()
 
 VERBOSE=0

--- a/utils/bpstat.cpp
+++ b/utils/bpstat.cpp
@@ -342,6 +342,10 @@ int main (int argc, char *argv[]) {
 
     inpath = std::string (argv[optind]);
 
+    if (access(inpath.c_str(), F_OK) != 0){
+        ERR_OUT("Input file does not exist")
+    }
+
     err = bpstat_core (inpath, cfg, stat);
     if (err != 0) { nerrs++; }
 

--- a/utils/bpstat.cpp
+++ b/utils/bpstat.cpp
@@ -315,7 +315,6 @@ err_out:;
 int main (int argc, char *argv[]) {
     int err = 0, nerrs = 0;
     int i;
-    int nsub;
     config cfg;
     bpstat stat;
     bpstat stat_all;
@@ -351,15 +350,16 @@ int main (int argc, char *argv[]) {
 
     stat_all.nvar = stat.nvar;
     stat_all.natt = stat.natt;
-    err = MPI_Reduce (&(stat.asize), &(stat_all.asize), 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, 0,
-                        MPI_COMM_WORLD);
+    err = MPI_Reduce(&stat.asize, &stat_all.asize, 1, MPI_UNSIGNED_LONG_LONG,
+                     MPI_SUM, 0, MPI_COMM_WORLD);
     CHECK_MPIERR
-    err = MPI_Reduce (&(stat.vsize), &(stat_all.vsize), 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, 0,
-                        MPI_COMM_WORLD);
+    err = MPI_Reduce(&stat.vsize, &stat_all.vsize, 1, MPI_UNSIGNED_LONG_LONG,
+                     MPI_SUM, 0, MPI_COMM_WORLD);
     CHECK_MPIERR
 
     if (cfg.rank == 0) {
-        std::cout << "Num subfiles: " << nsub << std::endl;
+        // Is there a way to query number of subfiles?
+        // std::cout << "Num subfiles: " << nsub << std::endl;
         std::cout << "Num variables: " << stat_all.nvar << std::endl;
         std::cout << "Total variable size: " << stat_all.vsize << std::endl;
         std::cout << "Num attributes: " << stat_all.natt << std::endl;

--- a/utils/wrap_runs.sh
+++ b/utils/wrap_runs.sh
@@ -49,7 +49,7 @@ elif test "$1" = ./dat2decomp ; then
       CMD="${RUN} $1 -a bp -i $LIST_FILE -o $1.bp"
       echo $CMD
       $CMD
-      rm -rf $1.bp.dir
+      rm -rf $1.bp
    fi
 elif test "$1" = ./decomp_copy ; then
    if test "x${ENABLE_PNC}" = x1 && test "x${ENABLE_HDF5}" = x1 ; then
@@ -71,7 +71,7 @@ elif test "$1" = ./decomp_copy ; then
       CMD="${RUN} $1 -a bp -i $NC_FILE -o $1.bp"
       echo $CMD
       $CMD
-      rm -rf $1.bp.dir
+      rm -rf $1.bp
    fi
 elif test "$1" = ./datstat ; then
    CMD="${RUN} $1 -d $top_srcdir/datasets/piodecomp16tasks16io02dims_ioid_548.dat"


### PR DESCRIPTION
Move from BP3 to BP5 for adios driver to write.
BP3 read capability preserved for reading decomposition file.
With required metadata to use BP5 conversion tool of SCORPIO.