### PR TITLE
disable detailed time profiling by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src datasets
+SUBDIRS = src . datasets
 DIST_SUBDIRS = src datasets utils
 
 if BUILD_UTILS

--- a/configure.ac
+++ b/configure.ac
@@ -245,6 +245,13 @@ AC_ARG_ENABLE([debug],
 )
 AM_CONDITIONAL(E3SM_IO_DEBUG, [test "x$debug" = xyes])
 
+AC_ARG_ENABLE([profiling],
+   [AS_HELP_STRING([--enable-profiling],
+                   [Enable time profiling. @<:@default: disabled@:>@])],
+   [enable_profiling=${enableval}], [enable_profiling=no]
+)
+AM_CONDITIONAL(E3SM_IO_PROFILING, [test x$enable_profiling = xyes])
+
 if test "x${debug}" = xyes; then
    dnl add -g flag if not presented
    dnl remove all -O and -fast flags
@@ -886,6 +893,7 @@ echo \
    ${PACKAGE_NAME} Version ${PACKAGE_VERSION}
 
    Features:  Internal debug mode         - ${debug}
+              Internal profiling mode     - ${enable_profiling}
               PnetCDF                     - ${have_pnc}
               NetCDF-4                    - ${have_netcdf4}
               HDF5                        - ${have_hdf5}

--- a/configure.ac
+++ b/configure.ac
@@ -247,9 +247,12 @@ AM_CONDITIONAL(E3SM_IO_DEBUG, [test "x$debug" = xyes])
 
 AC_ARG_ENABLE([profiling],
    [AS_HELP_STRING([--enable-profiling],
-                   [Enable time profiling. @<:@default: disabled@:>@])],
+                   [Enable internal time profiling. @<:@default: disabled@:>@])],
    [enable_profiling=${enableval}], [enable_profiling=no]
 )
+if test "x$enable_profiling" = xyes; then
+   AC_DEFINE([E3SM_IO_PROFILING], [1], [Enable internal time profiling])
+fi
 AM_CONDITIONAL(E3SM_IO_PROFILING, [test x$enable_profiling = xyes])
 
 if test "x${debug}" = xyes; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,47 +12,45 @@ AM_M4FLAGS = -I${srcdir}
 
 M4FLAGS += -I${top_srcdir}/m4
 
-M4_SRCS = e3sm_io_profile.m4 \
-          e3sm_io_profile_timers.m4
-
-M4H_SRCS = e3sm_io_profile.m4h
-
 bin_PROGRAMS = e3sm_io
 
 H_SRCS          = e3sm_io.h \
                   e3sm_io_err.h
+
+M4H_SRCS        = e3sm_io_profile.m4h
 
 e3sm_io_SOURCES = e3sm_io.c \
                   e3sm_io_core.cpp \
                   read_decomp.cpp \
                   calc_metadata.c
 
-e3sm_io_SOURCES += $(H_SRCS) \
-                   $(M4_SRCS:.m4=.cpp) \
-                   $(M4H_SRCS:.m4h=.hpp)
-
-e3sm_io_LDADD = cases/libe3sm_io_cases.la \
-                drivers/libe3sm_io_drivers.la
+e3sm_io_LDADD   = cases/libe3sm_io_cases.la \
+                  drivers/libe3sm_io_drivers.la
 
 if ENABLE_LOGVOL
-e3sm_io_LDADD += -lH5VL_log
+   e3sm_io_LDADD += -lH5VL_log
 endif
 
-$(M4_SRCS:.m4=.cpp): Makefile e3sm_io_profile_timers.m4
-$(M4H_SRCS:.m4h=.hpp): Makefile e3sm_io_profile_timers.m4
+BUILT_SOURCES = $(M4H_SRCS:.m4h=.hpp)
 
-.m4.cpp: e3sm_io_profile_timers.m4
+M4_SRCS       = e3sm_io_profile.m4 \
+                e3sm_io_profile_timers.m4
+
+if E3SM_IO_PROFILING
+   AM_CPPFLAGS     += -DE3SM_IO_PROFILING
+   e3sm_io_SOURCES += $(M4_SRCS:.m4=.cpp)
+endif
+
+.m4.cpp:
 	$(M4) $(AM_M4FLAGS) $(M4FLAGS) $< >$@
 
