### PR TITLE
Necessary code changes to run with Cache Vol and Async Vol

### DIFF
--- a/src/drivers/e3sm_io_driver.cpp
+++ b/src/drivers/e3sm_io_driver.cpp
@@ -137,7 +137,9 @@ e3sm_io_driver *e3sm_io_get_driver (const char *filename, /* NULL is for read */
             hid_t fid = -1;
             htri_t isnc, islog;
 
-            fid = H5Fopen (path, H5F_ACC_RDONLY, H5P_DEFAULT);
+            hid_t faplid = H5Pcreate (H5P_FILE_ACCESS);
+            H5Pset_fapl_mpio(faplid, MPI_COMM_SELF, MPI_INFO_NULL);
+            fid = H5Fopen (path, H5F_ACC_RDONLY, faplid);
             if (fid < 0) { ERR_OUT ("HDF5 header detected, but not a HDF5 file"); }
 
             // Check for NetCDF4
@@ -152,6 +154,7 @@ e3sm_io_driver *e3sm_io_get_driver (const char *filename, /* NULL is for read */
                 }
             }
             if (fid >= 0) { H5Fclose (fid); }
+            if (faplid >= 0) { H5Pclose(faplid); }
 
             if (isnc == false) {
                 goto done_check;

--- a/src/drivers/e3sm_io_driver_hdf5.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5.cpp
@@ -275,15 +275,23 @@ int e3sm_io_driver_hdf5::inq_file_info (int fid, MPI_Info *info) {
     int err = 0;
     herr_t herr;
     hdf5_file *fp = this->files[fid];
-    hid_t pid, fdid;
+    hid_t pid = -1, fdid = -1;
 
-    E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5)
+    // disable HDF5 error message
+    H5E_BEGIN_TRY{
+        // get file access property list
+        pid = H5Fget_access_plist (fp->id);
+    }H5E_END_TRY;
+    if (pid < 0) { goto err_out; }
 
-    pid = H5Fget_access_plist (fp->id);
-    CHECK_HID (pid);
+    // disable HDF5 error message
+    H5E_BEGIN_TRY{
+        // get driver
+        fdid = H5Pget_driver (pid);
+    }H5E_END_TRY;
+    if (fdid < 0) { goto err_out; }
+
     // Only MPI VFD supports H5Pget_fapl_mpio
-    fdid = H5Pget_driver (pid);
-    CHECK_HID (fdid)
     if (fdid ==	H5FD_MPIO){
         herr = H5Pget_fapl_mpio (pid, NULL, info);
         CHECK_HERR
@@ -292,10 +300,15 @@ int e3sm_io_driver_hdf5::inq_file_info (int fid, MPI_Info *info) {
         *info = MPI_INFO_NULL;
     }
 
+    goto fn_exit;
+
 err_out:;
+    printf ("Warning: An error occured in e3sm_io_driver_hdf5::inq_file_info in %s. Use MPI_INFO_NULL.\n", __FILE__);
+    *info = MPI_INFO_NULL;
+fn_exit:;
     if (pid != -1) H5Pclose (pid);
     E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5)
-    return err;
+    return 0;
 }
 
 int e3sm_io_driver_hdf5::inq_file_size (std::string path, MPI_Offset *size) {


### PR DESCRIPTION
This pr contains necessary code changes to run with Cache Vol and Async Vol.

Two changes are made:
1. Use MPI-IO when E3SM-IO checks for file type. This is because Cache Vol and Async Vol require all HDF5 files opened using MPI-IO.
2. Inside inq_file_info() function, if the underlying faplid is not recognized, return default MPI_INFO_NULL.