### PR TITLE
Bug fix: pass the vol info from HDF5_VOL_CONNECTOR to H5Pset_vol

### DIFF
--- a/src/drivers/e3sm_io_driver_hdf5.hpp
+++ b/src/drivers/e3sm_io_driver_hdf5.hpp
@@ -91,7 +91,6 @@ class e3sm_io_driver_hdf5 : public e3sm_io_driver {
    private:
     // Config
     bool use_dwrite_multi = false;
-    bool isSetEnvLogVOL = false;
 
    public:
     e3sm_io_driver_hdf5 (e3sm_io_config *cfg);

--- a/src/e3sm_io.h
+++ b/src/e3sm_io.h
@@ -180,6 +180,9 @@ typedef struct e3sm_io_config {
     case_meta I_case_h0;
     case_meta I_case_h1;
 
+    int   env_log;
+    int   env_log_passthru;
+    char *env_log_info;
 } e3sm_io_config;
 
 


### PR DESCRIPTION
env HDF5_VOL_CONNECTOR may contain other VOLs and their parameters.
which should be passed to H5Pset_vol. Below is the logic of enabling VOL
after checking HDF5_VOL_CONNECTOR.
```
if HDF5_VOL_CONNECTOR is not set,
   if command-line option `-x log` is set
      call H5Pset_vol() to enable Log VOL
   else
      No call H5Pset_vol()
else HDF5_VOL_CONNECTOR is set,
   if command-line option `-x log` is set
      if the 1st is Log VOL
         do NOT call H5Pset_vol().
         Let env HDF5_VOL_CONNECTOR to take effect.
      else
         call H5Pset_vol() and pass the vol info string that may
         contain other VOLs.
   else
      No call H5Pset_vol()
      Let env HDF5_VOL_CONNECTOR to take effect.
```