-.m4h.hpp: e3sm_io_profile_timers.m4
+.m4h.hpp:
 	$(M4) $(AM_M4FLAGS) $(M4FLAGS) $< >$@
-
-BUILT_SOURCES = $(M4_SRCS:.m4=.cpp) $(M4H_SRCS:.m4h=.hpp)
 
 SUBDIRS = drivers cases
 DIST_SUBDIRS = drivers cases
 
-EXTRA_DIST = $(M4H_SRCS) $(M4_SRCS)
+EXTRA_DIST = $(H_SRCS) $(M4H_SRCS) $(M4_SRCS)
 
 CLEANFILES = $(M4_SRCS:.m4=.cpp) $(M4H_SRCS:.m4h=.hpp)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,8 +37,9 @@ M4_SRCS       = e3sm_io_profile.m4 \
                 e3sm_io_profile_timers.m4
 
 if E3SM_IO_PROFILING
-   AM_CPPFLAGS     += -DE3SM_IO_PROFILING
-   e3sm_io_SOURCES += $(M4_SRCS:.m4=.cpp)
+   noinst_LTLIBRARIES = libe3sm_io_profiling.la
+   libe3sm_io_profiling_la_SOURCES = $(M4_SRCS:.m4=.cpp)
+   e3sm_io_LDADD   += libe3sm_io_profiling.la
 endif
 
 .m4.cpp:

