### PR TITLE
github actions: update to v3

### DIFF
--- a/.github/workflows/logvol_master.yml
+++ b/.github/workflows/logvol_master.yml
@@ -25,7 +25,7 @@ jobs:
       runs-on: ubuntu-latest
       timeout-minutes: 60
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Set up dependencies
           run: |
             sudo apt-get update

--- a/.github/workflows/mpich_static.yml
+++ b/.github/workflows/mpich_static.yml
@@ -25,7 +25,7 @@ jobs:
       runs-on: ubuntu-latest
       timeout-minutes: 60
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Set up dependencies
           run: |
             sudo apt-get update

--- a/.github/workflows/ubuntu_ompi.yml
+++ b/.github/workflows/ubuntu_ompi.yml
@@ -25,7 +25,7 @@ jobs:
       runs-on: ubuntu-latest
       timeout-minutes: 60
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Set up dependencies
           run: |
             sudo apt-get update


### PR DESCRIPTION
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2