--- a/src/drivers/e3sm_io_driver_hdf5_md.cpp
+++ b/src/drivers/e3sm_io_driver_hdf5_md.cpp
@@ -130,8 +130,6 @@ int e3sm_io_driver_hdf5::post_varn(int            fid,
     hdf5_file *fp = this->files[fid];
     H5S_seloper_t op = H5S_SELECT_SET;
 
-    E3SM_IO_TIMER_START (E3SM_IO_TIMER_HDF5_SEL)
-
     did = fp->dids[vid];
 
     dsid = H5Dget_space (did);
@@ -201,7 +199,6 @@ int e3sm_io_driver_hdf5::post_varn(int            fid,
         herr = H5Sclose(dsid);
         CHECK_HERR
     }
-    E3SM_IO_TIMER_STOP (E3SM_IO_TIMER_HDF5_SEL)
 
 err_out:
     return err;

--- a/src/e3sm_io.c
+++ b/src/e3sm_io.c
@@ -19,7 +19,10 @@
 
 #include <e3sm_io.h>
 #include <e3sm_io_err.h>
+
+#ifdef E3SM_IO_PROFILING
 #include <e3sm_io_profile.hpp>
+#endif
 
 static
 void check_connector_env(e3sm_io_config *cfg) {
@@ -542,8 +545,6 @@ int main (int argc, char **argv) {
         report_timing_WR(&cfg, &decom);
     }
 
-    if (cfg.profiling) e3sm_io_print_profile(&cfg);
-
     timing[0] = MPI_Wtime() - timing[0];
     MPI_Reduce(timing, max_t, 3, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
     if (cfg.rank == 0) {
@@ -552,6 +553,13 @@ int main (int argc, char **argv) {
         printf("-----------------------------------------------------------\n");
         printf("\n\n");
     }
+
+#ifdef E3SM_IO_PROFILING
+    if (cfg.profiling) e3sm_io_print_profile(&cfg);
+#else
+    if (cfg.profiling && cfg.rank == 0)
+        printf("\nWarning: E3SM-IO internal time profiling was disabled at configure time\n\n");
+#endif
 
 err_out:
     if (cfg.info != MPI_INFO_NULL)

--- a/src/e3sm_io_profile.m4
+++ b/src/e3sm_io_profile.m4
@@ -50,47 +50,45 @@ foreach(`t', E3SM_IO_TIMERS, `"CONCATE(`e3sm_io_timer_', t)",
 ')dnl
 };
 
-int e3sm_io_print_profile(e3sm_io_config *cfg){
+int e3sm_io_print_profile(e3sm_io_config *cfg)
+{
     int i;
 
-	MPI_Reduce (e3sm_io_profile_times, tmax, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_MAX, 0, cfg->io_comm);
-	MPI_Reduce (e3sm_io_profile_times, tmin, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_MIN, 0, cfg->io_comm);
-	MPI_Allreduce (e3sm_io_profile_times, tmean, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_SUM, cfg->io_comm);
-	for (i = 0; i < E3SM_IO_NTIMER; i++) {
-		tmean[i] /= cfg->np;
-		tvar_local[i] = (e3sm_io_profile_times[i] - tmean[i]) * (e3sm_io_profile_times[i] - tmean[i]);
-	}
-	MPI_Reduce (tvar_local, tvar, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_SUM, 0, cfg->io_comm);
+    MPI_Reduce (e3sm_io_profile_times, tmax, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_MAX, 0, cfg->io_comm);
+    MPI_Reduce (e3sm_io_profile_times, tmin, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_MIN, 0, cfg->io_comm);
+    MPI_Allreduce (e3sm_io_profile_times, tmean, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_SUM, cfg->io_comm);
+    for (i = 0; i < E3SM_IO_NTIMER; i++) {
+        tmean[i] /= cfg->np;
+        tvar_local[i] = (e3sm_io_profile_times[i] - tmean[i]) * (e3sm_io_profile_times[i] - tmean[i]);
+    }
+    MPI_Reduce (tvar_local, tvar, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_SUM, 0, cfg->io_comm);
 
-	if (cfg->rank == 0) {
-		for (i = 0; i < E3SM_IO_NTIMER; i++) {
-			printf ("#%%$: %s_time_mean: %lf\n", tname[i], tmean[i]);
-			printf ("#%%$: %s_time_max: %lf\n", tname[i], tmax[i]);
-			printf ("#%%$: %s_time_min: %lf\n", tname[i], tmin[i]);
-			printf ("#%%$: %s_time_var: %lf\n\n", tname[i], tvar[i]);
-		}
-	}
+    if (cfg->rank == 0) {
+        for (i = 0; i < E3SM_IO_NTIMER; i++) {
+            printf ("#%%$: %s_time_mean: %lf\n", tname[i], tmean[i]);
+            printf ("#%%$: %s_time_max: %lf\n", tname[i], tmax[i]);
+            printf ("#%%$: %s_time_min: %lf\n", tname[i], tmin[i]);
+            printf ("#%%$: %s_time_var: %lf\n\n", tname[i], tvar[i]);
+        }
+    }
 
-	MPI_Reduce (e3sm_io_profile_counts, tmax, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_MAX, 0, cfg->io_comm);
-	MPI_Reduce (e3sm_io_profile_counts, tmin, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_MIN, 0, cfg->io_comm);
-	MPI_Allreduce (e3sm_io_profile_counts, tmean, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_SUM, cfg->io_comm);
-	for (i = 0; i < E3SM_IO_NTIMER; i++) {
-		tmean[i] /= cfg->np;
-		tvar_local[i] = (e3sm_io_profile_counts[i] - tmean[i]) * (e3sm_io_profile_counts[i] - tmean[i]);
-	}
-	MPI_Reduce (tvar_local, tvar, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_SUM, 0, cfg->io_comm);
+    MPI_Reduce (e3sm_io_profile_counts, tmax, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_MAX, 0, cfg->io_comm);
+    MPI_Reduce (e3sm_io_profile_counts, tmin, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_MIN, 0, cfg->io_comm);
+    MPI_Allreduce (e3sm_io_profile_counts, tmean, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_SUM, cfg->io_comm);
+    for (i = 0; i < E3SM_IO_NTIMER; i++) {
+        tmean[i] /= cfg->np;
+        tvar_local[i] = (e3sm_io_profile_counts[i] - tmean[i]) * (e3sm_io_profile_counts[i] - tmean[i]);
+    }
+    MPI_Reduce (tvar_local, tvar, E3SM_IO_NTIMER, MPI_DOUBLE, MPI_SUM, 0, cfg->io_comm);
 
-	if (cfg->rank == 0) {
-		for (i = 0; i < E3SM_IO_NTIMER; i++) {
-			printf ("#%%$: %s_count_mean: %lf\n", tname[i], tmean[i]);
-			printf ("#%%$: %s_count_max: %lf\n", tname[i], tmax[i]);
-			printf ("#%%$: %s_count_min: %lf\n", tname[i], tmin[i]);
-			printf ("#%%$: %s_count_var: %lf\n\n", tname[i], tvar[i]);
-		}
-	}  
-
-	return 0;        
+    if (cfg->rank == 0) {
+        for (i = 0; i < E3SM_IO_NTIMER; i++) {
+            printf ("#%%$: %s_count_mean: %lf\n", tname[i], tmean[i]);
+            printf ("#%%$: %s_count_max: %lf\n", tname[i], tmax[i]);
+            printf ("#%%$: %s_count_min: %lf\n", tname[i], tmin[i]);
+            printf ("#%%$: %s_count_var: %lf\n\n", tname[i], tvar[i]);
+        }
+    }
+    return 0;
 }
-
-
 

--- a/src/e3sm_io_profile.m4h
+++ b/src/e3sm_io_profile.m4h
@@ -24,6 +24,8 @@ dnl
 #include <config.h>
 #endif
 
+#ifdef E3SM_IO_PROFILING
+
 /*
  * Report performance profiling
  */
@@ -76,6 +78,14 @@ extern double e3sm_io_profile_counts[E3SM_IO_NTIMER];
         e3sm_io_profile_counts[A] ++; \
     } \
 }
+#else
+#define E3SM_IO_TIMER_START(A)
+#define E3SM_IO_TIMER_PAUSE(A)
+#define E3SM_IO_TIMER_STOP(A)
+#define E3SM_IO_TIMER_SWAP(A, B)
+#define E3SM_IO_TIMER_STOPEX(A, B)
+#define E3SM_IO_TIMER_ADD(A, B)
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/e3sm_io_profile_timers.m4
+++ b/src/e3sm_io_profile_timers.m4
@@ -5,6 +5,10 @@ define(`E3SM_IO_TIMERS', `( `total', dnl
                             `init_case', dnl
                             `init_driver', dnl
                             `hdf5', dnl
+                            `hdf5_open', dnl
+                            `hdf5_def_dim', dnl
+                            `hdf5_def_var', dnl
+                            `hdf5_put_att', dnl
                             `hdf5_wr', dnl
                             `hdf5_sel', dnl
                             `hdf5_ext_dim', dnl
@@ -13,6 +17,7 @@ define(`E3SM_IO_TIMERS', `( `total', dnl
                             `hdf5_rd', dnl
                             `hdf5_nslab', dnl
                             `hdf5_dsize', dnl
+                            `hdf5_close', dnl
                             `adios2', dnl
                             `adios2_enddef', dnl
                             `adios2_sel', dnl

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -33,10 +33,10 @@ pnetcdf_blob_replay_LDADD = -lpnetcdf
 endif
 
 dat2decomp_SOURCES = dat2decomp.cpp 
-dat2decomp_LDADD = ../src/drivers/libe3sm_io_drivers.la ../src/e3sm_io_profile.o
+dat2decomp_LDADD = ../src/drivers/libe3sm_io_drivers.la
 
 decomp_copy_SOURCES = decomp_copy.cpp 
-decomp_copy_LDADD = ../src/drivers/libe3sm_io_drivers.la ../src/e3sm_io_profile.o
+decomp_copy_LDADD = ../src/drivers/libe3sm_io_drivers.la
 
 datstat_SOURCES = datstat.cpp
 

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -34,9 +34,15 @@ endif
 
 dat2decomp_SOURCES = dat2decomp.cpp 
 dat2decomp_LDADD = ../src/drivers/libe3sm_io_drivers.la
+if E3SM_IO_PROFILING
+   dat2decomp_LDADD += ../src/libe3sm_io_profiling.la
+endif
 
 decomp_copy_SOURCES = decomp_copy.cpp 
 decomp_copy_LDADD = ../src/drivers/libe3sm_io_drivers.la
+if E3SM_IO_PROFILING
+   decomp_copy_LDADD += ../src/libe3sm_io_profiling.la
+endif
 
 datstat_SOURCES = datstat.cpp
 


### PR DESCRIPTION
Because there are already high-level time profiling and output at the
end of a run, the detailed profiling should be disabled by default.
Use `--enable-profiling` to enable detailed profiling.